### PR TITLE
A couple of changes to event.psm1

### DIFF
--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1,5 +1,5 @@
 #Helper
-function Validate-SubscriptionEvent
+function Test-SubscriptionEvent
 {
     [CmdletBinding()]
     Param(
@@ -399,7 +399,7 @@ function New-SafeguardEventSubscription
     ForEach($IndividualEvent in $SubscriptionEvent)
     {
         $local:Event = $(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Events/$IndividualEvent").Name
-        $local:IsValidEvent = Validate-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $ObjectTypeToSubscribe -EventToValidate $local:Event
+        $local:IsValidEvent = Test-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $ObjectTypeToSubscribe -EventToValidate $local:Event
         if(-Not $local:IsValidEvent)
         {
             $InvalidEvents += $local:Event
@@ -652,7 +652,7 @@ function Edit-SafeguardEventSubscription
         ForEach($IndividualEvent in $SubscriptionEvent)
         {
             $local:Event = $(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Events/$IndividualEvent").Name
-            $local:IsValidEvent = Validate-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $Body.ObjectType -EventToValidate $local:Event
+            $local:IsValidEvent = Test-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $Body.ObjectType -EventToValidate $local:Event
             if(-Not $local:IsValidEvent)
             {
                 $InvalidEvents += $local:Event

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -468,7 +468,7 @@ function New-SafeguardEventSubscription
         if ($PSBoundParameters.ContainsKey("UserToSubscribe"))
         {
             $local:UserEmailAddress = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $UserToSubscribe).EmailAddress
-            If([string]::IsNullOrWhitespace($local:User.EmailAddress))
+            If([string]::IsNullOrWhitespace($local:UserEmailAddress))
             {
                 Write-Error -Message "An email address or a user with an email address must be specified." -Category InvalidArgument -ErrorAction Stop
             }
@@ -739,7 +739,7 @@ function Edit-SafeguardEventSubscription
         if ($PSBoundParameters.ContainsKey("UserToSubscribe"))
         {
             $local:UserEmailAddress = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $UserToSubscribe).EmailAddress
-            If([string]::IsNullOrWhitespace($local:User.EmailAddress))
+            If([string]::IsNullOrWhitespace($local:UserEmailAddress))
             {
                 Write-Error -Message "An email address or a user with an email address must be specified." -Category InvalidArgument -ErrorAction Stop
             }


### PR DESCRIPTION
I found an unapproved verb.  It was an internal function, but I've been trying to keep those clean even though Microsoft doesn't make it easy.

My editor found two lines of code in the second commit that were flagged because a variable was never used.  I'm wondering if you meant to use the `$local:UserEmailAddress` variable or the `$local:User.EmailAddress` variable here.  Otherwise $local:UserEmailAddress` goes unused even though you just called `Get-SafeguardUser` to fetch the data for it.