### PR TITLE
Don't convert ApplianceID to upper case when assigning SSL certificate

### DIFF
--- a/src/certificates.psm1
+++ b/src/certificates.psm1
@@ -650,7 +650,7 @@ function Set-SafeguardSslCertificateForAppliance
     {
         $ApplianceId = (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status).ApplianceId
     }
-    $ApplianceId = $ApplianceId.ToUpper()
+    
 
     Write-Host "Setting $Thumbprint as current SSL Certificate for $ApplianceId..."
     $local:CurrentIds = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "SslCertificates/$Thumbprint/Appliances")


### PR DESCRIPTION
@DanPeterson Please review this. Automation for A2A module was failing because of this. Found that we no longer need to change the ApplianceID to upper-case, when assigning SSL certificate. Something might have changed in the API? 

I was getting error "60493: 9F90A935CA904492B5B93A5B13C15117 is not a valid appliance ID in this cluster." We were explicitly changing the ApplianceID to upper-case. Removing that fixed it.