### PR TITLE
Install-SafeguardPatch uses too much memory

### DIFF
--- a/src/uploadPatch.ps1
+++ b/src/uploadPatch.ps1
@@ -1,0 +1,50 @@
+Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$Patch,
+        [Parameter(Mandatory=$false, Position=1)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false, Position=2)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false, Position=3)]
+        [int]$Version,
+        [Parameter(Mandatory=$false, Position=4)]
+        [int]$Timeout,
+        [Parameter(Mandatory=$false, Position=5)]
+        [ValidateSet('True','False', IgnoreCase=$true)]
+        [string]$Insecure
+    )
+
+try
+{
+    Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
+    Edit-SslVersionSupport
+
+    [Boolean]$Insecure = [System.Convert]::ToBoolean($Insecure)
+
+    if ($Insecure)
+    {
+        Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+    }
+    # Use the WebClient class to avoid the content scraping slow down from Invoke-RestMethod as well as timeout issues
+    Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
+    Add-ExWebClientExType
+
+    $WebClient = (New-Object Ex.WebClientEx -ArgumentList @($Timeout))
+    $WebClient.Headers.Add("Accept", "application/json")
+    $WebClient.Headers.Add("Content-type", "application/octet-stream")
+    $WebClient.Headers.Add("Authorization", "Bearer $AccessToken")
+    Write-Host "Uploading patch to Safeguard ($Appliance). This operation may take several minutes..."
+    $Bytes = [System.IO.File]::ReadAllBytes($Patch);
+
+    $ResponseBytes = $WebClient.UploadData("https://$Appliance/service/appliance/v$Version/Patch", "POST", $Bytes) | Out-Null
+    if ($ResponseBytes)
+    {
+        [System.Text.Encoding]::UTF8.GetString($ResponseBytes)
+    }
+}
+catch [System.Net.WebException]
+{
+    Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+    Out-SafeguardExceptionIfPossible $_.Exception
+}


### PR DESCRIPTION
This addresses issue: https://github.com/OneIdentity/safeguard-ps/issues/142

With this code change, patch will be uploaded in a separate powershell process. This way, when the upload is finished, the memory held by reading the patch file in the powershell script will be released. The installation and waiting for online status of the appliance doesn't cause any memory usage issue, so I kept it as before. 

I tried using FIleStream and StreamReader in powershell, but still saw the memory issue. I didn't go for integrating the C# code in the powershell script as I think this solution will suffice. 