### PR TITLE
MS Renamed PowerShell exec to pwsh in base containers

### DIFF
--- a/Dockerfile_centos7
+++ b/Dockerfile_centos7
@@ -4,7 +4,7 @@ MAINTAINER support@oneidentity.com
 COPY ["install-local.ps1", "/tmp/safeguard/"]
 COPY ["src/", "/tmp/safeguard/src/"]
 
-RUN powershell -NoProfile -Command "/tmp/safeguard/install-local.ps1 '/usr/local/share/powershell/Modules'; Remove-Item -Path /tmp/safeguard -recurse"
+RUN pwsh -NoProfile -Command "/tmp/safeguard/install-local.ps1 '/usr/local/share/powershell/Modules'; Remove-Item -Path /tmp/safeguard -recurse"
 
-ENTRYPOINT [ "powershell" ]
+ENTRYPOINT [ "pwsh" ]
 CMD ["-NoExit", "-Command", "Get-SafeguardBanner"]

--- a/Dockerfile_nanoserver
+++ b/Dockerfile_nanoserver
@@ -4,7 +4,7 @@ MAINTAINER support@oneidentity.com
 COPY ["install-local.ps1", "C:/safeguard/"]
 COPY ["src/", "C:/safeguard/src/"]
 
-RUN "C:\safeguard\install-local.ps1 'C:\Program Files\PowerShell\Modules'; Remove-Item -Path c:\safeguard -recurse"
+RUN pwsh -NoProfile -Command "C:\safeguard\install-local.ps1 'C:\Program Files\PowerShell\Modules'; Remove-Item -Path c:\safeguard -recurse"
 
-ENTRYPOINT [ "powershell" ]
+ENTRYPOINT [ "pwsh" ]
 CMD ["-NoExit", "-Command", "Get-SafeguardBanner"]


### PR DESCRIPTION
Sorry one more. I forgot to update my local containers so I didn't realize the executable was renamed in all of them.