### PR TITLE
Add CSV reports for access requests and password check and change

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,3 +449,12 @@ safeguard-ps can do run:
 - Get-SafeguardStarlingJoinUrl
 - Get-SafeguardStarlingSetting
 - Set-SafeguardStarlingSetting
+
+### Reports
+
+- Get-SafeguardReportAccountWithoutPassword
+- Get-SafeguardReportDailyAccessRequest
+- Get-SafeguardReportDailyPasswordChangeFail
+- Get-SafeguardReportDailyPasswordChangeSuccess
+- Get-SafeguardReportDailyPasswordCheckFail
+- Get-SafeguardReportDailyPasswordCheckSuccess

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -1,0 +1,88 @@
+function Get-SafeguardReportAccountWithoutPassword
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:OutFile = $null
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:OutFile = (Join-Path $OutputDirectory "sg-accounts-wo-password-$((Get-Date).ToString("yyyyMMddTHHmmssZz")).csv")
+    }
+
+    Invoke-SafeguardMethod Core GET PolicyAccounts -Accept "text/csv" -OutFile $local:OutFile -Parameters @{ 
+        filter = "HasPassword eq false";
+        fields = "SystemId,Id,SystemName,Name,DomainName,SystemNetworkAddress,HasPassword,Disabled,AllowPasswordRequest,AllowSessionRequest,PlatformDisplayName" }
+
+    if ($local:OutFile)
+    {
+        Write-Host "Data written to $($local:OutFile)"
+        if ($Excel)
+        {
+            Open-CsvInExcel $local:OutFile
+        }
+    }
+}
+
+function Get-SafeguardReportDailyAccessRequest
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut,
+        [Parameter(Mandatory=$false)]
+        [DateTime]$LocalDate = (Get-Date)
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
+    $local:EndDate = ($local:DayOnly.AddDays(1))
+
+    $local:OutFile = $null
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:OutFile = (Join-Path $OutputDirectory "sg-daily-access-request-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv")
+    }
+
+    # Calling AuditLog with just an endDate returns a result using a startDate 24 hours before the specified endDate
+    Invoke-SafeguardMethod Core GET AuditLog/AccessRequests/Activities -Accept "text/csv" -OutFile $local:OutFile -Parameters @{
+        endDate = "$($local:EndDate.ToString("yyyy-MM-ddTHH:mm:sszzz"))";
+        filter = "Action eq 'CheckOutPassword' or Action eq 'InitializeSession'";
+        fields = "LogTime,RequestId,RequesterId,RequesterName,SystemId,AccountId,SystemName,AccountName,AccountDomainName,AccessRequestType,Action,SessionId,ApplianceId,ApplianceName" }
+
+    if ($local:OutFile)
+    {
+        Write-Host "Data written to $($local:OutFile)"
+        if ($Excel)
+        {
+            Open-CsvInExcel $local:OutFile
+        }
+    }
+}

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -1,3 +1,88 @@
+# Helpers
+function Get-OutFileForParam
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$OutputDirectory,
+        [Parameter(Mandatory=$false)]
+        [string]$FileName,
+        [Parameter(Mandatory=$false)]
+        [switch]$StdOut
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $StdOut)
+    {
+        (Join-Path $OutputDirectory $FileName)
+    }
+    else
+    {
+        $null
+    }
+}
+function Out-FileAndExcel
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$OutFile,
+        [Parameter(Mandatory=$false)]
+        [switch]$Excel
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($OutFile)
+    {
+        Write-Host "Data written to $($OutFile)"
+        if ($Excel)
+        {
+            Open-CsvInExcel $OutFile
+        }
+    }
+}
+function Invoke-AuditLogMethod
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RelativeUrl,
+        [Parameter(Mandatory=$true, Position=1)]
+        [DateTime]$DayOnly,
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]$Filter,
+        [Parameter(Mandatory=$true, Position=3)]
+        [string]$Fields,
+        [Parameter(Mandatory=$false)]
+        [string]$OutFile,
+        [Parameter(Mandatory=$false)]
+        [switch]$Excel
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:EndDate = ($DayOnly.AddDays(1))
+
+    # Calling AuditLog with just an endDate returns a result using a startDate 24 hours before the specified endDate
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $RelativeUrl -Accept "text/csv" -OutFile $local:OutFile -Parameters @{
+        endDate = "$($local:EndDate.ToString("yyyy-MM-ddTHH:mm:sszzz"))";
+        filter = $Filter; fields = $Fields }
+
+    Out-FileAndExcel -OutFile $local:OutFile -Excel:$Excel
+}
+
+
 function Get-SafeguardReportAccountWithoutPassword
 {
     [CmdletBinding(DefaultParameterSetName="File")]
@@ -19,24 +104,14 @@ function Get-SafeguardReportAccountWithoutPassword
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:OutFile = $null
-    if ($PSCmdlet.ParameterSetName -eq "File")
-    {
-        $local:OutFile = (Join-Path $OutputDirectory "sg-accounts-wo-password-$((Get-Date).ToString("yyyyMMddTHHmmssZz")).csv")
-    }
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-accounts-wo-password-$((Get-Date).ToString("yyyyMMddTHHmmssZz")).csv" -StdOut:$StdOut)
 
-    Invoke-SafeguardMethod Core GET PolicyAccounts -Accept "text/csv" -OutFile $local:OutFile -Parameters @{ 
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "PolicyAccounts" -Accept "text/csv" -OutFile $local:OutFile -Parameters @{
         filter = "HasPassword eq false";
-        fields = "SystemId,Id,SystemName,Name,DomainName,SystemNetworkAddress,HasPassword,Disabled,AllowPasswordRequest,AllowSessionRequest,PlatformDisplayName" }
+        fields = ("SystemId,Id,SystemName,Name,DomainName,SystemNetworkAddress,HasPassword,Disabled,AllowPasswordRequest,AllowSessionRequest," + `
+            "PlatformDisplayName") }
 
-    if ($local:OutFile)
-    {
-        Write-Host "Data written to $($local:OutFile)"
-        if ($Excel)
-        {
-            Open-CsvInExcel $local:OutFile
-        }
-    }
+    Out-FileAndExcel -OutFile $local:OutFile -Excel:$Excel
 }
 
 function Get-SafeguardReportDailyAccessRequest
@@ -63,26 +138,143 @@ function Get-SafeguardReportDailyAccessRequest
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
-    $local:EndDate = ($local:DayOnly.AddDays(1))
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-daily-access-request-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv" -StdOut:$StdOut)
 
-    $local:OutFile = $null
-    if ($PSCmdlet.ParameterSetName -eq "File")
-    {
-        $local:OutFile = (Join-Path $OutputDirectory "sg-daily-access-request-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv")
-    }
+    Invoke-AuditLogMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "AuditLog/AccessRequests/Activities" $local:DayOnly `
+        "Action eq 'CheckOutPassword' or Action eq 'InitializeSession'" `
+        ("LogTime,RequestId,RequesterId,RequesterName,SystemId,AccountId,SystemName,AccountName,AccountDomainName,AccessRequestType,Action," + `
+        "SessionId,ApplianceId,ApplianceName") `
+        -OutFile $local:OutFile -Excel:$Excel
+}
 
-    # Calling AuditLog with just an endDate returns a result using a startDate 24 hours before the specified endDate
-    Invoke-SafeguardMethod Core GET AuditLog/AccessRequests/Activities -Accept "text/csv" -OutFile $local:OutFile -Parameters @{
-        endDate = "$($local:EndDate.ToString("yyyy-MM-ddTHH:mm:sszzz"))";
-        filter = "Action eq 'CheckOutPassword' or Action eq 'InitializeSession'";
-        fields = "LogTime,RequestId,RequesterId,RequesterName,SystemId,AccountId,SystemName,AccountName,AccountDomainName,AccessRequestType,Action,SessionId,ApplianceId,ApplianceName" }
+function Get-SafeguardReportDailyPasswordCheckFail
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut,
+        [Parameter(Mandatory=$false)]
+        [DateTime]$LocalDate = (Get-Date)
+    )
 
-    if ($local:OutFile)
-    {
-        Write-Host "Data written to $($local:OutFile)"
-        if ($Excel)
-        {
-            Open-CsvInExcel $local:OutFile
-        }
-    }
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-daily-pwcheck-fail-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv" -StdOut:$StdOut)
+
+    Invoke-AuditLogMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "AuditLog/Passwords/CheckPassword" $local:DayOnly `
+        "EventName eq 'PasswordCheckFailed'" `
+        ("LogTime,SystemId,AccountId,SystemName,AccountName,AccountDomainName,NetworkAddress,PlatformDisplayName,EventName," + `
+        "RequestStatus.Message,AssetPartitionId,AssetPartitionName,ProfileId,ProfileName,SyncGroupId,SyncGroupName,ApplianceId,ApplianceName") `
+        -OutFile $local:OutFile -Excel:$Excel
+}
+
+function Get-SafeguardReportDailyPasswordCheckSuccess
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut,
+        [Parameter(Mandatory=$false)]
+        [DateTime]$LocalDate = (Get-Date)
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-daily-pwcheck-success-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv" -StdOut:$StdOut)
+
+    Invoke-AuditLogMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "AuditLog/Passwords/CheckPassword" $local:DayOnly `
+        "EventName eq 'PasswordCheckSucceeded'" `
+        ("LogTime,SystemId,AccountId,SystemName,AccountName,AccountDomainName,NetworkAddress,PlatformDisplayName,EventName," + `
+        "AssetPartitionId,AssetPartitionName,ProfileId,ProfileName,SyncGroupId,SyncGroupName,ApplianceId,ApplianceName") `
+        -OutFile $local:OutFile -Excel:$Excel
+}
+
+function Get-SafeguardReportDailyPasswordChangeFail
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut,
+        [Parameter(Mandatory=$false)]
+        [DateTime]$LocalDate = (Get-Date)
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-daily-pwchange-fail-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv" -StdOut:$StdOut)
+
+    Invoke-AuditLogMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "AuditLog/Passwords/ChangePassword" $local:DayOnly `
+        "EventName eq 'PasswordChangeFailed'" `
+        ("LogTime,SystemId,AccountId,SystemName,AccountName,AccountDomainName,NetworkAddress,PlatformDisplayName,EventName," + `
+        "AssetPartitionId,AssetPartitionName,ProfileId,ProfileName,SyncGroupId,SyncGroupName,ApplianceId,ApplianceName") `
+        -OutFile $local:OutFile -Excel:$Excel
+}
+
+function Get-SafeguardReportDailyPasswordChangeSuccess
+{
+    [CmdletBinding(DefaultParameterSetName="File")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, ParameterSetName="File", Position=0)]
+        [string]$OutputDirectory = (Get-Location),
+        [Parameter(Mandatory=$false, ParameterSetName="File")]
+        [switch]$Excel = $false,
+        [Parameter(Mandatory=$false, ParameterSetName="StdOut")]
+        [switch]$StdOut,
+        [Parameter(Mandatory=$false)]
+        [DateTime]$LocalDate = (Get-Date)
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:DayOnly = (New-Object "System.DateTime" -ArgumentList $LocalDate.Year, $LocalDate.Month, $LocalDate.Day)
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-daily-pwchange-success-$(($local:DayOnly).ToString("yyyy-MM-dd")).csv" -StdOut:$StdOut)
+
+    Invoke-AuditLogMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure "AuditLog/Passwords/ChangePassword" $local:DayOnly `
+        "EventName eq 'PasswordChangeSucceeded'" `
+        ("LogTime,SystemId,AccountId,SystemName,AccountName,AccountDomainName,NetworkAddress,PlatformDisplayName,EventName," + `
+        "AssetPartitionId,AssetPartitionName,ProfileId,ProfileName,SyncGroupId,SyncGroupName,ApplianceId,ApplianceName") `
+        -OutFile $local:OutFile -Excel:$Excel
 }

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -87,7 +87,7 @@ function Invoke-AuditLogMethod
 Get CSV report of accounts without passwords.
 
 .DESCRIPTION
-This cmdlet will generate CSV for every account that has been added to Safeguard
+This cmdlet will generate CSV containing every account that has been added to Safeguard
 that does not have a password stored in Safeguard.
 
 This cmdlet will generate and save a CSV file by default.  This file can be opened
@@ -155,6 +155,55 @@ function Get-SafeguardReportAccountWithoutPassword
     Out-FileAndExcel -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of access requests for a given date (24 hour period).
+
+.DESCRIPTION
+This cmdlet will generate CSV containing every instance of access requests that either
+released a password or initialized a session during a 24 hour period.  Dates in Safeguard
+are UTC, but this cmdlet will use the local time for the 24 hour period.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.PARAMETER LocalDate
+The date for which to run the report (Default is today).  Ex. "2019-02-14".
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportDailyAccessRequest -StdOut
+
+.EXAMPLE
+Get-SafeguardReportDailyAccessRequest -OutputDirectory "C:\reports\" -Excel
+
+.EXAMPLE
+Get-SafeguardReportDailyAccessRequest -LocalDate "2019-02-22" -Excel
+#>
 function Get-SafeguardReportDailyAccessRequest
 {
     [CmdletBinding(DefaultParameterSetName="File")]

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -82,7 +82,48 @@ function Invoke-AuditLogMethod
     Out-FileAndExcel -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of accounts without passwords.
 
+.DESCRIPTION
+This cmdlet will generate CSV for every account that has been added to Safeguard
+that does not have a password stored in Safeguard.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportAccountWithoutPassword -StdOut
+
+.EXAMPLE
+Get-SafeguardReportAccountWithoutPassword -OutputDirectory "C:\reports\" -Excel
+#>
 function Get-SafeguardReportAccountWithoutPassword
 {
     [CmdletBinding(DefaultParameterSetName="File")]

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -237,6 +237,55 @@ function Get-SafeguardReportDailyAccessRequest
         -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of password check failures for a given date (24 hour period).
+
+.DESCRIPTION
+This cmdlet will generate CSV containing every instance of password check
+failures for a 24 hour period.  Dates in Safeguard are UTC, but this cmdlet
+will use the local time for the 24 hour period.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.PARAMETER LocalDate
+The date for which to run the report (Default is today).  Ex. "2019-02-14".
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckFail -StdOut
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckFail -OutputDirectory "C:\reports\" -Excel
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckFail -LocalDate "2019-02-22" -Excel
+#>
 function Get-SafeguardReportDailyPasswordCheckFail
 {
     [CmdletBinding(DefaultParameterSetName="File")]
@@ -270,6 +319,55 @@ function Get-SafeguardReportDailyPasswordCheckFail
         -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of successful password checks for a given date (24 hour period).
+
+.DESCRIPTION
+This cmdlet will generate CSV containing every instance of password checks that
+succeeded for a 24 hour period.  Dates in Safeguard are UTC, but this cmdlet
+will use the local time for the 24 hour period.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.PARAMETER LocalDate
+The date for which to run the report (Default is today).  Ex. "2019-02-14".
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckSuccess -StdOut
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckSuccess -OutputDirectory "C:\reports\" -Excel
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordCheckSuccess -LocalDate "2019-02-22" -Excel
+#>
 function Get-SafeguardReportDailyPasswordCheckSuccess
 {
     [CmdletBinding(DefaultParameterSetName="File")]
@@ -303,6 +401,55 @@ function Get-SafeguardReportDailyPasswordCheckSuccess
         -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of password change failures for a given date (24 hour period).
+
+.DESCRIPTION
+This cmdlet will generate CSV containing every instance of password changes that
+failed for a 24 hour period.  Dates in Safeguard are UTC, but this cmdlet
+will use the local time for the 24 hour period.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.PARAMETER LocalDate
+The date for which to run the report (Default is today).  Ex. "2019-02-14".
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeFail -StdOut
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeFail -OutputDirectory "C:\reports\" -Excel
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeFail -LocalDate "2019-02-22" -Excel
+#>
 function Get-SafeguardReportDailyPasswordChangeFail
 {
     [CmdletBinding(DefaultParameterSetName="File")]
@@ -336,6 +483,55 @@ function Get-SafeguardReportDailyPasswordChangeFail
         -OutFile $local:OutFile -Excel:$Excel
 }
 
+<#
+.SYNOPSIS
+Get CSV report of successful password changes for a given date (24 hour period).
+
+.DESCRIPTION
+This cmdlet will generate CSV containing every instance of successful password changes
+for a 24 hour period.  Dates in Safeguard are UTC, but this cmdlet
+will use the local time for the 24 hour period.
+
+This cmdlet will generate and save a CSV file by default.  This file can be opened
+in Excel automatically using the -Excel parameter or the Open-CsvInExcel cmdlet.
+You may alternatively send the CSV output to standard out.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER OutputDirectory
+String containing the directory where to create the CSV file.
+
+.PARAMETER Excel
+Automatically open the CSV file into excel after it is generation.
+
+.PARAMETER StdOut
+Send CSV to standard out instead of generating a file.
+
+.PARAMETER LocalDate
+The date for which to run the report (Default is today).  Ex. "2019-02-14".
+
+.INPUTS
+None.
+
+.OUTPUTS
+A CSV file or CSV text.
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeSuccess -StdOut
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeSuccess -OutputDirectory "C:\reports\" -Excel
+
+.EXAMPLE
+Get-SafeguardReportDailyPasswordChangeSuccess -LocalDate "2019-02-22" -Excel
+#>
 function Get-SafeguardReportDailyPasswordChangeSuccess
 {
     [CmdletBinding(DefaultParameterSetName="File")]

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -91,7 +91,8 @@ NestedModules = @(
     'a2acallers.psm1',
     'starling.psm1',
     'entitlements.psm1',
-    'accesscert.psm1'
+    'accesscert.psm1',
+    'reports.psm1'
     )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -206,7 +207,9 @@ FunctionsToExport = @(
     # managementShell.psm1
     'Get-SafeguardCommand', 'Get-SafeguardBanner',
     # entitlements.psm1
-    'New-SafeguardEntitlement','Get-SafeguardEntitlement','Remove-SafeguardEntitlement','Get-SafeguardUserEntitlementReport'
+    'New-SafeguardEntitlement','Get-SafeguardEntitlement','Remove-SafeguardEntitlement','Get-SafeguardUserEntitlementReport',
+    # reports.psm1
+    'Get-SafeguardReportAccountWithoutPassword','Get-SafeguardReportDailyAccessRequest'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -102,6 +102,8 @@ FunctionsToExport = @(
     'Connect-Safeguard','Disconnect-Safeguard','Invoke-SafeguardMethod',
     'Get-SafeguardAccessTokenStatus','Update-SafeguardAccessToken',
     'Get-SafeguardLoggedInUser',
+    # csv utility (also in safeguard-ps.psm1)
+    'Open-CsvInExcel',
     # datatypes.psm1
     'Get-SafeguardIdentityProviderType','Get-SafeguardPlatform','Find-SafeguardPlatform',
     'Get-SafeguardTimeZone','Get-SafeguardTransferProtocol',
@@ -202,7 +204,7 @@ FunctionsToExport = @(
     'Get-SafeguardAccessCertificationIdentity','Get-SafeguardAccessCertificationAccount','Get-SafeguardAccessCertificationGroup',
     'Get-SafeguardAccessCertificationEntitlement','Get-ADAccessCertificationIdentity','Update-SafeguardAccessCertificationGroupFromAD',
     # managementShell.psm1
-    'Get-SafeguardCommand', 'Get-SafeguardBanner'
+    'Get-SafeguardCommand', 'Get-SafeguardBanner',
     # entitlements.psm1
     'New-SafeguardEntitlement','Get-SafeguardEntitlement','Remove-SafeguardEntitlement','Get-SafeguardUserEntitlementReport'
     )

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -209,7 +209,9 @@ FunctionsToExport = @(
     # entitlements.psm1
     'New-SafeguardEntitlement','Get-SafeguardEntitlement','Remove-SafeguardEntitlement','Get-SafeguardUserEntitlementReport',
     # reports.psm1
-    'Get-SafeguardReportAccountWithoutPassword','Get-SafeguardReportDailyAccessRequest'
+    'Get-SafeguardReportAccountWithoutPassword','Get-SafeguardReportDailyAccessRequest',
+    'Get-SafeguardReportDailyPasswordCheckFail','Get-SafeguardReportDailyPasswordCheckSuccess',
+    'Get-SafeguardReportDailyPasswordChangeFail','Get-SafeguardReportDailyPasswordChangeSuccess'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.


### PR DESCRIPTION
Includes a simple utility for loading CSV from the command line into Excel and properly interpreting it so that you don't have go through the text file wizard.  (Open-CsvInExcel)

Current reports are:
- Get-SafeguardReportAccountWithoutPassword
- Get-SafeguardReportDailyAccessRequest
- Get-SafeguardReportDailyPasswordChangeFail
- Get-SafeguardReportDailyPasswordChangeSuccess
- Get-SafeguardReportDailyPasswordCheckFail
- Get-SafeguardReportDailyPasswordCheckSuccess

More can be added.