### PR TITLE
Add wrapper cmdlet Get-SafeguardAccessCertificationAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,16 @@ safeguard-ps can do run:
 - Get-SafeguardStarlingSetting
 - Set-SafeguardStarlingSetting
 
+### One Identity Starling Access Certification
+
+- Get-SafeguardAccessCertificationAll
+- Get-SafeguardAccessCertificationAccount
+- Get-SafeguardAccessCertificationGroup
+- Get-SafeguardAccessCertificationEntitlement
+- Get-SafeguardAccessCertificationIdentity
+- Get-ADAccessCertificationIdentity
+- Update-SafeguardAccessCertificationGroupFromAD
+
 ### Reports
 
 - Get-SafeguardReportAccountWithoutPassword

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -204,6 +204,7 @@ FunctionsToExport = @(
     # accesscert.psm1
     'Get-SafeguardAccessCertificationIdentity','Get-SafeguardAccessCertificationAccount','Get-SafeguardAccessCertificationGroup',
     'Get-SafeguardAccessCertificationEntitlement','Get-ADAccessCertificationIdentity','Update-SafeguardAccessCertificationGroupFromAD',
+    'Get-SafeguardAccessCertificationAll'
     # managementShell.psm1
     'Get-SafeguardCommand', 'Get-SafeguardBanner',
     # entitlements.psm1

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -204,7 +204,7 @@ FunctionsToExport = @(
     # accesscert.psm1
     'Get-SafeguardAccessCertificationIdentity','Get-SafeguardAccessCertificationAccount','Get-SafeguardAccessCertificationGroup',
     'Get-SafeguardAccessCertificationEntitlement','Get-ADAccessCertificationIdentity','Update-SafeguardAccessCertificationGroupFromAD',
-    'Get-SafeguardAccessCertificationAll'
+    'Get-SafeguardAccessCertificationAll',
     # managementShell.psm1
     'Get-SafeguardCommand', 'Get-SafeguardBanner',
     # entitlements.psm1


### PR DESCRIPTION
Based on feedback from internal users, this cmdlet calls the 6 other cmdlets and produces the 4 CSV files ready for import into Access Certification.

Also added the scripts to the README.md.