### PR TITLE
A2A Access Request Broker Updates

### DIFF
--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -311,11 +311,20 @@ A string containing the name of the identity provider of the user to create the 
 .PARAMETER ForUserName
 A string containing the name of the user to create the request for.
 
+.PARAMETER ForUserId
+An integer containing the ID of the user to create the request for.
+
 .PARAMETER AssetToUse
 A string containing the name of the asset to request.
 
+.PARAMETER AssetIdToUse
+An integer containing the ID of the asset to request.
+
 .PARAMETER AccountToUse
 A string containing the name of the account to request.
+
+.PARAMETER AccountIdToUse
+An integer containing the ID of the account to request
 
 .PARAMETER AccessRequestType
 A string containing the type of access request to make.
@@ -332,6 +341,18 @@ A string containing the reason comment for the access request.
 .PARAMETER TicketNumber
 A string containing the ticket number for the access request.
 
+.PARAMETER RequestedFor
+A string containing the UTC date/time the request becomes active.  For example: "2018-10-17T12:11:12Z".
+
+.PARAMETER RequestedDurationDays
+An integer containing the number of days for the request duration (0-31).
+
+.PARAMETER RequestedDurationHours
+An integer containing the number of hours for the request duration (0-23).
+
+.PARAMETER RequestedDurationMinutes
+An integer containing the number of minutes for the request duration (0-59).
+
 .INPUTS
 None.
 
@@ -346,29 +367,44 @@ New-SafeguardA2aAccessRequest 10.5.32.23 -CertificateFile .\CERT.pfx UK1Pf45hvWa
 #>
 function New-SafeguardA2aAccessRequest
 {
-    [CmdletBinding(DefaultParameterSetName="CertStore")]
+    [CmdletBinding(DefaultParameterSetName="CertStoreAndNames")]
     Param(
         [Parameter(Mandatory=$true,Position=0)]
         [string]$Appliance,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(ParameterSetName="File",Mandatory=$true)]
+        [Parameter(ParameterSetName="FileAndNames",Mandatory=$true)]
+        [Parameter(ParameterSetName="FileAndIds",Mandatory=$true)]
         [string]$CertificateFile,
-        [Parameter(ParameterSetName="File",Mandatory=$false)]
+        [Parameter(ParameterSetName="FileAndNames",Mandatory=$false)]
+        [Parameter(ParameterSetName="FileAndIds",Mandatory=$false)]
         [SecureString]$Password,
-        [Parameter(ParameterSetName="CertStore",Mandatory=$true)]
+        [Parameter(ParameterSetName="CertStoreAndNames",Mandatory=$true)]
+        [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$true)]
         [string]$Thumbprint,
         [Parameter(Mandatory=$true,Position=1)]
         [string]$ApiKey,
         [Parameter(Mandatory=$false)]
         [string]$ForProviderName,
-        [Parameter(Mandatory=$true,Position=2)]
+        [Parameter(ParameterSetName="FileAndNames",Mandatory=$true,Position=2)]
+        [Parameter(ParameterSetName="CertStoreAndNames",Mandatory=$true,Position=2)]
         [string]$ForUserName,
-        [Parameter(Mandatory=$true,Position=3)]
+        [Parameter(ParameterSetName="FileAndIds",Mandatory=$true,Position=2)]
+        [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$true,Position=2)]
+        [int]$ForUserId,
+        [Parameter(ParameterSetName="FileAndNames",Mandatory=$true,Position=3)]
+        [Parameter(ParameterSetName="CertStoreAndNames",Mandatory=$true,Position=3)]
         [string]$AssetToUse,
-        [Parameter(Mandatory=$true,Position=4)]
+        [Parameter(ParameterSetName="FileAndIds",Mandatory=$true,Position=3)]
+        [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$true,Position=3)]
+        [string]$AssetIdToUse,
+        [Parameter(ParameterSetName="FileAndNames",Mandatory=$false,Position=4)]
+        [Parameter(ParameterSetName="CertStoreAndNames",Mandatory=$false,Position=4)]
         [string]$AccountToUse,
-        [Parameter(Mandatory=$true,Position=5)]
+        [Parameter(ParameterSetName="FileAndIds",Mandatory=$false,Position=4)]
+        [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$false,Position=4)]
+        [string]$AccountIdToUse,
+        [Parameter(Mandatory=$false,Position=5)]
         [ValidateSet("Password", "SSH", "RemoteDesktop", "RDP", IgnoreCase=$true)]
         [string]$AccessRequestType,
         [Parameter(Mandatory=$false)]
@@ -378,7 +414,18 @@ function New-SafeguardA2aAccessRequest
         [Parameter(Mandatory=$false)]
         [string]$ReasonComment,
         [Parameter(Mandatory=$false)]
-        [string]$TicketNumber
+        [string]$TicketNumber,
+        [Parameter(Mandatory=$false)]
+        [string]RequestedFor,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(0, 31)]
+        [int]RequestedDurationDays,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(0, 23)]
+        [int]RequestedDurationHours,
+        [Parameter(Mandatory=$false)]
+        [ValidateRange(0, 59)]
+        [int]RequestedDurationMinutes
     )
 
     $ErrorActionPreference = "Stop"
@@ -389,13 +436,23 @@ function New-SafeguardA2aAccessRequest
         $AccessRequestType = "RemoteDesktop"
     }
 
-    ### We need to figure out how we are going to resolve Asset and Account IDs
-
-    $local:Body = @{
-        ForUser = $ForUserName;
-        SystemName = $AssetToUse;
-        AccountName = $AccountToUse;
-        AccessRequestType = "$AccessRequestType"
+    if ($PsCmdlet.ParameterSetName -eq "CertStoreAndNames" -or $PsCmdlet.ParameterSetName -eq "FileAndNames")
+    {
+        $local:Body = @{
+            ForUser = $ForUserName;
+            SystemName = $AssetToUse;
+            AccessRequestType = "$AccessRequestType"
+        }
+        if ($AccountToUse) { $local:Body["AccountName"] = $AccountToUse }
+    }
+    else
+    {
+        $local:Body = @{
+            ForUserId = $ForUserId;
+            SystemId = $AssetIdToUse;
+            AccessRequestType = "$AccessRequestType"
+        }
+        if ($AccountIdToUse) { $local:Body["AccountId"] = $AccountIdToUse }
     }
 
     if ($ForProviderName) {$local:Body["ForProvider"] = $ForProviderName }
@@ -410,7 +467,13 @@ function New-SafeguardA2aAccessRequest
     if ($ReasonComment) { $local:Body["ReasonComment"] = $ReasonComment }
     if ($TicketNumber) { $local:Body["TicketNumber"] = $TicketNumber }
 
-    if ($PsCmdlet.ParameterSetName -eq "CertStore")
+    if ($RequestedFor) { $local:Body["RequestedFor"] = $RequestedFor }
+
+    if ($RequestedDurationDays) { $local:Body["RequestedDurationDays"] = $RequestedDurationDays }
+    if ($RequestedDurationHours) { $local:Body["RequestedDurationHours"] = $RequestedDurationHours }
+    if ($RequestedDurationMinutes) { $local:Body["RequestedDurationMinutes"] = $RequestedDurationMinutes }
+
+    if ($PsCmdlet.ParameterSetName -eq "CertStoreAndNames" -or $PsCmdlet.ParameterSetName -eq "CertStoreAndIds")
     {
         Invoke-SafeguardA2aMethodWithCertificate -Insecure:$Insecure -Appliance $Appliance -Authorization "A2A $ApiKey" `
             -Thumbprint $Thumbprint -Method POST -RelativeUrl AccessRequests -Body $local:Body

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -416,16 +416,16 @@ function New-SafeguardA2aAccessRequest
         [Parameter(Mandatory=$false)]
         [string]$TicketNumber,
         [Parameter(Mandatory=$false)]
-        [string]RequestedFor,
+        [string]$RequestedFor,
         [Parameter(Mandatory=$false)]
         [ValidateRange(0, 31)]
-        [int]RequestedDurationDays,
+        [int]$RequestedDurationDays,
         [Parameter(Mandatory=$false)]
         [ValidateRange(0, 23)]
-        [int]RequestedDurationHours,
+        [int]$RequestedDurationHours,
         [Parameter(Mandatory=$false)]
         [ValidateRange(0, 59)]
-        [int]RequestedDurationMinutes
+        [int]$RequestedDurationMinutes
     )
 
     $ErrorActionPreference = "Stop"

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -397,13 +397,13 @@ function New-SafeguardA2aAccessRequest
         [string]$AssetToUse,
         [Parameter(ParameterSetName="FileAndIds",Mandatory=$true,Position=3)]
         [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$true,Position=3)]
-        [string]$AssetIdToUse,
+        [int]$AssetIdToUse,
         [Parameter(ParameterSetName="FileAndNames",Mandatory=$false,Position=4)]
         [Parameter(ParameterSetName="CertStoreAndNames",Mandatory=$false,Position=4)]
         [string]$AccountToUse,
         [Parameter(ParameterSetName="FileAndIds",Mandatory=$false,Position=4)]
         [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$false,Position=4)]
-        [string]$AccountIdToUse,
+        [int]$AccountIdToUse,
         [Parameter(Mandatory=$false,Position=5)]
         [ValidateSet("Password", "SSH", "RemoteDesktop", "RDP", IgnoreCase=$true)]
         [string]$AccessRequestType,

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -74,10 +74,10 @@ function Invoke-SafeguardA2aMethodWithCertificate
     catch
     {
         Write-Warning "An exception was caught trying to call A2A using a certificate."
-        Write-Warning "Your problem may be an quirk on Windows where the low-level HTTPS client requires that you have the Issuing CA"
-        Write-Warning "in your 'Intermediate Certificate Authorities' store, otherwise Windows doesn't think you have a matching"
-        Write-Warning "certificate to send in the initial client connection. This occurs even if you pass in a PFX file specifying"
-        Write-Warning "exactly which certificate to use."
+        Write-Warning "If you are experiencing a certificate connection failure, your problem may be an quirk on Windows where"
+        Write-Warning "the low-level HTTPS client requires that the Issuing CA be in your 'Intermediate Certificate Authorities'"
+        Write-Warning "store, otherwise Windows doesn't think you have a matching certificate to send in the initial client"
+        Write-Warning "connection. This occurs even if you pass in a PFX file specifying exactly which certificate to use."
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
         Out-SafeguardExceptionIfPossible $_.Exception
     }


### PR DESCRIPTION
Added the ability to use IDs as well as names for access request broker.
Added support for requesting in the future and change the default duration of the request.