### PR TITLE
Allow an empty payload

### DIFF
--- a/src/accesscert.psm1
+++ b/src/accesscert.psm1
@@ -338,7 +338,7 @@ function Write-CsvOutput
         [bool]$WriteToFile,
         [Parameter(Mandatory=$true, Position=1)]
         [string]$OutputFile,
-        [Parameter(Mandatory=$true, Position=2)]
+        [Parameter(Mandatory=$false, Position=2)]
         [object[]]$Payload,
         [Parameter(Mandatory=$true, Position=3)]
         [string[]]$FormatList


### PR DESCRIPTION
Fix for issue #129 
It was only failing because it couldn't bind the payload parameter.  Now it just prints an empty list or creates an empty file.