### PR TITLE
Add Edit-SafeguardUserGroup cmdlet to users module

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ safeguard-ps can do run:
 - Get-SafeguardUserGroup
 - New-SafeguardUserGroup
 - Remove-SafeguardUserGroup
+- Edit-SafeguardUserGroup
 - Get-SafeguardAssetGroup
 - New-SafeguardAssetGroup
 - Remove-SafeguardAssetGroup

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -155,6 +155,43 @@ function Remove-SafeguardGroup
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "$($local:RelativeUrl)/$($local:GroupId)" -Body $local:Body
 }
+function Edit-SafeguardGroup
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidateSet("User", "Asset", "Account", IgnoreCase=$true)]
+        [string]$GroupType,
+        [Parameter(Mandatory=$true,Position=1)]
+        [object]$GroupToEdit,
+        [Parameter(Mandatory=$true,Position=2)]
+        [string]$Operation,
+        [Parameter(Mandatory=$true,Position=3)]
+        [object]$ObjectToOperate
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    # Allow case insensitive group types to translate to appropriate case sensitive URL path
+    switch ($GroupType)
+    {
+        "user" { $GroupType = "User"; break }
+        "asset" { $GroupType = "Asset"; break }
+        "Account" { $GroupType = "Account"; break }
+    }
+
+    $local:RelativeUrl = "$($GroupType)Groups"
+    $local:GroupId = (Resolve-SafeguardGroupId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $GroupType $GroupToEdit)
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "$($local:RelativeUrl)/$($local:GroupId)/Members/$Operation" -Body $ObjectToOperate
+}
 
 <#
 .SYNOPSIS
@@ -363,6 +400,77 @@ function Remove-SafeguardUserGroup
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Remove-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure User $GroupToDelete
+}
+
+
+<#
+.SYNOPSIS
+Edits a user group to add or remove an existing user in Safeguard via the Web API.
+
+.DESCRIPTION
+When a user group is edited the changes also propagates to any entitlements where it may have been used
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER GroupToEdit
+Name of the group to edit
+
+.PARAMETER Operation
+String of type of operation to be perfomed on the user group. 'Add' to add users to the user group
+'Remove' to removed users from the user group
+
+.PARAMETER UserToOperate
+An array of usernames of the users to be added or removed in the users group
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Edit-SafeguardUserGroup testusergroup add testuser1,testuser2
+
+.EXAMPLE
+Edit-SafeguardUserGroup testusergroup remove testuser1
+#>
+function Edit-SafeguardUserGroup
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [object]$GroupToEdit,
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateSet("Add", "Remove", IgnoreCase=$true)]
+        [string]$Operation,
+        [Parameter(Mandatory=$true, Position=2)]
+        [object[]]$UserToOperate
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+    
+    [object[]]$Users = $null
+    ForEach($user in $UserToOperate)
+    {
+        $local:ResolvedUser = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $User)
+        $local:Users += $($local:ResolvedUser)
+    }
+
+    Edit-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure User $GroupToEdit $Operation $Users
 }
 
 <#

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -151,7 +151,7 @@ FunctionsToExport = @(
     'Test-SafeguardDirectoryAccountPassword','Invoke-SafeguardDirectoryAccountPasswordChange',
     'Remove-SafeguardDirectoryAccount',
     # groups.psm1
-    'Get-SafeguardUserGroup','New-SafeguardUserGroup','Remove-SafeguardUserGroup',
+    'Get-SafeguardUserGroup','New-SafeguardUserGroup','Remove-SafeguardUserGroup','Edit-SafeguardUserGroup',
     'Get-SafeguardAssetGroup','New-SafeguardAssetGroup','Remove-SafeguardAssetGroup',
     'Get-SafeguardAccountGroup','New-SafeguardAccountGroup','Remove-SafeguardAccountGroup',
     # policies.psm1


### PR DESCRIPTION
@DanPeterson I didn't change the version of the package. I added the code to the users module, updated the manifest and readme files to include the new cmdlet. I didn't run any automated tests to see if anything got broken. I think you did it when we had a call last dev sprint. I didn't have it documented and couldn't remember how you did it. 

I ran "install-local.ps1" to install the modified package locally and "Import-Module Safeguard-ps" worked fine. The cmdlet I added is working without errors.