### PR TITLE
Fix Issue #21 -- Add backward compatibility for 2.0.1

### DIFF
--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -17,12 +17,22 @@ function Resolve-SafeguardAssetId
 
     if (-not ($Asset -as [int]))
     {
-        $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
-                                                -Parameters @{ filter = "Name ieq '$Asset'" })
-        if (-not $local:Assets)
+        try
         {
             $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
-                                                    -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
+                                 -Parameters @{ filter = "Name ieq '$Asset'" })
+            if (-not $local:Assets)
+            {
+                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
+                                     -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
+            }
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
+                                 -Parameters @{ q = $Asset })
         }
         if (-not $local:Assets)
         {
@@ -67,8 +77,18 @@ function Resolve-SafeguardAssetAccountId
         {
             $local:RelativeUrl = "AssetAccounts"
         }
-        $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                                  -Parameters @{ filter = "Name ieq '$Account'" })
+        try
+        {
+            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+                                   -Parameters @{ filter = "Name ieq '$Account'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+                                   -Parameters @{ q = $Account })
+        }
         if (-not $local:Accounts)
         {
             throw "Unable to find account matching '$Account'"

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -252,8 +252,10 @@ function Find-SafeguardPlatform
     {}
     if (-not $local:Platforms)
     {
+        Write-Verbose $_
+        Write-Verbose "Caught exception with ieq filter, trying with q parameter"
         $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
-                                -Parameters @{ q = "$SearchString" })
+                                -Parameters @{ q = $SearchString })
     }
     $local:Platforms
 }

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -18,8 +18,18 @@ function Resolve-SafeguardPlatform
     while (-not $($Platform -as [int]))
     {
         Write-Host "Searching for platforms with '$Platform'"
-        $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
-                                                   -Parameters @{ Filter = "DisplayName icontains '$Platform'" })
+        try
+        {
+            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+                                    -Parameters @{ Filter = "DisplayName icontains '$Platform'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with icontains filter, trying with contains filter"
+            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+                                    -Parameters @{ Filter = "DisplayName contains '$Platform'" })
+        }
         if (-not $local:Platforms)
         {
             $local:Platforms = (Find-SafeguardPlatform -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "$Platform")

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -17,12 +17,22 @@ function Resolve-SafeguardPolicyAssetId
 
     if (-not ($Asset -as [int]))
     {
-        $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
-                                                -Parameters @{ filter = "Name ieq '$Asset'" })
-        if (-not $local:Assets)
+        try
         {
             $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
-                                                    -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
+                                 -Parameters @{ filter = "Name ieq '$Asset'" })
+            if (-not $local:Assets)
+            {
+                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+                                     -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
+            }
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+                                 -Parameters @{ q = $Asset })
         }
         if (-not $local:Assets)
         {
@@ -67,8 +77,18 @@ function Resolve-SafeguardPolicyAccountId
         {
             $local:RelativeUrl = "PolicyAccounts"
         }
-        $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                                  -Parameters @{ filter = "Name ieq '$Account'" })
+        try
+        {
+            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+                                   -Parameters @{ filter = "Name ieq '$Account'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+                                   -Parameters @{ q = $Account })
+        }
         if (-not $local:Accounts)
         {
             throw "Unable to find policy account matching '$Account'"

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -193,8 +193,7 @@ function Invoke-WithoutBody
 
     $local:Url = (New-SafeguardUrl $Appliance $Service $Version $RelativeUrl -Parameters $Parameters)
     Write-Verbose "Url=$($local:Url)"
-    Write-Verbose "Parameters=$Parameters"
-    Write-Verbose "Headers=$Headers"
+    Write-Verbose "Parameters=$(ConvertTo-Json -InputObject $Parameters)"
     if ($InFile)
     {
         if ($LongRunningTask)
@@ -261,8 +260,7 @@ function Invoke-WithBody
     }
     $local:Url = (New-SafeguardUrl $Appliance $Service $Version $RelativeUrl -Parameters $Parameters)
     Write-Verbose "Url=$($local:Url)"
-    Write-Verbose "Parameters=$Parameters"
-    Write-Verbose "Headers=$Headers"
+    Write-Verbose "Parameters=$(ConvertTo-Json -InputObject $Parameters)"
     Write-Verbose "Body=$($local:Body)"
     if ($LongRunningTask)
     {
@@ -897,7 +895,8 @@ function Invoke-SafeguardMethod
             "Accept" = $Accept;
             "Content-type" = $ContentType;
         }
-    
+    Write-Verbose "HeadersBeforeTokenIncluded=$(ConvertTo-Json -InputObject $Headers)"
+
     if (-not $Anonymous)
     {
         $local:Headers["Authorization"] = "Bearer $AccessToken"

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -17,8 +17,18 @@ function Resolve-SafeguardUserId
 
     if (-not ($User -as [int]))
     {
-        $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
-                                               -Parameters @{ filter = "UserName ieq '$User'" })
+        try
+        {
+            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+                                -Parameters @{ filter = "UserName ieq '$User'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+                                -Parameters @{ q = $User })
+        }
         if (-not $local:Users)
         {
             throw "Unable to find user matching '$User'"
@@ -93,8 +103,18 @@ function Get-SafeguardIdentityProvider
         }
         else
         {
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
-                -Parameters @{ filter = "Name ieq '$ProviderToGet'" }
+            try
+            {
+                Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
+                    -Parameters @{ filter = "Name ieq '$ProviderToGet'" }
+            }
+            catch
+            {
+                Write-Verbose $_
+                Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+                Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
+                    -Parameters @{ q = $ProviderToGet }
+            }
         }
     }
     else


### PR DESCRIPTION
Safeguard 2.1.0 is actually what this first release of scripts is targeting.  It added some filter options for ieq and icontains.  This is PR is to try again using a legacy filter criteria or the q option.

Fixes Issue #21.