### PR TITLE
Can't create a new access request

### DIFF
--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -315,6 +315,19 @@ function New-SafeguardAccessRequest
         }
         $local:AccountId = (Resolve-SafeguardRequestableAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
     }
+    else 
+    {
+        if ($PSBoundParameters.ContainsKey("AccountToUse")) 
+        {
+            # Try to resolve AccountId, but do not fail on error
+            try {
+                $local:AccountId = (Resolve-SafeguardRequestableAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
+            }
+            catch {
+                Write-Warning $_
+            }
+        }
+    }
     if ($local:AccountId) { $local:Body["AccountId"] = $local:AccountId }
 
     if ($Emergency) { $local:Body["IsEmergency"] = $true }


### PR DESCRIPTION
This addresses the issue : https://github.com/OneIdentity/safeguard-ps/issues/170

I think we can **try** to resolve the AccountID even if the AccessRequestType is not "Password", but "AccountToUse" is provided. Since an account ID is not required for sessions access request type, do not fail the cmdlet if we fail to resolve the AccountId in this case. 