### PR TITLE
Directory rewrite v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ safeguard-ps can do run:
 - Test-SafeguardAsset
 - Remove-SafeguardAsset
 - Edit-SafeguardAsset
+- Sync-SafeguardDirectoryAsset
 
 ### Asset Accounts
 
@@ -342,15 +343,6 @@ safeguard-ps can do run:
 - Invoke-SafeguardAssetAccountPasswordChange
 - Invoke-SafeguardAssetSshHostKeyDiscovery
 - Remove-SafeguardAssetAccount
-
-### Directories
-
-- Get-SafeguardDirectory
-- New-SafeguardDirectory
-- Test-SafeguardDirectory
-- Remove-SafeguardDirectory
-- Edit-SafeguardDirectory
-- Sync-SafeguardDirectory
 
 ### Directory Accounts
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,15 @@ safeguard-ps can do run:
 - Invoke-SafeguardAssetSshHostKeyDiscovery
 - Remove-SafeguardAssetAccount
 
+### Directories
+
+- Get-SafeguardDirectory
+- New-SafeguardDirectory
+- Test-SafeguardDirectory
+- Remove-SafeguardDirectory
+- Edit-SafeguardDirectory
+- Sync-SafeguardDirectory
+
 ### Directory Accounts
 
 - Get-SafeguardDirectoryAccount

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,6 @@ build_script:
 
     Import-Module -Name safeguard-ps -Verbose
 test: off
-deploy_script:
-- ps: Publish-Module -Name safeguard-ps -NuGetApiKey $env:PsGalleryApiKey -Verbose
 notifications:
 - provider: Email
   to:

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -106,7 +106,71 @@ function Resolve-SafeguardAssetAccountId
         $Account
     }
 }
+function Resolve-SafeguardAssetPartitionId
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$AssetPartition
+    )
 
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not ($AssetPartition -as [int]))
+    {
+        try
+        {
+            $local:AssetPartitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
+                                 -Parameters @{ filter = "Name ieq '$AssetPartition'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:AssetPartitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
+                                 -Parameters @{ q = $AssetPartition })
+        }
+        if (-not $local:AssetPartitions)
+        {
+            throw "Unable to find asset partition matching '$AssetPartition'"
+        }
+        if ($local:AssetPartitions.Count -ne 1)
+        {
+            throw "Found $($local:AssetPartitions.Count) asset partitions matching '$AssetPartition'"
+        }
+        $local:AssetPartitions[0].Id
+    }
+    else
+    {
+        $AssetPartition
+    }
+}
+function Get-SafeguardDirectoryAssetDomains
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [int]$DirectoryAssetId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets/$DirectoryAssetId).DirectoryAssetProperties.Domains
+}
 <#
 .SYNOPSIS
 Discover SSH host key by connecting to asset managed by Safeguard via the Web API.
@@ -378,6 +442,9 @@ A string containing the service account name.
 .PARAMETER ServiceAccountPassword
 A SecureString containing the password to use for the service account.
 
+.PARAMETER ServiceAccountCredentialType
+Type of credential to use to authenticate the asset.
+
 .PARAMETER ServiceAccountSecretKey
 A string containing an API access key for the service account.
 
@@ -386,6 +453,16 @@ Whether or not to skip SSH host key discovery for platforms that support it.
 
 .PARAMETER AcceptSshHostKey
 Whether or not to auto-accept SSH host key for platforms that support it.
+
+.PARAMETER ServiceAccountDistinguishedName
+A string containing the LDAP distinguished name of a service account.  This is used for
+creating LDAP directories.
+
+.PARAMETER NoSslEncryption
+Do not use SSL encryption for LDAP directory.
+
+.PARAMETER DoNotVerifyServerSslCertificate
+Do not verify Server SSL certificate of LDAP directory.
 
 .INPUTS
 None.
@@ -398,10 +475,13 @@ New-SafeguardAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 New-SafeguardAsset winserver.domain.corp 31 archie
+
+.EXAMPLE
+New-SafeguardAsset -Platform 3 -ServiceAccountDomainName "a.b.corp" -ServiceAccountName "foo"
 #>
 function New-SafeguardAsset
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName="Ad")]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -415,27 +495,39 @@ function New-SafeguardAsset
         [string]$Description,
         [Parameter(Mandatory=$false)]
         [int]$AssetPartitionId = -1,
-        [Parameter(Mandatory=$true,Position=0)]
-        [string]$NetworkAddress,
-        [Parameter(Mandatory=$false,Position=1)]
+        [Parameter(Mandatory=$true,Position=1)]
         [object]$Platform,
-        [Parameter(Mandatory=$false)]
-        [int]$Port,
-        [Parameter(Mandatory=$false)]
-        [ValidateSet("None","Password","SshKey","DirectoryPassword","LocalHostPassword","AccessKey","AccountPassword",IgnoreCase=$true)]
-        [string]$ServiceAccountCredentialType,
-        [Parameter(Mandatory=$false)]
-        [string]$ServiceAccountDomainName,
-        [Parameter(Mandatory=$false,Position=2)]
-        [string]$ServiceAccountName,
-        [Parameter(Mandatory=$false,Position=3)]
-        [SecureString]$ServiceAccountPassword,
         [Parameter(Mandatory=$false)]
         [string]$ServiceAccountSecretKey,
         [Parameter(Mandatory=$false)]
         [switch]$NoSshHostKeyDiscovery = $false,
         [Parameter(Mandatory=$false)]
-        [switch]$AcceptSshHostKey = $false
+        [switch]$AcceptSshHostKey = $false,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("None","Password","SshKey","DirectoryPassword","LocalHostPassword","AccessKey","AccountPassword",IgnoreCase=$true)]
+        [string]$ServiceAccountCredentialType,
+        [Parameter(Mandatory=$true,ParameterSetName="Ldap",Position=0)]
+        [string]$ServiceAccountDistinguishedName,
+        [Parameter(Mandatory=$false,ParameterSetName="Ldap")]
+        [switch]$NoSslEncryption,
+        [Parameter(Mandatory=$false,ParameterSetName="Ldap")]
+        [switch]$DoNotVerifyServerSslCertificate,
+        [Parameter(Mandatory=$false,ParameterSetName="Asset")]
+        [Parameter(Mandatory=$true,ParameterSetName="Ad",Position=0)]
+        [string]$ServiceAccountDomainName,
+        [Parameter(Mandatory=$true,ParameterSetName="Asset",Position=2)]
+        [Parameter(Mandatory=$true,ParameterSetName="Ad",Position=1)]
+        [string]$ServiceAccountName,
+        [Parameter(Mandatory=$true,ParameterSetName="Asset", Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="Ldap")]
+        [string]$NetworkAddress,
+        [Parameter(Mandatory=$false,ParameterSetName="Asset")]
+        [Parameter(Mandatory=$false,ParameterSetName="Ldap")]
+        [int]$Port,
+        [Parameter(Mandatory=$false,ParameterSetName="Asset",Position=3)]
+        [Parameter(Mandatory=$false,ParameterSetName="Ad",Position=2)]
+        [Parameter(Mandatory=$false,ParameterSetName="Ldap",Position=1)]
+        [SecureString]$ServiceAccountPassword
     )
 
     $ErrorActionPreference = "Stop"
@@ -443,22 +535,33 @@ function New-SafeguardAsset
     Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
     Import-Module -Name "$PSScriptRoot\datatypes.psm1" -Scope Local
 
-    if (-not $PSBoundParameters.ContainsKey("DisplayName"))
+    if (-not $PSCmdlet.ParameterSetName -eq "Ad")
     {
-        if (Test-IpAddress $NetworkAddress)
+        if (-not $PSBoundParameters.ContainsKey("NetworkAddress"))
         {
-            $DisplayName = (Read-Host "DisplayName")
-        }
-        else
-        {
-            $DisplayName = $NetworkAddress
+            $NetworkAddress = (Read-Host "NetworkAddress")
         }
     }
 
-    if (-not $PSBoundParameters.ContainsKey("Platform"))
+    if (-not $PSBoundParameters.ContainsKey("DisplayName"))
     {
-        $Platform = (Read-Host "Enter platform ID or search string")
+        if ($PSCmdlet.ParameterSetName -eq "Ad")
+        {
+            $DisplayName = $ServiceAccountDomainName
+        }
+        else 
+        {
+            if (Test-IpAddress $NetworkAddress)
+            {
+                $DisplayName = $NetworkAddress
+            }
+            else
+            {
+                $DisplayName = (Read-Host "DisplayName")
+            }
+        }
     }
+
     $local:PlatformId = Resolve-SafeguardPlatform -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Platform
 
     if (-not $PSBoundParameters.ContainsKey("ServiceAccountCredentialType"))
@@ -471,6 +574,8 @@ function New-SafeguardAsset
     }
 
     if ($PSBoundParameters.ContainsKey("Port")) { $local:ConnectionProperties.Port = $Port }
+    if ($PSBoundParameters.ContainsKey("ServiceAccountDomainName")) { $local:ConnectionProperties.ServiceAccountDomainName = $ServiceAccountDomainName }
+
     if ($ServiceAccountCredentialType -ne "None")
     {
         switch ($ServiceAccountCredentialType.ToLower())
@@ -478,7 +583,10 @@ function New-SafeguardAsset
             {$_ -in "password","accountpassword","accesskey"} {
                 if (-not $PSBoundParameters.ContainsKey("ServiceAccountName"))
                 {
-                    $ServiceAccountName = (Read-Host "ServiceAccountName")
+                    if (-not $PSCmdlet.ParameterSetName -eq "Ldap")
+                    {
+                        $ServiceAccountName = (Read-Host "ServiceAccountName")
+                    }
                 }
                 $local:ConnectionProperties.ServiceAccountName = $ServiceAccountName
                 if ($ServiceAccountCredentialType -eq "AccessKey")
@@ -511,6 +619,24 @@ function New-SafeguardAsset
     {
         # No Service Account -- so don't detect SSH host key
         $NoSshHostKeyDiscovery = $true
+    }
+
+    #Ldap Connection properties
+    if ($PSCmdlet.ParameterSetName -eq "Ldap")
+    {
+        $local:ConnectionProperties.UseSslEncryption = $true;
+        $local:ConnectionProperties.VerifySslCertificate = $true;
+        $local:ConnectionProperties.ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName;
+
+        if ($NoSslEncryption)
+        {
+            $local:ConnectionProperties.UseSslEncryption = $false
+            $local:ConnectionProperties.VerifySslCertificate = $false
+        }
+        if ($DoNotVerifyServerSslCertificate)
+        {
+            $local:ConnectionProperties.VerifySslCertificate = $false
+        }
     }
 
     $local:Body = @{
@@ -706,8 +832,21 @@ A string containing the service account name.
 .PARAMETER ServiceAccountPassword
 A SecureString containing the password to use for the service account.
 
+.PARAMETER ServiceAccountCredentialType
+Type of credential to use to authenticate the asset.
+
 .PARAMETER ServiceAccountSecretKey
 A string containing an API access key for the service account.
+
+.PARAMETER ServiceAccountDistinguishedName
+A string containing the LDAP distinguished name of a service account.  This is used for
+creating LDAP directories.
+
+.PARAMETER NoSslEncryption
+Do not use SSL encryption for LDAP directory.
+
+.PARAMETER DoNotVerifyServerSslCertificate
+Do not verify Server SSL certificate of LDAP directory.
 
 .PARAMETER AssetObject
 An object containing the existing asset with desired properties set.
@@ -723,6 +862,9 @@ Edit-SafeguardAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure -AssetOb
 
 .EXAMPLE
 Edit-SafeguardAsset winserver.domain.corp 31 archie
+
+.EXAMPLE
+Edit-SafeguardAsset -AssetToEdit "fooLdapAsset" -UseSslEncryption $True
 #>
 function Edit-SafeguardAsset
 {
@@ -757,6 +899,12 @@ function Edit-SafeguardAsset
         [SecureString]$ServiceAccountPassword,
         [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
         [string]$ServiceAccountSecretKey,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$ServiceAccountDistinguishedName,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [boolean]$UseSslEncryption,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [boolean]$VerifyServerSslCertificate,
         [Parameter(ParameterSetName="Object",Mandatory=$true,ValueFromPipeline=$true)]
         [object]$AssetObject
     )
@@ -789,6 +937,17 @@ function Edit-SafeguardAsset
         if ($PSBoundParameters.ContainsKey("ServiceAccountCredentialType")) { $AssetObject.ConnectionProperties.ServiceAccountCredentialType = $ServiceAccountCredentialType }
         if ($PSBoundParameters.ContainsKey("ServiceAccountDomainName")) { $AssetObject.ConnectionProperties.ServiceAccountDomainName = $ServiceAccountDomainName }
         if ($PSBoundParameters.ContainsKey("ServiceAccountName")) { $AssetObject.ConnectionProperties.ServiceAccountName = $ServiceAccountName }
+
+        #Ldap Connection properties
+        if ($PSBoundParameters.ContainsKey("ServiceAccountDistinguishedName")) { $AssetObject.ConnectionProperties.ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName }
+        if ($PSBoundParameters.ContainsKey("UseSslEncryption")) { $AssetObject.ConnectionProperties.UseSslEncryption = $UseSslEncryption }
+        if ($PSBoundParameters.ContainsKey("VerifyServerSslCertificate")) { $AssetObject.ConnectionProperties.VerifySslCertificate = $VerifyServerSslCertificate }
+        if (-not $UseSslEncryption)
+        {
+            $AssetObject.ConnectionProperties.UseSslEncryption = $false
+            $AssetObject.ConnectionProperties.VerifySslCertificate = $false
+        }
+
         if ($PSBoundParameters.ContainsKey("ServiceAccountPassword"))
         {
             $AssetObject.ConnectionProperties.ServiceAccountPassword = `
@@ -797,7 +956,7 @@ function Edit-SafeguardAsset
         if ($PSBoundParameters.ContainsKey("ServiceAccountSecretKey")) { AssetObject.ConnectionProperties.ServiceAccountSecretKey = $ServiceAccountSecretKey }
 
         # Body
-        if ($PSBoundParameters.ContainsKey("DisplayName")) { $AssetObject.DisplayName = $DisplayName }
+        if ($PSBoundParameters.ContainsKey("DisplayName")) { $AssetObject.Name = $DisplayName }
         if ($PSBoundParameters.ContainsKey("Description")) { $AssetObject.Description = $Description }
         if ($PSBoundParameters.ContainsKey("NetworkAddress")) { $AssetObject.NetworkAddress = $NetworkAddress }
         if ($PSBoundParameters.ContainsKey("Platform"))
@@ -808,6 +967,67 @@ function Edit-SafeguardAsset
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Assets/$($AssetObject.Id)" -Body $AssetObject
+}
+
+<#
+.SYNOPSIS
+synchronize an existing directory in Safeguard via the Web API.
+
+.DESCRIPTION
+synchronize an existing directory in Safeguard.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER DirectoryToSync
+An integer containing the ID of the directory to synchronize or a string containing the name.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Sync-SafeguardDirectoryAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure -1 5
+
+.EXAMPLE
+Sync-SafeguardDirectoryAsset fooPartition internal.domain.corp
+#>
+function Sync-SafeguardDirectoryAsset
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$true,Position=1)]
+        [object]$DirectoryAssetToSync
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:AssetPartitionId = (Resolve-SafeguardAssetPartitionId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetPartition)
+    $local:DirectoryAsset = Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryAssetToSync
+    
+    if(-not $local:DirectoryAsset.IsDirectory)
+    {
+        throw "Asset '$($local:DirectoryAsset.Name)' is not a directory asset"
+    }
+    Write-Host "Triggered sync for directory: $($local:DirectoryAsset.Name)"
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Assets/$local:AssetPartitionId/Synchronize?assetId=$($local:DirectoryAsset.Id)"
 }
 
 <#
@@ -988,6 +1208,9 @@ A string containing the name for the account.
 .PARAMETER Description
 A string containing the description for the account.
 
+.PARAMETER DomainName
+A string containing the domain name for the account.
+
 .INPUTS
 None.
 
@@ -1015,7 +1238,9 @@ function New-SafeguardAssetAccount
         [Parameter(Mandatory=$true,Position=1)]
         [string]$NewAccountName,
         [Parameter(Mandatory=$false)]
-        [string]$Description
+        [string]$Description,
+        [Parameter(Mandatory=$false)]
+        [string]$DomainName
     )
 
     $ErrorActionPreference = "Stop"
@@ -1029,6 +1254,7 @@ function New-SafeguardAssetAccount
     }
 
     if ($PSBoundParameters.ContainsKey("Description")) { $local:Body.Description = $Description }
+    if ($PSBoundParameters.ContainsKey("DomainName")) { $local:Body.DomainName = $DomainName }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "AssetAccounts" -Body $local:Body
 }
@@ -1060,6 +1286,9 @@ An integer containing the ID of the account to edit or a string containing the n
 
 .PARAMETER Description
 A string containing the description for the account.
+
+.PARAMETER DomainName
+A string containing the domain name for the account.
 
 .PARAMETER AccountObject
 An object containing the existing asset account with desired properties set.
@@ -1095,6 +1324,8 @@ function Edit-SafeguardAssetAccount
         [object]$AccountToEdit,
         [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
         [string]$Description,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$DomainName,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
         [object]$AccountObject
     )
@@ -1122,9 +1353,10 @@ function Edit-SafeguardAssetAccount
 
     if (-not ($PsCmdlet.ParameterSetName -eq "Object"))
     {
-        $AccountObject = (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $local:AccountId)
+        $AccountObject = (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $local:AccountId)
 
         if ($PSBoundParameters.ContainsKey("Description")) { $AccountObject.Description = $Description }
+        if ($PSBoundParameters.ContainsKey("DomainName")) { $AccountObject.DomainName = $DomainName }
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "AssetAccounts/$($AccountObject.Id)" -Body $AccountObject

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -713,17 +713,13 @@ function Test-SafeguardAsset
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
+        [Parameter(Mandatory=$true,Position=0)]
         [object]$AssetToTest
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if (-not $PSBoundParameters.ContainsKey("AssetToTest"))
-    {
-        $AssetToTest = (Read-Host "AssetToTest")
-    }
     $local:AssetId = Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToTest
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
@@ -772,17 +768,12 @@ function Remove-SafeguardAsset
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
+        [Parameter(Mandatory=$true,Position=0)]
         [object]$AssetToDelete
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-
-    if (-not $PSBoundParameters.ContainsKey("AssetToDelete"))
-    {
-        $AssetToDelete = (Read-Host "AssetToDelete")
-    }
 
     $local:AssetId = Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToDelete
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "Assets/$($local:AssetId)"
@@ -1240,7 +1231,9 @@ function New-SafeguardAssetAccount
         [Parameter(Mandatory=$false)]
         [string]$Description,
         [Parameter(Mandatory=$false)]
-        [string]$DomainName
+        [string]$DomainName,
+        [Parameter(Mandatory=$false)]
+        [string]$DistinguishedName
     )
 
     $ErrorActionPreference = "Stop"
@@ -1255,6 +1248,7 @@ function New-SafeguardAssetAccount
 
     if ($PSBoundParameters.ContainsKey("Description")) { $local:Body.Description = $Description }
     if ($PSBoundParameters.ContainsKey("DomainName")) { $local:Body.DomainName = $DomainName }
+    if ($PSBoundParameters.ContainsKey("DistinguishedName")) { $local:Body.DistinguishedName = $DistinguishedName }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "AssetAccounts" -Body $local:Body
 }

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -1017,7 +1017,7 @@ function Sync-SafeguardDirectoryAsset
     {
         throw "Asset '$($local:DirectoryAsset.Name)' is not a directory asset"
     }
-    Write-Host "Triggered sync for directory: $($local:DirectoryAsset.Name)"
+    Write-Host "Triggering sync for directory: $($local:DirectoryAsset.Name)"
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Assets/$local:AssetPartitionId/Synchronize?assetId=$($local:DirectoryAsset.Id)"
 }
 

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -279,7 +279,7 @@ function Find-SafeguardPlatform
         try
         {
             $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
-                                    -Parameters @{ filter = "DisplayName icontains '$SearchString' or Name icontains '$SearchString'" })
+                                    -Parameters @{ filter = "DisplayName icontains '$SearchString' or Name icontains '$SearchString'" } -RetryVersion 2 -RetryUrl "Platforms")
         }
         catch
         {
@@ -290,14 +290,14 @@ function Find-SafeguardPlatform
         {
             Write-Verbose "No results yet, trying with q parameter"
             $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
-                                    -Parameters @{ q = $SearchString })
+                                    -Parameters @{ q = $SearchString } -RetryVersion 2 -RetryUrl "Platforms")
         }
         $local:Platforms
     }
     else
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
-            -Parameters @{ filter = $QueryFilter }
+            -Parameters @{ filter = $QueryFilter } -RetryVersion 2 -RetryUrl "Platforms"
     }
 }
 

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -375,12 +375,12 @@ function New-SafeguardDirectory
         {
             if ($PSCmdlet.ParameterSetName -eq "Ldap")
             {
-                $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP")[0].Id
+                $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure)[0].Id
                 New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DisplayName $NetworkAddress -Platform $local:LdapPlatformId -ServiceAccountDistinguishedName $ServiceAccountDistinguishedName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description -NetworkAddress $NetworkAddress -Port $Port -NoSslEncryption:$NoSslEncryption -DoNotVerifyServerSslCertificate:$DoNotVerifyServerSslCertificate
             }
             else
             {
-                $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+                $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure)[0].Id
                 New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DisplayName $ServiceAccountDomainName -Platform $local:AdPlatformId -ServiceAccountName $ServiceAccountName -ServiceAccountDomainName $ServiceAccountDomainName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description
             }
         }

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -210,6 +210,10 @@ function Get-SafeguardDirectory
                 (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
             }
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -384,6 +388,10 @@ function New-SafeguardDirectory
                 New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DisplayName $ServiceAccountDomainName -Platform $local:AdPlatformId -ServiceAccountName $ServiceAccountName -ServiceAccountDomainName $ServiceAccountDomainName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description
             }
         }
+        else
+        {
+            throw
+        }
     }
     
 }
@@ -450,6 +458,10 @@ function Test-SafeguardDirectory
         {
             Test-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToTest $DirectoryToTest        
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -512,6 +524,10 @@ function Remove-SafeguardDirectory
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
             Remove-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToDelete $DirectoryToDelete
+        }
+        else
+        {
+            throw
         }
     }
 }
@@ -676,6 +692,10 @@ function Edit-SafeguardDirectory
         {
             Edit-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetObject $DirectoryObject
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -741,6 +761,10 @@ function Sync-SafeguardDirectory
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
             Sync-SafeguardDirectoryAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetPartition $AssetPartition -DirectoryAssetToSync $DirectoryToSync
+        }
+        else
+        {
+            throw
         }
     }
 }
@@ -858,6 +882,10 @@ function Get-SafeguardDirectoryAccount
                 }
             }
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -943,6 +971,10 @@ function Find-SafeguardDirectoryAccount
             {
                 (Find-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -QueryFilter $QueryFilter) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
             }
+        }
+        else
+        {
+            throw
         }
     }
 }
@@ -1059,6 +1091,10 @@ function New-SafeguardDirectoryAccount
         {
             New-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ParentAsset $ParentDirectory -NewAccountName $NewAccountName -DomainName $DomainName -DistinguishedName $DistinguishedName -Description $Description
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -1127,6 +1163,10 @@ function Edit-SafeguardDirectoryAccount
         {
             $AccountObject = Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $AccountObject.Id
             Edit-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountObject $AccountObject
+        }
+        else
+        {
+            throw
         }
     }
 }
@@ -1225,6 +1265,10 @@ function Set-SafeguardDirectoryAccountPassword
                 Set-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -NewPassword $NewPassword -AccountToSet $AccountToSet
             }
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -1309,6 +1353,10 @@ function New-SafeguardDirectoryAccountRandomPassword
                 New-SafeguardAssetAccountRandomPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
             }
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -1391,6 +1439,10 @@ function Test-SafeguardDirectoryAccountPassword
             {
                 Test-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
             }
+        }
+        else
+        {
+            throw
         }
     }
 }
@@ -1475,6 +1527,10 @@ function Invoke-SafeguardDirectoryAccountPasswordChange
                 Invoke-SafeguardAssetAccountPasswordChange -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
             }
         }
+        else
+        {
+            throw
+        }
     }
 }
 
@@ -1557,6 +1613,10 @@ function Remove-SafeguardDirectoryAccount
             {
                 Remove-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToDelete $AccountToDelete
             }
+        }
+        else
+        {
+            throw
         }
     }
 }

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -21,16 +21,16 @@ function Resolve-SafeguardDirectoryId
         try
         {
             $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories `
-                                      -Parameters @{ filter = "Name ieq '$Directory'" })
+                                      -Parameters @{ filter = "Name ieq '$Directory'" } -Version 2)
             if (-not $local:Directories)
             {
                 $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories `
-                                          -Parameters @{ filter = "NetworkAddress ieq '$Directory'" })
+                                          -Parameters @{ filter = "NetworkAddress ieq '$Directory'" } -Version 2)
             }
             if (-not $local:Directories)
             {
                 $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories `
-                                          -Parameters @{ filter = "Domains.DomainName ieq '$Directory'" })
+                                          -Parameters @{ filter = "Domains.DomainName ieq '$Directory'" } -Version 2)
             }
         }
         catch
@@ -38,7 +38,7 @@ function Resolve-SafeguardDirectoryId
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
             $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories `
-                                      -Parameters @{ q = $Directory })
+                                      -Parameters @{ q = $Directory } $DirectoryId)
         }
         if (-not $local:Directories)
         {
@@ -72,7 +72,7 @@ function Get-SafeguardDirectoryDomains
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories/1).Domains
+    (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories/$DirectoryId -Version 2).Domains
 }
 function Resolve-SafeguardDirectoryAccountId
 {
@@ -106,14 +106,14 @@ function Resolve-SafeguardDirectoryAccountId
         try
         {
             $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                   -Parameters @{ filter = "Name ieq '$Account'" })
+                                   -Parameters @{ filter = "Name ieq '$Account'" } -Version 2)
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
             $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                   -Parameters @{ q = $Account })
+                                   -Parameters @{ q = $Account } -Version 2)
         }
         if (-not $local:Accounts)
         {
@@ -182,14 +182,34 @@ function Get-SafeguardDirectory
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
+    try 
     {
-        $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToGet
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Directories/$($local:DirectoryId)"
+        if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
+        {
+            $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToGet
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Directories/$($local:DirectoryId)" -Version 2
+        }
+        else
+        {
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories -Version 2
+        }
     }
-    else
+    catch 
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
+            {
+                Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToGet
+            }
+            else
+            {
+                $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+                $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+
+                (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+            }
+        }
     }
 }
 
@@ -272,10 +292,10 @@ function New-SafeguardDirectory
         [string]$ServiceAccountName,
         [Parameter(Mandatory=$true,ParameterSetName="Ldap",Position=0)]
         [string]$ServiceAccountDistinguishedName,
-        [Parameter(Mandatory=$false,ParameterSetName="Ad",Position=2)]
-        [Parameter(Mandatory=$false,ParameterSetName="Ldap",Position=1)]
+        [Parameter(Mandatory=$true,ParameterSetName="Ad",Position=2)]
+        [Parameter(Mandatory=$true,ParameterSetName="Ldap",Position=1)]
         [SecureString]$ServiceAccountPassword,
-        [Parameter(Mandatory=$false,ParameterSetName="Ldap")]
+        [Parameter(Mandatory=$true,ParameterSetName="Ldap")]
         [string]$NetworkAddress,
         [Parameter(Mandatory=$false,ParameterSetName="Ldap")]
         [int]$Port,
@@ -291,61 +311,81 @@ function New-SafeguardDirectory
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
     Import-Module -Name "$PSScriptRoot\datatypes.psm1" -Scope Local
 
-    if (-not $PSBoundParameters.ContainsKey("ServiceAccountPassword"))
+    try 
     {
-        $ServiceAccountPassword = (Read-Host -AsSecureString "ServiceAccountPassword")
-    }
-
-    if ($PSCmdlet.ParameterSetName -eq "Ldap")
-    {
-        $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
-        $local:Body = @{
-            PlatformId = $local:LdapPlatformId;
-            ConnectionProperties = @{
-                UseSslEncryption = $true;
-                VerifySslCertificate = $true;
-                ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName;
-                ServiceAccountPassword = `
-                    [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+        if (-not $PSBoundParameters.ContainsKey("ServiceAccountPassword"))
+        {
+            $ServiceAccountPassword = (Read-Host -AsSecureString "ServiceAccountPassword")
+        }
+    
+        if ($PSCmdlet.ParameterSetName -eq "Ldap")
+        {
+            $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+            $local:Body = @{
+                PlatformId = $local:LdapPlatformId;
+                ConnectionProperties = @{
+                    UseSslEncryption = $true;
+                    VerifySslCertificate = $true;
+                    ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName;
+                    ServiceAccountPassword = `
+                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                }
+            }
+            if ($PSBoundParameters.ContainsKey("NetworkAddress"))
+            {
+                $local:Body.ConnectionProperties.NetworkAddress = $NetworkAddress
+            }
+            if ($PSBoundParameters.ContainsKey("Port"))
+            {
+                $local:Body.ConnectionProperties.Port = $Port
+            }
+            if ($NoSslEncryption)
+            {
+                $local:Body.ConnectionProperties.UseSslEncryption = $false
+                $local:Body.ConnectionProperties.VerifySslCertificate = $false
+            }
+            if ($DoNotVerifyServerSslCertificate)
+            {
+                $local:Body.ConnectionProperties.VerifySslCertificate = $false
             }
         }
-        if ($PSBoundParameters.ContainsKey("NetworkAddress"))
+        else
         {
-            $local:Body.ConnectionProperties.NetworkAddress = $NetworkAddress
+            $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+            $local:Body = @{
+                PlatformId = $local:AdPlatformId;
+                ConnectionProperties = @{
+                    ServiceAccountDomainName = $ServiceAccountDomainName;
+                    ServiceAccountName = $ServiceAccountName;
+                    ServiceAccountPassword = `
+                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                }
+            }
         }
-        if ($PSBoundParameters.ContainsKey("Port"))
+        if ($PSBoundParameters.ContainsKey("Description"))
         {
-            $local:Body.ConnectionProperties.Port = $Port
+            $local:Body.Description = $Description
         }
-        if ($NoSslEncryption)
-        {
-            $local:Body.ConnectionProperties.UseSslEncryption = $false
-            $local:Body.ConnectionProperties.VerifySslCertificate = $false
-        }
-        if ($DoNotVerifyServerSslCertificate)
-        {
-            $local:Body.ConnectionProperties.VerifySslCertificate = $false
-        }
+    
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST Directories -Body $local:Body -Version 2
     }
-    else
+    catch 
     {
-        $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
-        $local:Body = @{
-            PlatformId = $local:AdPlatformId;
-            ConnectionProperties = @{
-                ServiceAccountDomainName = $ServiceAccountDomainName;
-                ServiceAccountName = $ServiceAccountName;
-                ServiceAccountPassword = `
-                    [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSCmdlet.ParameterSetName -eq "Ldap")
+            {
+                $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP")[0].Id
+                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Platform $local:LdapPlatformId -ServiceAccountDistinguishedName $ServiceAccountDistinguishedName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description -NetworkAddress $NetworkAddress -Port $Port -NoSslEncryption:$NoSslEncryption -DoNotVerifyServerSslCertificate:$DoNotVerifyServerSslCertificate
+            }
+            else
+            {
+                $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Platform $local:AdPlatformId -ServiceAccountName $ServiceAccountName -ServiceAccountDomainName $ServiceAccountDomainName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description
             }
         }
     }
-    if ($PSBoundParameters.ContainsKey("Description"))
-    {
-        $local:Body.Description = $Description
-    }
-
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST Directories -Body $local:Body
+    
 }
 
 <#
@@ -391,21 +431,26 @@ function Test-SafeguardDirectory
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
+        [Parameter(Mandatory=$true,Position=0)]
         [object]$DirectoryToTest
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if (-not $PSBoundParameters.ContainsKey("DirectoryToTest"))
+    try 
     {
-        $DirectoryToTest = (Read-Host "DirectoryToTest")
+        $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToTest
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            POST "Directories/$($local:DirectoryId)/TestConnection" -LongRunningTask -Version 2
     }
-    $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToTest
-
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-        POST "Directories/$($local:DirectoryId)/TestConnection" -LongRunningTask
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            Test-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToTest $DirectoryToTest        
+        }
+    }
 }
 
 <#
@@ -457,13 +502,18 @@ function Remove-SafeguardDirectory
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if (-not $PSBoundParameters.ContainsKey("DirectoryToDelete"))
+    try 
     {
-        $DirectoryToDelete = (Read-Host "DirectoryToDelete")
+        $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToDelete
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "Directories/$($local:DirectoryId)" -Version 2
     }
-
-    $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToDelete
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "Directories/$($local:DirectoryId)"
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            Remove-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToDelete $DirectoryToDelete
+        }
+    }
 }
 
 <#
@@ -544,7 +594,7 @@ function Edit-SafeguardDirectory
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(ParameterSetName="Attributes",Mandatory=$false,Position=0)]
+        [Parameter(ParameterSetName="Attributes",Mandatory=$true,Position=0)]
         [object]$DirectoryToEdit,
         [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
         [string]$ServiceAccountDomainName,
@@ -616,16 +666,25 @@ function Edit-SafeguardDirectory
         if ($PSBoundParameters.ContainsKey("NetworkAddress")) { $DirectoryObject.NetworkAddress = $NetworkAddress }
     }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Directories/$($DirectoryObject.Id)" -Body $DirectoryObject
+    try 
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Directories/$($DirectoryObject.Id)" -Body $DirectoryObject -Version 2
+    }
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            Edit-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetObject $DirectoryObject
+        }
+    }
 }
 
 <#
 .SYNOPSIS
-Remove a directory from Safeguard via the Web API.
+synchronize an existing directory in Safeguard via the Web API.
 
 .DESCRIPTION
-Remove a directory from Safeguard. Make sure it is not in use before
-you remove it.
+synchronize an existing directory in Safeguard.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -661,21 +720,29 @@ function Sync-SafeguardDirectory
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
-        [object]$DirectoryToSync
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$DirectoryToSync,
+        [Parameter(Mandatory=$false,Position=1)]
+        [object]$AssetPartition = -1
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if (-not $PSBoundParameters.ContainsKey("DirectoryToSync"))
+    try 
     {
-        $DirectoryToSync = (Read-Host "DirectoryToSync")
+        $local:Directory = Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSync
+        Write-Host "Triggering sync for directory: $($local:Directory.Name)"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Directories/$($local:Directory.Id)/Synchronize" -Version 2
     }
-
-    $local:Directory = Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSync
-    Write-Host "Triggered sync for directory: $($local:Directory.Name)"
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Directories/$($local:Directory.Id)/Synchronize"
+    catch 
+    {
+        Write-Host "Exception while triggering sync for directory: $($local:Directory.Name). Retrying..."
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            Sync-SafeguardDirectoryAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetPartition $AssetPartition -DirectoryAssetToSync $DirectoryToSync
+        }
+    }
 }
 
 <#
@@ -733,29 +800,63 @@ function Get-SafeguardDirectoryAccount
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
+    try 
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToGet)
-        if ($PSBoundParameters.ContainsKey("$AccountToGet"))
+        if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
         {
-            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToGet)
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts/$($local:AccountId)"
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToGet)
+            if ($PSBoundParameters.ContainsKey("AccountToGet"))
+            {
+                $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToGet)
+                Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts/$($local:AccountId)" -Version 2
+            }
+            else
+            {
+                Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Directories/$($local:DirectoryId)/Accounts" -Version 2
+            }
         }
         else
         {
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Directories/$($local:DirectoryId)/Accounts"
+            if ($PSBoundParameters.ContainsKey("AccountToGet"))
+            {
+                $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToGet)
+                Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts/$($local:AccountId)" -Version 2
+            }
+            else
+            {
+                $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+                $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+
+                (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" -Version 2) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+            }
         }
     }
-    else
+    catch 
     {
-        if ($PSBoundParameters.ContainsKey("AccountToGet"))
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
-            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToGet)
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts/$($local:AccountId)"
-        }
-        else
-        {
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts"
+            if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
+            {
+                if ($PSBoundParameters.ContainsKey("AccountToGet"))
+                {
+                    Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $DirectoryToGet -AccountToGet $AccountToGet
+                }
+                else
+                {
+                    Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $DirectoryToGet
+                }
+            }
+            else
+            {
+                if ($PSBoundParameters.ContainsKey("AccountToGet"))
+                {
+                    Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $AccountToGet
+                }
+                else
+                {
+                    (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+                }
+            }
         }
     }
 }
@@ -817,15 +918,32 @@ function Find-SafeguardDirectoryAccount
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSCmdlet.ParameterSetName -eq "Search")
+    try 
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
-            -Parameters @{ q = $SearchString }
+        if ($PSCmdlet.ParameterSetName -eq "Search")
+        {
+            (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
+                -Parameters @{ q = $SearchString } -Version 2) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+        }
+        else
+        {
+            (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
+                -Parameters @{ filter = $QueryFilter } -Version 2) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+        }
     }
-    else
+    catch 
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DirectoryAccounts" `
-            -Parameters @{ filter = $QueryFilter }
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSCmdlet.ParameterSetName -eq "Search")
+            {
+                (Find-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -SearchString $SearchString) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+            }
+            else
+            {
+                (Find-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -QueryFilter $QueryFilter) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
+            }
+        }
     }
 }
 
@@ -885,49 +1003,63 @@ function New-SafeguardDirectoryAccount
         [object]$ParentDirectory,
         [Parameter(Mandatory=$true,Position=1)]
         [string]$NewAccountName,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$true)]
         [string]$DomainName,
         [Parameter(Mandatory=$false)]
-        [string]$DistinguishedName
+        [string]$DistinguishedName,
+        [Parameter(Mandatory=$false)]
+        [string]$Description
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Directory = (Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $ParentDirectory)
+    try 
+    {
+        $local:Directory = (Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $ParentDirectory)
 
-    $local:Body = @{
-        "Name" = $NewAccountName;
-        "DirectoryProperties" = @{
-            "DirectoryId" = $local:Directory.Id;
+        $local:Body = @{
+            "Name" = $NewAccountName;
+            "DirectoryProperties" = @{
+                "DirectoryId" = $local:Directory.Id;
+            }
         }
-    }
-
-    if ($PSBoundParameters.ContainsKey("DomainName"))
-    {
-        $local:Body.DirectoryProperties.DomainName = $DomainName
-    }
-    elseif ($PSBoundParameters.ContainsKey("DistinguishedName"))
-    {
-        $local:Body.DirectoryProperties.DistinguishedName = $DistinguishedName
-    }
-    else
-    {
-        if ($ParentDirectory -as [string])
+    
+        if ($PSBoundParameters.ContainsKey("DomainName"))
         {
-            $local:MatchedDomain = ($local:Directory.Domains | Where-Object { $_.DomainName -ieq ([string]$ParentDirectory) })
+            $local:Body.DirectoryProperties.DomainName = $DomainName
         }
-        if ($local:MatchedDomain)
+        elseif ($PSBoundParameters.ContainsKey("DistinguishedName"))
         {
-            $local:Body.DirectoryProperties.DomainName = $local:MatchedDomain.DomainName
+            $local:Body.DirectoryProperties.DistinguishedName = $DistinguishedName
         }
         else
         {
-            $local:Body.DirectoryProperties.DomainName = $local:Directory.Domains[0].DomainName
+            if ($ParentDirectory -as [string])
+            {
+                $local:MatchedDomain = ($local:Directory.Domains | Where-Object { $_.DomainName -ieq ([string]$ParentDirectory) })
+            }
+            if ($local:MatchedDomain)
+            {
+                $local:Body.DirectoryProperties.DomainName = $local:MatchedDomain.DomainName
+                $DomainName = $local:MatchedDomain.DomainName
+            }
+            else
+            {
+                $local:Body.DirectoryProperties.DomainName = $local:Directory.Domains[0].DomainName
+                $DomainName = $local:Directory.Domains[0].DomainName
+            }
+        }
+    
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts" -Body $local:Body -Version 2
+    }
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            New-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ParentAsset $ParentDirectory -NewAccountName $NewAccountName -DomainName $DomainName -DistinguishedName $DistinguishedName -Description $Description
         }
     }
-
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts" -Body $local:Body
 }
 
 <#
@@ -985,8 +1117,18 @@ function Edit-SafeguardDirectoryAccount
     {
         throw "AccountObject must not be null"
     }
-
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($AccountObject.Id)" -Body $AccountObject
+    try 
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($AccountObject.Id)" -Body $AccountObject -Version 2
+    }
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            $AccountObject = Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $AccountObject.Id
+            Edit-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountObject $AccountObject
+        }
+    }
 }
 
 <#
@@ -1049,22 +1191,41 @@ function Set-SafeguardDirectoryAccountPassword
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToSet"))
-    {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSet)
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToSet)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToSet)
-    }
     if (-not $NewPassword)
     {
         $NewPassword = (Read-Host -AsSecureString "NewPassword")
     }
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($NewPassword))
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($local:AccountId)/Password" `
-        -Body $local:PasswordPlainText
+
+    try 
+    {
+        if ($PSBoundParameters.ContainsKey("DirectoryToSet"))
+        {
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSet)
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToSet)
+        }
+        else
+        {
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToSet)
+        }
+
+        $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($NewPassword))
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($local:AccountId)/Password" `
+            -Body $local:PasswordPlainText -Version 2
+    }
+    catch 
+    {
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToSet"))
+            {
+                Set-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -NewPassword $NewPassword -AssetToSet $DirectoryToSet -AccountToSet $AccountToSet
+            }
+            else
+            {
+                Set-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -NewPassword $NewPassword -AccountToSet $AccountToSet
+            }
+        }
+    }
 }
 
 <#
@@ -1122,16 +1283,33 @@ function New-SafeguardDirectoryAccountRandomPassword
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+    try 
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+        {
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        }
+        else
+        {
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/GeneratePassword" -Version 2
     }
-    else
+    catch 
     {
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+            {
+                New-SafeguardAssetAccountRandomPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToUse $DirectoryToUse -AccountToUse $AccountToUse
+            }
+            else
+            {
+                New-SafeguardAssetAccountRandomPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
+            }
+        }
     }
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/GeneratePassword"
 }
 
 <#
@@ -1188,16 +1366,33 @@ function Test-SafeguardDirectoryAccountPassword
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+    try 
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+        {
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        }
+        else
+        {
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/CheckPassword" -LongRunningTask -Version 2
     }
-    else
+    catch 
     {
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+            {
+                Test-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToUse $DirectoryToUse -AccountToUse $AccountToUse
+            }
+            else
+            {
+                Test-SafeguardAssetAccountPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
+            }
+        }
     }
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/CheckPassword" -LongRunningTask
 }
 
 <#
@@ -1254,16 +1449,33 @@ function Invoke-SafeguardDirectoryAccountPasswordChange
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+    try 
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+        {
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToUse)
+        }
+        else
+        {
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/ChangePassword" -LongRunningTask -Version 2
     }
-    else
+    catch 
     {
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+            {
+                Invoke-SafeguardAssetAccountPasswordChange -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToUse $DirectoryToUse -AccountToUse $AccountToUse
+            }
+            else
+            {
+                Invoke-SafeguardAssetAccountPasswordChange -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToUse $AccountToUse
+            }
+        }
     }
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/ChangePassword" -LongRunningTask
 }
 
 <#
@@ -1320,14 +1532,31 @@ function Remove-SafeguardDirectoryAccount
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+    try 
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToDelete)
+        if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+        {
+            $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToUse)
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryId $local:DirectoryId $AccountToDelete)
+        }
+        else
+        {
+            $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToDelete)
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "DirectoryAccounts/$($local:AccountId)" -Version 2
     }
-    else
+    catch 
     {
-        $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToDelete)
+        if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
+        {
+            if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
+            {
+                Remove-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToUse $DirectoryToUse -AccountToDelete $AccountToDelete
+            }
+            else
+            {
+                Remove-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToDelete $AccountToDelete
+            }
+        }
     }
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "DirectoryAccounts/$($local:AccountId)"
 }

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -376,12 +376,12 @@ function New-SafeguardDirectory
             if ($PSCmdlet.ParameterSetName -eq "Ldap")
             {
                 $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP")[0].Id
-                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Platform $local:LdapPlatformId -ServiceAccountDistinguishedName $ServiceAccountDistinguishedName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description -NetworkAddress $NetworkAddress -Port $Port -NoSslEncryption:$NoSslEncryption -DoNotVerifyServerSslCertificate:$DoNotVerifyServerSslCertificate
+                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DisplayName $NetworkAddress -Platform $local:LdapPlatformId -ServiceAccountDistinguishedName $ServiceAccountDistinguishedName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description -NetworkAddress $NetworkAddress -Port $Port -NoSslEncryption:$NoSslEncryption -DoNotVerifyServerSslCertificate:$DoNotVerifyServerSslCertificate
             }
             else
             {
                 $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
-                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Platform $local:AdPlatformId -ServiceAccountName $ServiceAccountName -ServiceAccountDomainName $ServiceAccountDomainName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description
+                New-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DisplayName $ServiceAccountDomainName -Platform $local:AdPlatformId -ServiceAccountName $ServiceAccountName -ServiceAccountDomainName $ServiceAccountDomainName -ServiceAccountPassword $ServiceAccountPassword -ServiceAccountCredentialType "password" -Description $Description
             }
         }
     }

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -38,7 +38,7 @@ function Resolve-SafeguardDirectoryId
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
             $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Directories `
-                                      -Parameters @{ q = $Directory } $DirectoryId)
+                                      -Parameters @{ q = $Directory } -Version 2)
         }
         if (-not $local:Directories)
         {
@@ -292,8 +292,8 @@ function New-SafeguardDirectory
         [string]$ServiceAccountName,
         [Parameter(Mandatory=$true,ParameterSetName="Ldap",Position=0)]
         [string]$ServiceAccountDistinguishedName,
-        [Parameter(Mandatory=$true,ParameterSetName="Ad",Position=2)]
-        [Parameter(Mandatory=$true,ParameterSetName="Ldap",Position=1)]
+        [Parameter(Mandatory=$false,ParameterSetName="Ad",Position=2)]
+        [Parameter(Mandatory=$false,ParameterSetName="Ldap",Position=1)]
         [SecureString]$ServiceAccountPassword,
         [Parameter(Mandatory=$true,ParameterSetName="Ldap")]
         [string]$NetworkAddress,
@@ -1003,7 +1003,7 @@ function New-SafeguardDirectoryAccount
         [object]$ParentDirectory,
         [Parameter(Mandatory=$true,Position=1)]
         [string]$NewAccountName,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [string]$DomainName,
         [Parameter(Mandatory=$false)]
         [string]$DistinguishedName,

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -317,7 +317,7 @@ function New-SafeguardUserGroup
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
+    Import-Module -Name "$PSScriptRoot\assets.psm1" -Scope Local
 
     $local:Body = @{ Name = $Name }
     if ($PSCmdlet.ParameterSetName -eq "Local")
@@ -326,13 +326,14 @@ function New-SafeguardUserGroup
     }
     else
     {
-        $local:DirectoryId = (Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Directory)
+        $local:DirectoryId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Directory)
         if (-not $PSBoundParameters.ContainsKey("DomainName"))
         {
-            $local:Domains = (Get-SafeguardDirectoryDomains -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryId)
+            $local:Domains = (Get-SafeguardDirectoryAssetDomains -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -DirectoryAssetId $DirectoryId)
+            
             if (-not ($local:Domains -is [array]))
             {
-                $DomainName = $local:Domains[0].DomainName
+                $DomainName = $local:Domains.DomainName
             }
             else
             {

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -201,6 +201,57 @@ function Get-SafeguardVersion
 
 <#
 .SYNOPSIS
+Test whether the version of a Safeguard appliance is greater than
+or equal to a minimum version via the Web API.
+
+.DESCRIPTION
+Get the version information from a Safeguard appliance and compare
+whether it is greater than or equal to a minimum version provided
+as a string in x.y format.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate
+
+.PARAMETER MinVersion
+A string containing the desired minimum major and minor version in x.y format.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Test-SafeguardVersion 2.3
+
+.EXAMPLE
+Test-SafeguardVersion -Appliance 10.5.32.54 -Insecure 2.6
+#>
+function Test-SafeguardVersion
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidatePattern("^\d+\.\d+$")]
+        [string]$MinVersion
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+    Test-SafeguardMinVersionInternal -Appliance $Appliance -Insecure:$Insecure -MinVersion $MinVersion
+}
+
+<#
+.SYNOPSIS
 Get the system verification information on a Safeguard appliance via the Web API.
 
 .DESCRIPTION

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -123,7 +123,7 @@ FunctionsToExport = @(
     'Install-SafeguardDesktopClient',
     # maintenance.psm1
     'Get-SafeguardStatus','Get-SafeguardApplianceAvailability','Get-SafeguardApplianceState',
-    'Get-SafeguardVersion','Get-SafeguardApplianceVerification','Get-SafeguardTime',
+    'Get-SafeguardVersion','Test-SafeguardVersion','Get-SafeguardApplianceVerification','Get-SafeguardTime',
     'Get-SafeguardApplianceUptime','Get-SafeguardHealth','Get-SafeguardApplianceName','Set-SafeguardApplianceName',
     'Invoke-SafeguardApplianceShutdown','Invoke-SafeguardApplianceReboot','Invoke-SafeguardApplianceFactoryReset',
     'Get-SafeguardSupportBundle','Get-SafeguardPatch','Clear-SafeguardPatch','Install-SafeguardPatch',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -81,6 +81,7 @@ NestedModules = @(
     'requests.psm1',
     'users.psm1',
     'assets.psm1',
+    'directories.psm1',
     'groups.psm1',
     'policies.psm1',
     'managementShell.psm1',
@@ -157,6 +158,13 @@ FunctionsToExport = @(
     'Set-SafeguardAssetAccountPassword','New-SafeguardAssetAccountRandomPassword',
     'Test-SafeguardAssetAccountPassword','Invoke-SafeguardAssetAccountPasswordChange',
     'Remove-SafeguardAssetAccount','Invoke-SafeguardAssetSshHostKeyDiscovery',
+    # directories.psm1
+    'Get-SafeguardDirectory','New-SafeguardDirectory','Test-SafeguardDirectory',
+    'Remove-SafeguardDirectory','Edit-SafeguardDirectory','Sync-SafeguardDirectory',
+    'Get-SafeguardDirectoryAccount','Find-SafeguardDirectoryAccount','New-SafeguardDirectoryAccount',
+    'Set-SafeguardDirectoryAccountPassword','New-SafeguardDirectoryAccountRandomPassword',
+    'Test-SafeguardDirectoryAccountPassword','Invoke-SafeguardDirectoryAccountPasswordChange',
+    'Edit-SafeguardDirectoryAccount','Remove-SafeguardDirectoryAccount',
     # groups.psm1
     'Get-SafeguardUserGroup','New-SafeguardUserGroup','Remove-SafeguardUserGroup',
     'Edit-SafeguardUserGroup',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -81,7 +81,6 @@ NestedModules = @(
     'requests.psm1',
     'users.psm1',
     'assets.psm1',
-    'directories.psm1',
     'groups.psm1',
     'policies.psm1',
     'managementShell.psm1',
@@ -153,18 +152,11 @@ FunctionsToExport = @(
     'Edit-SafeguardUser','Enable-SafeguardUser','Disable-SafeguardUser','Rename-SafeguardUser',
     # assets.psm1
     'Get-SafeguardAsset','Find-SafeguardAsset','New-SafeguardAsset','Test-SafeguardAsset',
-    'Remove-SafeguardAsset','Edit-SafeguardAsset',
+    'Remove-SafeguardAsset','Edit-SafeguardAsset', 'Sync-SafeguardDirectoryAsset'
     'Get-SafeguardAssetAccount','Find-SafeguardAssetAccount','New-SafeguardAssetAccount','Edit-SafeguardAssetAccount',
     'Set-SafeguardAssetAccountPassword','New-SafeguardAssetAccountRandomPassword',
     'Test-SafeguardAssetAccountPassword','Invoke-SafeguardAssetAccountPasswordChange',
     'Remove-SafeguardAssetAccount','Invoke-SafeguardAssetSshHostKeyDiscovery',
-    # directories.psm1
-    'Get-SafeguardDirectory','New-SafeguardDirectory','Test-SafeguardDirectory',
-    'Remove-SafeguardDirectory','Edit-SafeguardDirectory','Sync-SafeguardDirectory',
-    'Get-SafeguardDirectoryAccount','Find-SafeguardDirectoryAccount','New-SafeguardDirectoryAccount',
-    'Set-SafeguardDirectoryAccountPassword','New-SafeguardDirectoryAccountRandomPassword',
-    'Test-SafeguardDirectoryAccountPassword','Invoke-SafeguardDirectoryAccountPasswordChange',
-    'Edit-SafeguardDirectoryAccount','Remove-SafeguardDirectoryAccount',
     # groups.psm1
     'Get-SafeguardUserGroup','New-SafeguardUserGroup','Remove-SafeguardUserGroup',
     'Edit-SafeguardUserGroup',

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1244,8 +1244,10 @@ function Invoke-SafeguardMethod
     }
     catch
     {
-        if ($_.Exception.HttpStatusCode -eq 404 -and $RetryUrl)
+        if ($_.Exception -and ($_.Exception.HttpStatusCode -eq 404 -and ($RetryUrl -or ($RetryVersion -ne $Version))))
         {
+            if (-not $RetryVersion) { $RetryVersion = $Version}
+            if (-not $RetryUrl) { $RetryUrl = $RelativeUrl}
             Write-Verbose "Trying to use RetryVersion: $RetryVersion, and RetryUrl: $RetryUrl"
             Invoke-Internal $Appliance $Service $Method $RetryVersion $RetryUrl $local:Headers `
                             -Body $Body -JsonBody $JsonBody `
@@ -1253,6 +1255,9 @@ function Invoke-SafeguardMethod
         }
         else
         {
+            Write-Verbose "NOT FOUND: YOU MAY BE USING AN OLDER VERSION OF SAFEGUARD API:"
+            Write-Verbose "    TRY CONNECTING WITH THE Version PARAMETER SET TO $($Version - 1), OR"
+            Write-Verbose "    DOWNLOAD THE VERSION OF safeguard-ps MATCHING YOUR VERSION OF SAFEGUARD"
             throw
         }
     }

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -480,7 +480,7 @@ Path to a PFX (PKCS12) file containing the client certificate to use to connect 
 Client certificate thumbprint to use to authenticate the connection to the RSTS.
 
 .PARAMETER Version
-Version of the Web API you are using (default: 2).
+Version of the Web API you are using (default: 3).
 
 .PARAMETER Gui
 Display redistributable STS login window in a browser.  Supports 2FA.
@@ -557,7 +557,7 @@ function Connect-Safeguard
         [Parameter(Mandatory=$false)]
         [switch]$Gui,
         [Parameter(Mandatory=$false)]
-        [int]$Version = 2,
+        [int]$Version = 3,
         [Parameter(Mandatory=$false)]
         [switch]$NoSessionVariable = $false
     )
@@ -873,7 +873,7 @@ Invalidate specific access token rather than the session variable.
 Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER Version
-Version of the Web API you are using (default: 2).
+Version of the Web API you are using (default: 3).
 
 .INPUTS
 None.
@@ -898,7 +898,7 @@ function Disconnect-Safeguard
         [Parameter(ParameterSetName="AccessToken",Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(ParameterSetName="AccessToken",Mandatory=$false)]
-        [int]$Version = 2
+        [int]$Version = 3
     )
 
     $ErrorActionPreference = "Stop"
@@ -1008,7 +1008,7 @@ HTTP method verb you would like to use: GET, PUT, POST, DELETE.
 Relative portion of the Url you would like to call starting after the version.
 
 .PARAMETER Version
-Version of the Web API you are using (default: 2).
+Version of the Web API you are using (default: 3).
 
 .PARAMETER RetryUrl
 Relative portion of the Url to retry if the initial call returns 404 (for backwards compatibility).
@@ -1097,7 +1097,7 @@ function Invoke-SafeguardMethod
         [Parameter(Mandatory=$true,Position=2)]
         [string]$RelativeUrl,
         [Parameter(Mandatory=$false)]
-        [int]$Version = 2,
+        [int]$Version = 3,
         [Parameter(Mandatory=$false)]
         [string]$RetryUrl,
         [Parameter(Mandatory=$false)]
@@ -1314,7 +1314,7 @@ function Get-SafeguardAccessTokenStatus
         }
         $local:Response = (Invoke-WebRequest -Method GET -Headers @{ 
                 "Authorization" = "Bearer $AccessToken"
-            } -Uri "https://$Appliance/service/core/v2/Me")
+            } -Uri "https://$Appliance/service/core/v3/Me")
         $local:TimeRemaining = (New-TimeSpan -Minutes $local:Response.Headers["X-TokenLifetimeRemaining"])
         if ($Raw)
         {

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -92,6 +92,34 @@ namespace Ex
     }
     throw $local:ExceptionToThrow
 }
+function Test-SafeguardMinVersionInternal
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true)]
+        [ValidatePattern("^\d+\.\d+")]
+        [string]$MinVersion
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    [int]$local:Major,[int]$local:Minor = $MinVersion.split(".")
+    $local:CurrentVersion = (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Appliance GET Version -RetryVersion 2)
+    if (([int]$local:CurrentVersion.Major) -gt $local:Major `
+        -or (([int]$local:CurrentVersion.Major) -eq $local:Major -and ([int]$local:CurrentVersion.Minor) -ge $local:Minor))
+    {
+        $true
+    }
+    else
+    {
+        $false
+    }
+}
 function Wait-ForSafeguardStatus
 {
     [CmdletBinding()]

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -335,17 +335,8 @@ function Resolve-SafeguardSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset ID, trying directories"
-        try 
-        {
-            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
-            Resolve-SafeguardDirectoryId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System
-        }
-        catch
-        {
-            Write-Verbose "Unable to resolve to directory ID"
-            throw "Cannot determine system ID for '$System'"
-        }
+        Write-Verbose "Unable to resolve to asset ID"
+        throw "Cannot determine system ID for '$System'"
     }
 }
 
@@ -373,17 +364,8 @@ function Resolve-SafeguardAccountIdWithoutSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset account ID, trying directories"
-        try 
-        {
-            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
-            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Account
-        }
-        catch
-        {
-            Write-Verbose "Unable to resolve to directory account ID"
-            throw "Cannot determine account ID for '$Account'"
-        }
+        Write-Verbose "Unable to resolve to asset account ID"
+        throw "Cannot determine account ID for '$Account'"
     }
 }
 
@@ -413,17 +395,8 @@ function Resolve-SafeguardAccountIdWithSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset account ID, trying directories"
-        try 
-        {
-            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
-            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -DirectoryId $SystemId $Account
-        }
-        catch
-        {
-            Write-Verbose "Unable to resolve to directory account ID"
-            throw "Cannot determine system ID for '$System'"
-        }
+        Write-Verbose "Unable to resolve to asset account ID"
+        throw "Cannot determine system ID for '$System'"
     }
 }
 

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -335,8 +335,17 @@ function Resolve-SafeguardSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset ID"
-        throw "Cannot determine system ID for '$System'"
+        Write-Verbose "Unable to resolve to asset ID, trying directories"
+        try 
+        {
+            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
+            Resolve-SafeguardDirectoryId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System
+        }
+        catch
+        {
+            Write-Verbose "Unable to resolve to directory ID"
+            throw "Cannot determine system ID for '$System'"
+        }
     }
 }
 
@@ -364,8 +373,17 @@ function Resolve-SafeguardAccountIdWithoutSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset account ID"
-        throw "Cannot determine account ID for '$Account'"
+        Write-Verbose "Unable to resolve to asset account ID, trying directories"
+        try 
+        {
+            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
+            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Account
+        }
+        catch
+        {
+            Write-Verbose "Unable to resolve to directory account ID"
+            throw "Cannot determine account ID for '$Account'"
+        }
     }
 }
 
@@ -395,8 +413,17 @@ function Resolve-SafeguardAccountIdWithSystemId
     }
     catch
     {
-        Write-Verbose "Unable to resolve to asset account ID"
-        throw "Cannot determine system ID for '$System'"
+        Write-Verbose "Unable to resolve to asset account ID, trying directories"
+        try 
+        {
+            Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
+            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -DirectoryId $SystemId $Account
+        }
+        catch
+        {
+            Write-Verbose "Unable to resolve to directory account ID"
+            throw "Cannot determine system ID for '$System'"
+        }
     }
 }
 

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -368,7 +368,7 @@ A string containing a mobile phone number for the user.
 
 .PARAMETER AdminRoles
 An array of strings containing the permissions (admin roles) to assign to the user.  You may also specify
-'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'DirectoryAdmin', 'Auditor',
+'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'Auditor',
 'AssetAdmin', 'ApplianceAdmin', 'PolicyAdmin', 'UserAdmin', 'HelpdeskAdmin', 'OperationsAdmin'.
 
 .PARAMETER Password
@@ -421,7 +421,7 @@ function New-SafeguardUser
         [Parameter(Mandatory=$false)]
         [string]$MobilePhone = $null,
         [Parameter(Mandatory=$false)]
-        [ValidateSet('GlobalAdmin','DirectoryAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin','All',IgnoreCase=$true)]
+        [ValidateSet('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin','All',IgnoreCase=$true)]
         [string[]]$AdminRoles = $null,
         [Parameter(Mandatory=$false)]
         [SecureString]$Password,
@@ -464,7 +464,7 @@ function New-SafeguardUser
 
     if ($AdminRoles -contains "All")
     {
-        $AdminRoles = @('GlobalAdmin','DirectoryAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
+        $AdminRoles = @('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
     }
 
     if ($Provider -eq $local:LocalProviderId -and $PSBoundParameters.ContainsKey("Password"))
@@ -711,7 +711,7 @@ A string containing a mobile phone number for the user.
 
 .PARAMETER AdminRoles
 An array of strings containing the permissions (admin roles) to assign to the user.  You may also specify
-'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'DirectoryAdmin', 'Auditor',
+'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'Auditor',
 'AssetAdmin', 'ApplianceAdmin', 'PolicyAdmin', 'UserAdmin', 'HelpdeskAdmin', 'OperationsAdmin'.
 
 .PARAMETER UserObject
@@ -757,7 +757,7 @@ function Edit-SafeguardUser
         [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
         [string]$MobilePhone = $null,
         [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
-        [ValidateSet('GlobalAdmin','DirectoryAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin','All',IgnoreCase=$true)]
+        [ValidateSet('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin','All',IgnoreCase=$true)]
         [string[]]$AdminRoles = $null,
         [Parameter(ParameterSetName="Object",Mandatory=$false)]
         [object]$UserObject
@@ -795,7 +795,7 @@ function Edit-SafeguardUser
         {
             if ($AdminRoles -contains "All")
             {
-                $AdminRoles = @('GlobalAdmin','DirectoryAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
+                $AdminRoles = @('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
             }
             $UserObject.AdminRoles = $AdminRoles
         }

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -466,7 +466,15 @@ function New-SafeguardUser
 
     if ($AdminRoles -contains "All")
     {
-        $AdminRoles = @('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
+        Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+        if (Test-SafeguardMinVersionInternal -Appliance $Appliance -Insecure:$Insecure -MinVersion "2.7")
+        {
+            $AdminRoles = @('GlobalAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
+        }
+        else
+        {
+            $AdminRoles = @('GlobalAdmin','DirectoryAdmin','Auditor','AssetAdmin','ApplianceAdmin','PolicyAdmin','UserAdmin','HelpdeskAdmin','OperationsAdmin')
+        }
     }
 
     if ($Provider -eq $local:LocalProviderId -and $PSBoundParameters.ContainsKey("Password"))


### PR DESCRIPTION
Few things to note here:

1. I changed the default endpoint to v3 because all the Safeguard versions going forward will run on v3. So I think v2 should be the RetryVersion wherever needed.

2. **I only updated the cmdlets I have touched for Directory Rewrite** to include the logic to retry with v2 if v3 endpoint is not found. However, some cmdlets that I haven't touched might still be broken.

I think the best solution for this is to always retry with version 2 when we get a 404 from the API v3 endpoint. Right now, we only retry when a "RetryUrl" is passed by the cmdlet here: https://github.com/OneIdentity/safeguard-ps/blob/master/src/safeguard-ps.psm1#L1220

I suggest something like this:

>  try
>     {
>         Invoke-Internal $Appliance $Service $Method $Version $RelativeUrl $local:Headers `
>                         -Body $Body -JsonBody $JsonBody `
>                         -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
>     }
>     catch
>     {
>         if ($_.Exception.HttpStatusCode -eq 404)
>         {
> 			$RetryVersion = 2
> 
> 			if ($RetryUrl)
> 			{
> 				Write-Verbose "Trying to use RetryVersion: $RetryVersion, and RetryUrl: $RetryUrl"
> 				Invoke-Internal $Appliance $Service $Method $RetryVersion $RetryUrl $local:Headers `
> 								-Body $Body -JsonBody $JsonBody `
> 								-Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
> 			}
> 			else
> 			{
> 				Write-Verbose "Trying to use RetryVersion: $RetryVersion, and RetryUrl: $RetryUrl"
> 				Invoke-Internal $Appliance $Service $Method $RetryVersion $RelativeUrl $local:Headers `
>                             -Body $Body -JsonBody $JsonBody `
>                             -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
> 			}
>             
>         }
>         else
>         {
>             throw
>         }
>     }

"Connect-Safeguard" cmdlet will need something more than this.

3. I edited appvoyer.yml to not push to powershell gallery