### PR TITLE
Add support for query parameter 'filter' from Find-Safeguard* cmdlets

### DIFF
--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -912,6 +912,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the asset account.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -923,10 +926,13 @@ Find-SafeguardAssetAccount -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Find-SafeguardAssetAccount "root"
+
+.EXAMPLE
+Find-SafeguardAssetAccount -QueryFilter "CreatedByUserDisplayName eq 'George Smith'"
 #>
 function Find-SafeguardAssetAccount
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -934,15 +940,25 @@ function Find-SafeguardAssetAccount
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts" `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts" `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts" `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -285,6 +285,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the asset.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -296,10 +299,13 @@ Find-SafeguardAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Find-SafeguardAsset "linux.company.corp"
+
+.EXAMPLE
+Find-SafeguardAsset -QueryFilter "Platform.PlatformFamily eq 'Windows'"
 #>
 function Find-SafeguardAsset
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -307,15 +313,25 @@ function Find-SafeguardAsset
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets" `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets" `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets" `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -780,6 +780,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the directory account.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -791,10 +794,13 @@ Find-SafeguardDirectoryAccount -AccessToken $token -Appliance 10.5.32.54 -Insecu
 
 .EXAMPLE
 Find-SafeguardDirectoryAccount "-adm"
+
+.EXAMPLE
+Find-SafeguardDirectoryAccount -QueryFilter "DirectoryProperties.DomainName eq 'child.sample.net'"
 #>
 function Find-SafeguardDirectoryAccount
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -802,15 +808,25 @@ function Find-SafeguardDirectoryAccount
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -426,6 +426,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the policy account.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -437,10 +440,13 @@ Find-SafeguardPolicyAccount -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Find-SafeguardPolicyAccount "root"
+
+.EXAMPLE
+Find-SafeguardPolicyAccount -QueryFilter "IsServiceAccount eq True"
 #>
 function Find-SafeguardPolicyAccount
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -448,15 +454,25 @@ function Find-SafeguardPolicyAccount
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAccounts `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAccounts `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAccounts `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -284,6 +284,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the policy asset.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -295,10 +298,16 @@ Find-SafeguardPolicyAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Find-SafeguardPolicyAsset "HP-UX"
+
+.EXAMPLE
+Find-SafeguardPolicyAsset -QueryFilter "AllowSessionRequests eq False"
+
+.EXAMPLE
+Find-SafeguardPolicyAsset -QueryFilter "Disabled eq True"
 #>
 function Find-SafeguardPolicyAsset
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -306,15 +315,25 @@ function Find-SafeguardPolicyAsset
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -557,6 +557,9 @@ JSON response from Safeguard Web API.
 
 .EXAMPLE
 Find-SafeguardRequestableAccount -SearchString testString
+
+.EXAMPLE
+Find-SafeguardRequestableAccount -AssetQueryFilter "PlatformType eq 'Ubuntu'" -AccountQueryFilter "AccountRequestTypes contains 'LocalPassword'"
 #>
 function Find-SafeguardRequestableAccount
 {

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -181,6 +181,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string containing the ID of the access request.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -192,10 +195,13 @@ Find-SafeguardAccessRequest 123
 
 .EXAMPLE
 Find-SafeguardAccessRequest -SearchString testString
+
+.EXAMPLE
+Find-SafeguardAccessRequest -QueryFilter "(AssetName eq 'Linux') and (AccountName eq 'root')"
 #>
 function Find-SafeguardAccessRequest
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -203,15 +209,25 @@ function Find-SafeguardAccessRequest
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true, Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true, Position=0, ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AccessRequests" `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AccessRequests" `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AccessRequests" `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -762,6 +762,7 @@ function Disconnect-Safeguard
                     Disable-SslVerification
                     if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
                 }
+                Write-Host "Logging out $($SafeguardSession.IdentityProvider)\$($SafeguardSession.Username)"
                 Write-Verbose "Calling Safeguard Logout service..."
                 $local:Headers = @{
                     "Accept" = "application/json";

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -272,6 +272,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER SearchString
 A string to search for in the user.
 
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
 .INPUTS
 None.
 
@@ -283,10 +286,13 @@ Find-SafeguardUser -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Find-SafeguardUser "Peterson"
+
+.EXAMPLE
+Find-SafeguardUser -QueryFilter "SecondaryAuthenticationProviderId eq null" | ft Id,PrimaryAuthenticationProviderName,UserName,EmailAddress
 #>
 function Find-SafeguardUser
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Search")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -294,15 +300,25 @@ function Find-SafeguardUser
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$SearchString
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
-        -Parameters @{ q = $SearchString }
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            -Parameters @{ q = $SearchString }
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            -Parameters @{ filter = $QueryFilter }
+    }
 }
 
 <#


### PR DESCRIPTION
All of the following now support a -QueryFilter parameter that will go directly to the filter query parameter:
- Find-SafeguardAccessRequest
- Find-SafeguardAsset
- Find-SafeguardAssetAccount
- Find-SafeguardDirectoryAccount
- Find-SafeguardEventSubscription
- Find-SafeguardPlatform
- Find-SafeguardPolicyAccount
- Find-SafeguardPolicyAsset
- Find-SafeguardUser

Because of how it is implemented this cmdlet has -AssetQueryFilter and -AccountFilter that can be used separately or together:
- Find-SafeguardRequestableAccount