### PR TITLE
Added depth to Invoke-WithBody func. Default depth is 2.

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -288,7 +288,7 @@ function Invoke-WithBody
     $local:BodyInternal = $JsonBody
     if ($Body)
     {
-        $local:BodyInternal = (ConvertTo-Json -InputObject $Body)
+        $local:BodyInternal = (ConvertTo-Json -Depth 5 -InputObject $Body)
     }
     $local:Url = (New-SafeguardUrl $Appliance $Service $Version $RelativeUrl -Parameters $Parameters)
     Write-Verbose "Url=$($local:Url)"


### PR DESCRIPTION
Edit-SafeguardAsset was failing because the Asset.Owners.DirectorProperties dict wasn't being parsed into JSON. 

The JSON conversion was occurring in Invoke-WithBody by using the ConvertTo-Json cmdlet on the passed-in body. 

According to [this](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertto-json?view=powershell-6) the default depth of the ConvertTo-Json cmdlet is 2. I increased to 5. 

This caused Edit-SafeguardAsset to succeed.

Depth can go up to 100, and while I'm not sure 5 is enough, it's better than 2.