### PR TITLE
New-SafeguardAsset doesn't discover the host key

### DIFF
--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -577,11 +577,6 @@ function New-SafeguardAsset
             }
         }
     }
-    else
-    {
-        # No Service Account -- so don't detect SSH host key
-        $NoSshHostKeyDiscovery = $true
-    }
 
     #Ldap Connection properties
     if ($PSCmdlet.ParameterSetName -eq "Ldap")


### PR DESCRIPTION
Discover Ssh host key when adding a new asset even if the service account is not provided

This addresses issue https://github.com/OneIdentity/safeguard-ps/issues/169