### PR TITLE
Backward compatibility support in Invoke-SafeguardMethod

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1177,7 +1177,7 @@ function Invoke-SafeguardMethod
     }
     catch
     {
-        if ($_.Exception.HttpStatusCode -eq 404)
+        if ($_.Exception.HttpStatusCode -eq 404 -and $RetryUrl)
         {
             Write-Verbose "Trying to use RetryUrl: $RetryUrl"
             Invoke-Internal $Appliance $Service $Method $Version $RetryUrl $local:Headers `

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -981,7 +981,12 @@ Relative portion of the Url you would like to call starting after the version.
 Version of the Web API you are using (default: 2).
 
 .PARAMETER RetryUrl
-Relative portion of the Url to retry if the RelativeUrl returns 404 (for backwards compatibility).
+Relative portion of the Url to retry if the initial call returns 404 (for backwards compatibility).
+Retry will only occur if this parameter is included.  If the retry needs to differ only by version,
+you must specify this anyway (even if it is the same value) along with RetryVersion.
+
+.PARAMETER RetryVersion
+Version of the Web API to retry if the initial call returns 404 (for backwards compatibility).
 
 .PARAMETER Accept
 Specify the Accept header (default: application/json)
@@ -1062,6 +1067,8 @@ function Invoke-SafeguardMethod
         [int]$Version = 2,
         [Parameter(Mandatory=$false)]
         [string]$RetryUrl,
+        [Parameter(Mandatory=$false)]
+        [int]$RetryVersion = $Version,
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
@@ -1179,8 +1186,8 @@ function Invoke-SafeguardMethod
     {
         if ($_.Exception.HttpStatusCode -eq 404 -and $RetryUrl)
         {
-            Write-Verbose "Trying to use RetryUrl: $RetryUrl"
-            Invoke-Internal $Appliance $Service $Method $Version $RetryUrl $local:Headers `
+            Write-Verbose "Trying to use RetryVersion: $RetryVersion, and RetryUrl: $RetryUrl"
+            Invoke-Internal $Appliance $Service $Method $RetryVersion $RetryUrl $local:Headers `
                             -Body $Body -JsonBody $JsonBody `
                             -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
         }

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -25,6 +25,7 @@ namespace Ex
         public SafeguardMethodException(int httpCode, string httpMessage, int errorCode, string errorMessage, string errorJson)
             : base(httpCode + ": " + httpMessage + " -- " + errorCode + ": " + errorMessage)
         {
+            HttpStatusCode = httpCode;
             ErrorCode = errorCode;
             ErrorMessage = errorMessage;
             ErrorJson = errorJson;
@@ -34,6 +35,7 @@ namespace Ex
         protected SafeguardMethodException
             (SerializationInfo info, StreamingContext context)
             : base(info, context) {}
+        public int HttpStatusCode { get; set; }
         public int ErrorCode { get; set; }
         public string ErrorMessage { get; set; }
         public string ErrorJson { get; set; }


### PR DESCRIPTION
Added two parameters to Invoke-SafeguardMethod that will be used if a 404 is encountered.

`-RetryUrl`
A relative URL to try on the second attempt

`-RetryVersion`
The version number to try on the second attempt