### PR TITLE
Fix support for non-Windows platforms running in docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,6 @@ safeguard-ps can do run:
 - Remove-SafeguardClusterMember
 - Get-SafeguardClusterMember
 - Get-SafeguardClusterHealth
-- Get-SafeguardClusterApplianceHealth
 - Get-SafeguardClusterPrimary
 - Set-SafeguardClusterPrimary
 - Enable-SafeguardClusterPrimary

--- a/src/clustering.psm1
+++ b/src/clustering.psm1
@@ -793,7 +793,7 @@ function Get-SafeguardClusterSummary
     Write-Host(
     $local:Errors | Out-String)
 
-    Write-Host "`n---Operation Status---"
+    Write-Host "`n`n---Operation Status---"
     Write-Host(
     Get-SafeguardClusterOperationStatus -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure | Format-Table | Out-String)
 }

--- a/src/clustering.psm1
+++ b/src/clustering.psm1
@@ -240,53 +240,6 @@ function Get-SafeguardClusterHealth
 
 <#
 .SYNOPSIS
-Get health (with forced update) of this appliance in the cluster from Safeguard via the Web API.
-
-.DESCRIPTION
-Force a health check on the currently connected appliance via the Web API and report its cluster health.
-Running the health check synchronously makes this take more time than the normal cluster health call.
-
-.PARAMETER Appliance
-IP address or hostname of a Safeguard appliance.
-
-.PARAMETER AccessToken
-A string containing the bearer token to be used with Safeguard Web API.
-
-.PARAMETER Insecure
-Ignore verification of Safeguard appliance SSL certificate.
-
-.INPUTS
-None.
-
-.OUTPUTS
-JSON response from Safeguard Web API.
-
-.EXAMPLE
-Get-SafeguardClusterApplianceHealth -AccessToken $token -Appliance 10.5.32.54
-
-.EXAMPLE
-Get-SafeguardClusterApplianceHealth
-#>
-function Get-SafeguardClusterApplianceHealth
-{
-    [CmdletBinding()]
-    Param(
-        [Parameter(Mandatory=$false)]
-        [string]$Appliance,
-        [Parameter(Mandatory=$false)]
-        [object]$AccessToken,
-        [Parameter(Mandatory=$false)]
-        [switch]$Insecure
-    )
-
-    $ErrorActionPreference = "Stop"
-    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-
-    (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET ClusterMembers/Self).Health
-}
-
-<#
-.SYNOPSIS
 Add a new replica to the cluster via the Safeguard Web API.
 
 .DESCRIPTION

--- a/src/desktopclient.psm1
+++ b/src/desktopclient.psm1
@@ -57,58 +57,58 @@ function Install-SafeguardDesktopClient
     try
     {
         # Get Version Info from Appliance
-    $UninstallKey = "HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
-    $Version = (Invoke-RestMethod "https://$Appliance/service/appliance/v2/Version" -EA SilentlyContinue)
-    if (-not $Version)
-    {
-        $Version = (Invoke-RestMethod "https://$Appliance/service/appliance/v1/Version" -EA SilentlyContinue)
+        $UninstallKey = "HKLM\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+        $Version = (Invoke-RestMethod "https://$Appliance/service/appliance/v2/Version" -EA SilentlyContinue)
         if (-not $Version)
         {
-            throw "You must specify a valid Safeguard Appliance"
+            $Version = (Invoke-RestMethod "https://$Appliance/service/appliance/v1/Version" -EA SilentlyContinue)
+            if (-not $Version)
+            {
+                throw "You must specify a valid Safeguard Appliance"
+            }
         }
-    }
 
-    # Clear Safeguard Client Updates
-    $Installers = @(Get-ChildItem -Path "$env:LOCALAPPDATA\Pangaea\Safeguard" -Filter "*.msi" -Recurse -EA SilentlyContinue) + `
-                    @(Get-ChildItem -Path "$env:LOCALAPPDATA\Safeguard\Updates" -Filter "*.msi" -Recurse -EA SilentlyContinue)
-    foreach ($installer in $Installers)
-    {
-        Write-Host "Removing: $($installer.FullName)"
-        Remove-Item -Force $installer.FullName
-    }
+        # Clear Safeguard Client Updates
+        $Installers = @(Get-ChildItem -Path "$env:LOCALAPPDATA\Pangaea\Safeguard" -Filter "*.msi" -Recurse -EA SilentlyContinue) + `
+                        @(Get-ChildItem -Path "$env:LOCALAPPDATA\Safeguard\Updates" -Filter "*.msi" -Recurse -EA SilentlyContinue)
+        foreach ($installer in $Installers)
+        {
+            Write-Host "Removing: $($installer.FullName)"
+            Remove-Item -Force $installer.FullName
+        }
 
-    Write-Host ("Downloading Safeguard Client for BUILD: {0}.{1}.{2}.{3}" -f $Version.Major,$Version.Minor,$Version.Revision,$Version.Build)
-    $TempFile = "$env:TEMP\Safeguard.msi"
-    Remove-Item -Force $TempFile -EA SilentlyContinue
-    $WebClient = (New-Object System.Net.WebClient)
-    try
-    {
-        $WebClient.DownloadFile("https://$Appliance/en-US/Safeguard.msi", $TempFile)
-    }
-    catch
-    {
-        $WebClient.DownloadFile("https://$Appliance/Safeguard.msi", $TempFile)
-    }
-    Write-Host "Uninstalling previous build..."
-    try
-    {
-        $Key = ((& reg query $UninstallKey /s /v DisplayName | Select-String "Safeguard" -Context 1,0).ToString().Split("`n") | Select-String HKEY).ToString().Trim()
-        $UninstallCmd = (& reg query $Key /v UninstallString | Select-String "UninstallString").ToString()
-    }
-    catch
-    {}
-    if ($UninstallCmd)
-    {
-        $CmdArray = $UninstallCmd.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
-        Start-Process $CmdArray[2] -ArgumentList "$($CmdArray[3]) /quiet /passive" -Verb RunAs -Wait
-    }
-    else
-    {
-        Write-Host "Not currently installed."
-    }
+        Write-Host ("Downloading Safeguard Client for BUILD: {0}.{1}.{2}.{3}" -f $Version.Major,$Version.Minor,$Version.Revision,$Version.Build)
+        $TempFile = "$env:TEMP\Safeguard.msi"
+        Remove-Item -Force $TempFile -EA SilentlyContinue
+        $WebClient = (New-Object System.Net.WebClient)
+        try
+        {
+            $WebClient.DownloadFile("https://$Appliance/en-US/Safeguard.msi", $TempFile)
+        }
+        catch
+        {
+            $WebClient.DownloadFile("https://$Appliance/Safeguard.msi", $TempFile)
+        }
+        Write-Host "Uninstalling previous build..."
+        try
+        {
+            $Key = ((& reg query $UninstallKey /s /v DisplayName | Select-String "Safeguard" -Context 1,0).ToString().Split("`n") | Select-String HKEY).ToString().Trim()
+            $UninstallCmd = (& reg query $Key /v UninstallString | Select-String "UninstallString").ToString()
+        }
+        catch
+        {}
+        if ($UninstallCmd)
+        {
+            $CmdArray = $UninstallCmd.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+            Start-Process $CmdArray[2] -ArgumentList "$($CmdArray[3]) /quiet /passive" -Verb RunAs -Wait
+        }
+        else
+        {
+            Write-Host "Not currently installed."
+        }
 
-    Write-Host "Installing..."
-    Start-Process msiexec.exe -ArgumentList "/i $TempFile /quiet /passive" -Verb RunAs -Wait
+        Write-Host "Installing..."
+        Start-Process msiexec.exe -ArgumentList "/i $TempFile /quiet /passive" -Verb RunAs -Wait
     }
     finally
     {

--- a/src/desktopclient.psm1
+++ b/src/desktopclient.psm1
@@ -40,6 +40,7 @@ function Install-SafeguardDesktopClient
     if ($Insecure)
     {
         Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
     }
 
     if (-not $Appliance)

--- a/src/desktopclient.psm1
+++ b/src/desktopclient.psm1
@@ -116,6 +116,7 @@ function Install-SafeguardDesktopClient
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }

--- a/src/desktopclient.psm1
+++ b/src/desktopclient.psm1
@@ -32,6 +32,11 @@ function Install-SafeguardDesktopClient
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
     Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
 
+    if ($PSVersionTable.PSEdition -eq "Core")
+    {
+        throw "This cmdlet is not supported in PowerShell Core"
+    }
+
     if ($SafeguardSession)
     {
         $Insecure = $SafeguardSession["Insecure"]

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -185,7 +185,10 @@ IP address or hostname of a Safeguard appliance.
 A string containing the bearer token to be used with Safeguard Web API.
 
 .PARAMETER Insecure
-Ignore verification of Safeguard appliance SSL certificate
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ForceUpdate
+Force health checks to run and wait to get up-to-date information.
 
 .INPUTS
 None.
@@ -208,13 +211,22 @@ function Get-SafeguardHealth
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$ForceUpdate
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET ApplianceStatus/Health
+    if ($ForceUpdate)
+    {
+        (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET ClusterMembers/Self).Health
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET ApplianceStatus/Health
+    }
 }
 
 <#
@@ -718,6 +730,7 @@ function Get-SafeguardSupportBundle
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }
@@ -956,6 +969,7 @@ function Install-SafeguardPatch
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 
@@ -1241,6 +1255,7 @@ function Export-SafeguardBackup
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 
@@ -1373,6 +1388,7 @@ function Import-SafeguardBackup
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -680,6 +680,7 @@ function Get-SafeguardSupportBundle
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
         # Use the WebClient class to avoid the content scraping slow down from Invoke-RestMethod as well as timeout issues
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
@@ -912,6 +913,7 @@ function Install-SafeguardPatch
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
         # Use the WebClient class to avoid the content scraping slow down from Invoke-RestMethod as well as timeout issues
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
@@ -1201,6 +1203,7 @@ function Export-SafeguardBackup
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
         # Use the WebClient class to avoid the content scraping slow down from Invoke-RestMethod as well as timeout issues
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
@@ -1327,6 +1330,7 @@ function Import-SafeguardBackup
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
         # Use the WebClient class to avoid the content scraping slow down from Invoke-RestMethod as well as timeout issues
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -167,7 +167,7 @@ FunctionsToExport = @(
     'Get-SafeguardEvent', 'Get-SafeguardEventName', 'Get-SafeguardEventSubscription', 'Find-SafeguardEventSubscription',
     'New-SafeguardEventSubscription', 'Remove-SafeguardEventSubscription', 'Edit-SafeguardEventSubscription',
     # clustering.psm1
-    'Get-SafeguardClusterMember','Get-SafeguardClusterHealth','Get-SafeguardClusterApplianceHealth','Get-SafeguardClusterOperationStatus',
+    'Get-SafeguardClusterMember','Get-SafeguardClusterHealth','Get-SafeguardClusterOperationStatus',
     'Add-SafeguardClusterMember','Remove-SafeguardClusterMember','Get-SafeguardClusterPrimary','Set-SafeguardClusterPrimary',
     'Enable-SafeguardClusterPrimary','Unlock-SafeguardCluster','Get-SafeguardClusterSummary',
     # managementShell.psm1

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -432,6 +432,7 @@ function Connect-Safeguard
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
 
         if ($Gui)
@@ -636,6 +637,7 @@ function Connect-Safeguard
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }
@@ -698,6 +700,7 @@ function Disconnect-Safeguard
             if ($Insecure)
             {
                 Disable-SslVerification
+                if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
             }
             Write-Verbose "Calling Safeguard Logout service..."
             $local:Headers = @{
@@ -713,6 +716,7 @@ function Disconnect-Safeguard
             if ($Insecure)
             {
                 Enable-SslVerification
+                if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
             }
         }
     }
@@ -734,6 +738,7 @@ function Disconnect-Safeguard
                 if ($Insecure)
                 {
                     Disable-SslVerification
+                    if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
                 }
                 Write-Verbose "Calling Safeguard Logout service..."
                 $local:Headers = @{
@@ -752,6 +757,7 @@ function Disconnect-Safeguard
             if ($Insecure)
             {
                 Enable-SslVerification
+                if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
             }
         }
     }
@@ -951,6 +957,7 @@ function Invoke-SafeguardMethod
     if ($Insecure)
     {
         Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
     }
 
     $local:Headers = @{
@@ -1018,6 +1025,7 @@ function Invoke-SafeguardMethod
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }
@@ -1093,6 +1101,7 @@ function Get-SafeguardAccessTokenStatus
         if ($Insecure)
         {
             Disable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
         $local:Response = (Invoke-WebRequest -Method GET -Headers @{ 
                 "Authorization" = "Bearer $AccessToken"
@@ -1117,6 +1126,7 @@ function Get-SafeguardAccessTokenStatus
         if ($Insecure)
         {
             Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
     }
 }

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -81,6 +81,11 @@ function Get-RstsTokenFromGui
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($PSVersionTable.PSEdition -eq "Core")
+    {
+        throw "This -Gui parameter is not supported in PowerShell Core"
+    }
+
     Show-RstsWindow $Appliance
     $local:Code = $global:AuthorizationCode
     Remove-Variable -Name AuthorizationCode -Scope Global -Force -ErrorAction "SilentlyContinue"

--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -25,24 +25,24 @@ function Disable-SslVerification
     else
     {
         Write-Verbose "Disabling SSL on Windows platform"
-        if (-not ([System.Management.Automation.PSTypeName]"TrustEverything").Type)
-        {
-            Write-Verbose "Adding the PSType for SSL trust override"
-            Add-Type -TypeDefinition  @"
+    }
+    if (-not ([System.Management.Automation.PSTypeName]"TrustEverything").Type)
+    {
+        Write-Verbose "Adding the PSType for SSL trust override"
+        Add-Type -TypeDefinition  @"
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 public static class TrustEverything
 {
-    private static bool ValidationCallback(object sender, X509Certificate certificate, X509Chain chain,
-        SslPolicyErrors sslPolicyErrors) { return true; }
-    public static void SetCallback() { System.Net.ServicePointManager.ServerCertificateValidationCallback = ValidationCallback; }
-    public static void UnsetCallback() { System.Net.ServicePointManager.ServerCertificateValidationCallback = null; }
+private static bool ValidationCallback(object sender, X509Certificate certificate, X509Chain chain,
+    SslPolicyErrors sslPolicyErrors) { return true; }
+public static void SetCallback() { System.Net.ServicePointManager.ServerCertificateValidationCallback = ValidationCallback; }
+public static void UnsetCallback() { System.Net.ServicePointManager.ServerCertificateValidationCallback = null; }
 }
 "@
-        }
-        Write-Verbose "Adding the trust everything callback"
-        [TrustEverything]::SetCallback()
     }
+    Write-Verbose "Adding the trust everything callback"
+    [TrustEverything]::SetCallback()
 }
 function Enable-SslVerification
 {
@@ -69,11 +69,11 @@ function Enable-SslVerification
     else
     {
         Write-Verbose "Enabling SSL on Windows platform"
-        if (([System.Management.Automation.PSTypeName]"TrustEverything").Type)
-        {
-            Write-Verbose "Removing the trust everything callback"
-            [TrustEverything]::UnsetCallback()
-        }
+    }
+    if (([System.Management.Automation.PSTypeName]"TrustEverything").Type)
+    {
+        Write-Verbose "Removing the trust everything callback"
+        [TrustEverything]::UnsetCallback()
     }
 }
 function Edit-SslVersionSupport

--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -18,8 +18,8 @@ function Disable-SslVerification
         else
         {
             Write-Verbose "Disabling SSL on non-Windows platform"
-            $PSDefaultParameterValues.Add("Invoke-RestMethod:SkipCertificateCheck",$true)
-            $PSDefaultParameterValues.Add("Invoke-WebRequest:SkipCertificateCheck",$true)
+            $global:PSDefaultParameterValues.Add("Invoke-RestMethod:SkipCertificateCheck",$true)
+            $global:PSDefaultParameterValues.Add("Invoke-WebRequest:SkipCertificateCheck",$true)
         }
     }
     else
@@ -62,8 +62,8 @@ function Enable-SslVerification
         else
         {
             Write-Verbose "Enabling SSL on non-Windows platform"
-            $PSDefaultParameterValues.Remove("Invoke-RestMethod:SkipCertificateCheck")
-            $PSDefaultParameterValues.Remove("Invoke-WebRequest:SkipCertificateCheck")
+            $global:PSDefaultParameterValues.Remove("Invoke-RestMethod:SkipCertificateCheck")
+            $global:PSDefaultParameterValues.Remove("Invoke-WebRequest:SkipCertificateCheck")
         }
     }
     else

--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -6,6 +6,9 @@ function Disable-SslVerification
     Param(
     )
 
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
     if (-not ([System.Management.Automation.PSTypeName]"TrustEverything").Type)
     {
         Write-Verbose "Adding the PSType for SSL trust override"
@@ -30,6 +33,9 @@ function Enable-SslVerification
     Param(
     )
 
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
     if (([System.Management.Automation.PSTypeName]"TrustEverything").Type)
     {
         Write-Verbose "Removing the trust everything callback"
@@ -41,6 +47,9 @@ function Edit-SslVersionSupport
     [CmdletBinding()]
     Param(
     )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Write-Verbose "Configuring SSL version support to be secure"
     # Remove SSLv3, if present


### PR DESCRIPTION
We were having issues with ignoring SSL certificate validation which made it very difficult to use safeguard-ps from an Ubuntu docker container