### PR TITLE
Entitlement and Request Improvements, -Fields parameter support, Cluster improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,9 @@ update this list.
 - Get-SafeguardRequestableAccount (Get-SafeguardMyRequestable)
 - Find-SafeguardRequestableAccount (Find-SafeguardMyRequestable)
 - Get-SafeguardAccessRequestPassword (Get-SafeguardAccessRequestCheckoutPassword)
+- Get-SafeguardAccessRequestRdpFile
+- Get-SafeguardAccessRequestSshUrl
+- Start-SafeguardAccessRequestSession
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ update this list.
 - Close-SafeguardAccessRequest
 - Approve-SafeguardAccessRequest
 - Deny-SafeguardAccessRequest (Revoke-SafeguardAccessRequest)
+- Get-SafeguardAccessRequestActionLog
+- Assert-SafeguardAccessRequest
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,8 @@ update this list.
 - Start-SafeguardAccessRequestSession
 - Copy-SafeguardAccessRequestPassword
 - Close-SafeguardAccessRequest
+- Approve-SafeguardAccessRequest
+- Deny-SafeguardAccessRequest (Revoke-SafeguardAccessRequest)
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ update this list.
 - Get-SafeguardAccessRequestSshUrl
 - Start-SafeguardAccessRequestSession
 - Copy-SafeguardAccessRequestPassword
+- Close-SafeguardAccessRequest
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -466,9 +466,11 @@ update this list.
 - Get-SafeguardAssetGroup
 - New-SafeguardAssetGroup
 - Remove-SafeguardAssetGroup
+- Edit-SafeguardAssetGroup
 - Get-SafeguardAccountGroup
 - New-SafeguardAccountGroup
 - Remove-SafeguardAccountGroup
+- Edit-SafeguardAccountGroup
 
 ### Policy Assets and Policy Accounts (for use in entitlements & access policies)
 

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ update this list.
 - Get-SafeguardAccessRequestRdpFile
 - Get-SafeguardAccessRequestSshUrl
 - Start-SafeguardAccessRequestSession
+- Copy-SafeguardAccessRequestPassword
 
 ### Users
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ update this list.
 - Find-SafeguardRequestableAccount (Find-SafeguardMyRequestable)
 - Get-SafeguardAccessRequestPassword (Get-SafeguardAccessRequestCheckoutPassword)
 - Get-SafeguardAccessRequestRdpFile
+- Get-SafeguardAccessRequestRdpUrl
 - Get-SafeguardAccessRequestSshUrl
 - Start-SafeguardAccessRequestSession
 - Copy-SafeguardAccessRequestPassword

--- a/README.md
+++ b/README.md
@@ -382,8 +382,11 @@ update this list.
 - New-SafeguardAccessRequest
 - Edit-SafeguardAccessRequest
 - Get-SafeguardActionableRequest
-- Get-SafeguardRequestableAccount
-- Find-SafeguardRequestableAccount
+- Get-SafeguardMyRequest
+- Get-SafeguardMyApproval
+- Get-SafeguardMyReview
+- Get-SafeguardRequestableAccount (Get-SafeguardMyRequestable)
+- Find-SafeguardRequestableAccount (Find-SafeguardMyRequestable)
 - Get-SafeguardAccessRequestPassword (Get-SafeguardAccessRequestCheckoutPassword)
 
 ### Users
@@ -401,6 +404,7 @@ update this list.
 - Rename-SafeguardUser
 
 ### Asset Partitions
+
 - Get-SafeguardAssetPartition
 - New-SafeguardAssetPartition
 - Remove-SafeguardAssetPartition

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ update this list.
 - New-SafeguardDirectoryIdentityProvider
 - Remove-SafeguardDirectoryIdentityProvider
 - Edit-SafeguardDirectoryIdentityProvider
+- Get-SafeguardDirectoryIdentityProviderDomain
 - Get-SafeguardDirectoryIdentityProviderSchemaMapping
 - Set-SafeguardDirectoryIdentityProviderSchemaMapping
 - Get-SafeguardDirectory

--- a/cleanup-local.ps1
+++ b/cleanup-local.ps1
@@ -1,8 +1,9 @@
+[CmdletBinding()]
 Param(
     [string]$TargetDir
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 if (-not $TargetDir)
 {

--- a/docker-include.psm1
+++ b/docker-include.psm1
@@ -13,7 +13,7 @@ function Get-SafeguardDockerFile
         [string]$ImageType = "alpine"
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     switch ($ImageType)

--- a/install-appveyor.ps1
+++ b/install-appveyor.ps1
@@ -1,4 +1,8 @@
-$ErrorActionPreference = "Stop"
+[CmdletBinding()]
+Param(
+)
+
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 $TargetDir = (($env:PSModulePath -split ';') | Where-Object { $_.StartsWith($env:UserProfile) })[0]
 if (-not $TargetDir)

--- a/install-local.ps1
+++ b/install-local.ps1
@@ -1,8 +1,9 @@
+[CmdletBinding()]
 Param(
   [string]$TargetDir
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 if ($PSVersionTable.Platform -ne "Unix")
 {

--- a/install-local.ps1
+++ b/install-local.ps1
@@ -4,17 +4,29 @@ Param(
 
 $ErrorActionPreference = "Stop"
 
+if ($PSVersionTable.Platform -ne "Unix")
+{
+    $UserProf = $env:USERPROFILE
+    $Delim = ';'
+}
+else
+{
+    $UserProf = $HOME
+    $Delim = ':'
+}
+
 if (-not $TargetDir)
 {
-    $TargetDir = [array]($env:PSModulePath -split ';') | Where-Object { $_.StartsWith($env:USERPROFILE) } | Select-Object -First 1
+    $TargetDir = [array]($env:PSModulePath -split $Delim) | Where-Object { $_.StartsWith($UserProf) } | Select-Object -First 1
     if (-not $TargetDir)
     {
-        throw "Unable to find a PSModulePath in your user profile (" + $env:UserProfile + "), PSModulePath: " + $env:PSModulePath
+        throw "Unable to find a PSModulePath in your user profile (" + $UserProf + "), PSModulePath: " + $env:PSModulePath
     }
 }
 
 if (-not (Test-Path $TargetDir))
 {
+    Write-Host "Creating target directory '$TargetDir'"
     New-Item -Path $TargetDir -ItemType Container -Force | Out-Null
 }
 $ModuleName = "safeguard-ps"
@@ -25,15 +37,20 @@ Write-Host "Installing '$ModuleName $($ModuleDef["ModuleVersion"])' to '$TargetD
 $ModuleDir = (Join-Path $TargetDir $ModuleName)
 if (-not (Test-Path $ModuleDir))
 {
+    Write-Host "Creating module directory '$ModuleDir'"
     New-Item -Path $ModuleDir -ItemType Container -Force | Out-Null
 }
 else
 {
+    Write-Host "Removing module directory '$ModuleDir'"
     Remove-Item -Recurse -Force (Join-Path $ModuleDir "*")
 }
 $VersionDir = (Join-Path $ModuleDir $ModuleDef["ModuleVersion"])
 if (-not (Test-Path $VersionDir))
 {
+    Write-Host "Creating version directory '$VersionDir'"
     New-Item -Path $VersionDir -ItemType Container -Force | Out-Null
 }
-Copy-Item -Recurse -Path (Join-Path $PSScriptRoot "src\*") -Destination $VersionDir
+$Sources = (Join-Path $PSScriptRoot (Join-Path "src" "*"))
+Write-Host "Copying '$Sources' to '$VersionDir'"
+Copy-Item -Recurse -Path $Sources -Destination $VersionDir

--- a/invoke-docker-build.ps1
+++ b/invoke-docker-build.ps1
@@ -4,7 +4,7 @@ Param(
     [string]$ImageType = "alpine"
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
 Import-Module -Name "$PSScriptRoot\docker-include.psm1" -Scope Local

--- a/invoke-docker-run.ps1
+++ b/invoke-docker-run.ps1
@@ -4,7 +4,7 @@ Param(
     [string]$ImageType = "alpine"
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
 Import-Module -Name "$PSScriptRoot\docker-include.psm1" -Scope Local

--- a/samples/fix-service-account-ssh-keys.ps1
+++ b/samples/fix-service-account-ssh-keys.ps1
@@ -1,9 +1,10 @@
 # BUG#777399 -- After patching to 2.2, tasks fail on assets with service accounts using SSH keys
 # Support Reference: 4304990
+[CmdletBinding()]
 Param(
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 if (-not $SafeguardSession)
 {

--- a/samples/new-test-entitlement.ps1
+++ b/samples/new-test-entitlement.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$true)]
     [string]$EntitlementName,
@@ -5,7 +6,7 @@ Param(
     [string]$ApproverUserName
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 if (-not $SafeguardSession)
 {

--- a/src/a2a.psm1
+++ b/src/a2a.psm1
@@ -497,7 +497,7 @@ function Edit-SafeguardA2a
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    
+
     if (-not $A2aObject)
     {
         throw "A2aObject must not be null"
@@ -513,7 +513,7 @@ Get configuration of credential retrieval for an account from an A2A registratio
 via the Web API.
 
 .DESCRIPTION
-Get all or one of the accounts configured for credential retrieval in an A2A registrations that have 
+Get all or one of the accounts configured for credential retrieval in an A2A registrations that have
 been added to Safeguard.  Accounts for credential retrieval are given API keys and may be configured
 with IP address restrictions.
 
@@ -609,7 +609,7 @@ via the Web API.
 
 .DESCRIPTION
 Add an account credential retrieval to an A2A registration that has been added to Safeguard.
-Accounts for credential retrieval are given API keys and may be configured with IP address 
+Accounts for credential retrieval are given API keys and may be configured with IP address
 restrictions.
 
 .PARAMETER Appliance
@@ -715,7 +715,7 @@ function Add-SafeguardA2aCredentialRetrieval
 
     if ($IpRestrictions)
     {
-        $local:Body.IpRestrictions = $IpRestrictions 
+        $local:Body.IpRestrictions = $IpRestrictions
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -729,7 +729,7 @@ via the Web API.
 
 .DESCRIPTION
 Remove an account credential retrieval from an A2A registration that has been added to Safeguard.
-Accounts for credential retrieval are given API keys and may be configured with IP address 
+Accounts for credential retrieval are given API keys and may be configured with IP address
 restrictions.
 
 .PARAMETER Appliance

--- a/src/a2a.psm1
+++ b/src/a2a.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardA2aId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($A2a.Id -as [int])
+    {
+        $A2a = $User.Id
+    }
+
     if (-not ($A2a -as [int]))
     {
         try
@@ -72,7 +77,12 @@ function Resolve-SafeguardA2aAccountId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if (-not ($A2a -as [int]))
+    if ($Account.Id -as [int])
+    {
+        $Account = $Account.Id
+    }
+
+    if (-not ($Account -as [int]))
     {
         $local:Filter = "AccountName ieq '$Account'"
         if ($PSBoundParameters.ContainsKey("System") -and $System)

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -55,7 +55,7 @@ function Invoke-SafeguardA2aMethodWithCertificate
     $Service = $Service.ToLower()
 
     $local:BodyInternal = $null
-    if ($Body) 
+    if ($Body)
     {
         $local:BodyInternal = (ConvertTo-Json -InputObject $Body)
         Write-Verbose "---Request Body---"
@@ -201,7 +201,7 @@ function Get-SafeguardA2aRetrievableAccount
     if (-not $Thumbprint)
     {
         if (-not $Password)
-        { 
+        {
             $Password = (Read-Host "Password" -AsSecureString)
         }
         $local:Registrations = (Invoke-SafeguardA2aMethodWithCertificate -Insecure:$Insecure -Appliance $Appliance `

--- a/src/accesscert.psm1
+++ b/src/accesscert.psm1
@@ -422,10 +422,10 @@ function Get-IdentitiesFile
         [Parameter(Mandatory=$false)]
         [switch]$ExcludeSafeguardIdentities
 	)
-	
+
 	$local:adIdentitiesFile = Join-Path $OutputDirectory $DomainName-identities.csv
 	$local:sgIdentitiesFile = Join-Path $OutputDirectory $Identifier-identities.csv
-	
+
 	if (-not $ExcludeSafeguardIdentities)
 	{
 		# Get both and merge into a single file with the desired file name
@@ -996,7 +996,7 @@ Update an existing group comma-separated values (CSV) for access certification
 that was extracted from Safeguard to add group owner information.
 
 .DESCRIPTION
-This utility takes a group CSV file and calls the Active Directory PowerShell module 
+This utility takes a group CSV file and calls the Active Directory PowerShell module
 to look up groups to see if the managedBy attribute is set and then adds the owner
 to the CSV based on the user specified in that attribute.
 

--- a/src/archives.psm1
+++ b/src/archives.psm1
@@ -205,7 +205,7 @@ function New-SafeguardArchiveServer
     {
         $ServiceAccountCredentialType = (Resolve-SafeguardServiceAccountCredentialType)
     }
-    
+
 
     if (-not $PSBoundParameters.ContainsKey("ServiceAccountPassword"))
     {

--- a/src/assetpartitions.psm1
+++ b/src/assetpartitions.psm1
@@ -182,7 +182,7 @@ function New-SafeguardAssetPartition
         Name = $Name
     }
     if ($PSBoundParameters.ContainsKey("Description")) { $local:Body.Description = $Description }
-    if ($PSBoundParameters.ContainsKey("Owners")) 
+    if ($PSBoundParameters.ContainsKey("Owners"))
     {
         Import-Module -Name "$PSScriptRoot\users.psm1" -Scope Local
         $local:Body.Owners = @()
@@ -263,7 +263,7 @@ function Remove-SafeguardAssetPartition
     if ($PSBoundParameters.ContainsKey("FailoverPartition"))
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "AssetPartitions/$($local:PartitionId)" `
-            -Parameters @{ 
+            -Parameters @{
                 failoverPartitionId = (Resolve-SafeguardAssetPartitionId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $FailoverPartition)
             }
     }
@@ -364,7 +364,7 @@ function Edit-SafeguardAssetPartition
 
         if ($PSBoundParameters.ContainsKey("Name")) { $AssetPartitionObject.Name = $Name }
         if ($PSBoundParameters.ContainsKey("Description")) { $AssetPartitionObject.Description = $Description }
-        if ($PSBoundParameters.ContainsKey("Owners")) 
+        if ($PSBoundParameters.ContainsKey("Owners"))
         {
             Import-Module -Name "$PSScriptRoot\users.psm1" -Scope Local
             $AssetPartitionObject.Owners = @()

--- a/src/assetpartitions.psm1
+++ b/src/assetpartitions.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardAssetPartitionId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($AssetPartition.Id -as [int])
+    {
+        $AssetPartition = $AssetPartition.Id
+    }
+
     if (-not ($AssetPartition -as [int]))
     {
         try

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -117,25 +117,6 @@ function Resolve-SafeguardAssetAccountId
     }
 }
 
-function Get-SafeguardDirectoryAssetDomains
-{
-    [CmdletBinding()]
-    Param(
-        [Parameter(Mandatory=$false)]
-        [string]$Appliance,
-        [Parameter(Mandatory=$false)]
-        [object]$AccessToken,
-        [Parameter(Mandatory=$false)]
-        [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [int]$DirectoryAssetId
-    )
-
-    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
-    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-
-    (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets/$DirectoryAssetId).DirectoryAssetProperties.Domains
-}
 <#
 .SYNOPSIS
 Discover SSH host key by connecting to asset managed by Safeguard via the Web API.

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardAssetId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($Asset.Id -as [int])
+    {
+        $Asset = $Asset.Id
+    }
+
     if (-not ($Asset -as [int]))
     {
         try
@@ -68,6 +73,11 @@ function Resolve-SafeguardAssetAccountId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Account.Id -as [int])
+    {
+        $Account = $Account.Id
+    }
 
     if (-not ($Account -as [int]))
     {

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -379,7 +379,7 @@ NetworkAddress is an IP address rather than a DNS name.
 A string containing a description for this asset.
 
 .PARAMETER AssetPartition
-An integer containing an ID  or a string containing the name of the asset partition 
+An integer containing an ID  or a string containing the name of the asset partition
 where this asset should be created.
 
 .PARAMETER AssetPartitionId
@@ -513,7 +513,7 @@ function New-SafeguardAsset
         {
             $DisplayName = $ServiceAccountDomainName
         }
-        else 
+        else
         {
             if (-not (Test-IpAddress $NetworkAddress))
             {
@@ -870,7 +870,7 @@ function Edit-SafeguardAsset
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     Write-Host "ErrorActionPreference is :"
     Write-Host $ErrorActionPreference
 
@@ -985,7 +985,7 @@ function Sync-SafeguardDirectoryAsset
     Import-Module -Name "$PSScriptRoot\assetpartitions.psm1" -Scope Local
     $local:AssetPartitionId = (Resolve-SafeguardAssetPartitionId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetPartition)
     $local:DirectoryAsset = Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryAssetToSync
-    
+
     if(-not $local:DirectoryAsset.IsDirectory)
     {
         throw "Asset '$($local:DirectoryAsset.Name)' is not a directory asset"
@@ -1162,7 +1162,7 @@ Create a new account on an asset managed by Safeguard via the Web API.
 
 .DESCRIPTION
 Create a representation of an account on a managed asset.  Accounts passwords can
-be managed, and Safeguard can be configured to check and change those passwords.  
+be managed, and Safeguard can be configured to check and change those passwords.
 Policy can be created to allow access to passwords and sessions based on those passwords.
 
 .PARAMETER Appliance

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -254,6 +254,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER AssetToGet
 An integer containing the ID of the asset to get or a string containing the name.
 
+.PARAMETER Fields
+An array of the asset property names to return.
+
 .INPUTS
 None.
 
@@ -264,7 +267,7 @@ JSON response from Safeguard Web API.
 Get-SafeguardAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
-Get-SafeguardAsset
+Get-SafeguardAsset -Fields Id,Name,NetworkAddress
 #>
 function Get-SafeguardAsset
 {
@@ -277,20 +280,28 @@ function Get-SafeguardAsset
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [object]$AssetToGet
+        [object]$AssetToGet,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
     if ($PSBoundParameters.ContainsKey("AssetToGet"))
     {
         $local:AssetId = Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToGet
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets/$($local:AssetId)"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets/$($local:AssetId)" -Parameters $local:Parameters
     }
     else
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets" -Parameters $local:Parameters
     }
 }
 
@@ -1026,6 +1037,9 @@ An integer containing the ID of the asset to get accounts from or a string conta
 .PARAMETER AccountToGet
 An integer containing the ID of the account to get or a string containing the name.
 
+.PARAMETER Fields
+An array of the account property names to return.
+
 .INPUTS
 None.
 
@@ -1036,7 +1050,7 @@ JSON response from Safeguard Web API.
 Get-SafeguardAssetAccount -AccessToken $token -Appliance 10.5.32.54 -Insecure windows.blah.corp administrator
 
 .EXAMPLE
-Get-SafeguardAssetAccount -AccountToGet oracle
+Get-SafeguardAssetAccount -AccountToGet oracle -Fields AssetId,Id,AssetName,Name
 #>
 function Get-SafeguardAssetAccount
 {
@@ -1051,11 +1065,19 @@ function Get-SafeguardAssetAccount
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToGet,
         [Parameter(Mandatory=$false,Position=1)]
-        [object]$AccountToGet
+        [object]$AccountToGet,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
 
     if ($PSBoundParameters.ContainsKey("AssetToGet"))
     {
@@ -1063,11 +1085,11 @@ function Get-SafeguardAssetAccount
         if ($PSBoundParameters.ContainsKey("AccountToGet"))
         {
             $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToGet)
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts/$($local:AccountId)"
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts/$($local:AccountId)" -Parameters $local:Parameters
         }
         else
         {
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets/$($local:AssetId)/Accounts"
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Assets/$($local:AssetId)/Accounts" -Parameters $local:Parameters
         }
     }
     else
@@ -1075,11 +1097,11 @@ function Get-SafeguardAssetAccount
         if ($PSBoundParameters.ContainsKey("AccountToGet"))
         {
             $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToGet)
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts/$($local:AccountId)"
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts/$($local:AccountId)" -Parameters $local:Parameters
         }
         else
         {
-            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts"
+            Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts" -Parameters $local:Parameters
         }
     }
 }

--- a/src/certificates.psm1
+++ b/src/certificates.psm1
@@ -835,12 +835,6 @@ function Get-SafeguardSslCertificateForAppliance
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Parameters = $null
-    if ($Fields)
-    {
-        $local:Parameters = @{ fields = ($Fields -join ",")}
-    }
-
     if (-not $ApplianceId)
     {
         $ApplianceId = (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status).ApplianceId
@@ -1026,7 +1020,7 @@ function New-SafeguardCertificateSigningRequest
     $local:Csr = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "ServerCertificateSignatureRequests" -Body $local:Body)
     $local:Csr
     $local:Csr.Base64RequestData | Out-File -Encoding ASCII -FilePath $OutFile -NoNewline
-    Write-Host "CSR saved to $OutFile"
+    Write-Host "CSR saved to '$OutFile'"
 }
 New-Alias -Name New-SafeguardCsr -Value New-SafeguardCertificateSigningRequest
 

--- a/src/certificates.psm1
+++ b/src/certificates.psm1
@@ -4,7 +4,7 @@ Upload trusted certificate to Safeguard via the Web API.
 
 .DESCRIPTION
 Upload a certificate to serve as a new trusted root certificate for
-Safeguard. You use this same method to upload an intermediate 
+Safeguard. You use this same method to upload an intermediate
 certificate that is part of the chain of trust.
 
 .PARAMETER Appliance
@@ -92,7 +92,7 @@ JSON response from Safeguard Web API.
 Uninstall-SafeguardTrustedCertificate -AccessToken $token -Appliance 10.5.32.54
 
 .EXAMPLE
-Uninstall-SafeguardTrustedCertificate -Thumbprint 3E1A99AE7ACFB163DEE3CCAC00A437D675937FCA 
+Uninstall-SafeguardTrustedCertificate -Thumbprint 3E1A99AE7ACFB163DEE3CCAC00A437D675937FCA
 #>
 function Uninstall-SafeguardTrustedCertificate
 {
@@ -337,7 +337,7 @@ function Install-SafeguardAuditLogSigningCertificate
     {
         $local:NewCertificate = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
             PUT "AuditLog/Retention/SigningCertificate" -Body @{
-                Base64CertificateData = "$($local:CertificateContents)" 
+                Base64CertificateData = "$($local:CertificateContents)"
             })
     }
 
@@ -479,7 +479,7 @@ function Install-SafeguardSslCertificate
     {
         $local:NewCertificate = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
             POST SslCertificates -Body @{
-                Base64CertificateData = "$($local:CertificateContents)" 
+                Base64CertificateData = "$($local:CertificateContents)"
             })
     }
 
@@ -521,7 +521,7 @@ JSON response from Safeguard Web API.
 Uninstall-SafeguardSslCertificate -AccessToken $token -Appliance 10.5.32.54
 
 .EXAMPLE
-Uninstall-SafeguardSslCertificate -Thumbprint 3E1A99AE7ACFB163DEE3CCAC00A437D675937FCA 
+Uninstall-SafeguardSslCertificate -Thumbprint 3E1A99AE7ACFB163DEE3CCAC00A437D675937FCA
 #>
 function Uninstall-SafeguardSslCertificate
 {
@@ -688,7 +688,7 @@ function Set-SafeguardSslCertificateForAppliance
     {
         $ApplianceId = (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status).ApplianceId
     }
-    
+
 
     Write-Host "Setting $Thumbprint as current SSL Certificate for $ApplianceId..."
     $local:CurrentIds = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "SslCertificates/$Thumbprint/Appliances")
@@ -774,7 +774,7 @@ function Clear-SafeguardSslCertificateForAppliance
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "SslCertificates/$Thumbprint/Appliances" -JsonBody "[]"
     }
-    else 
+    else
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "SslCertificates/$Thumbprint/Appliances" -Body $local:NewIds
     }
@@ -1013,7 +1013,7 @@ function New-SafeguardCertificateSigningRequest
                 throw "$_ is not an IP address"
             }
         }
-        $local:Body.IpAddresses = $IpAddresses 
+        $local:Body.IpAddresses = $IpAddresses
     }
     if ($PSBoundParameters.ContainsKey("DnsNames")) { $local:Body.DnsNames = $DnsNames }
 
@@ -1109,7 +1109,7 @@ None.  Just host messages describing what has been created.
 New-SafeguardTestCertificates -SubjectBaseDn "OU=petrsnd,O=OneIdentityInc,C=US"
 
 .EXAMPLE
-New-SafeguardTestCertificates 
+New-SafeguardTestCertificates
 #>
 function New-SafeguardTestCertificatePki
 {

--- a/src/certificates.psm1
+++ b/src/certificates.psm1
@@ -141,6 +141,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER Thumbprint
 A string containing the thumbprint of the certificate.
 
+.PARAMETER Fields
+An array of the certificate property names to return.
+
 .INPUTS
 None.
 
@@ -164,19 +167,29 @@ function Get-SafeguardTrustedCertificate
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [string]$Thumbprint
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
     if ($PSBoundParameters.ContainsKey("Thumbprint"))
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "TrustedCertificates/$Thumbprint"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            GET "TrustedCertificates/$Thumbprint" -Parameters $local:Parameters
     }
     else
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET TrustedCertificates
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            GET TrustedCertificates  -Parameters $local:Parameters
     }
 }
 

--- a/src/clustering.psm1
+++ b/src/clustering.psm1
@@ -313,16 +313,16 @@ function Get-SafeguardClusterHealth
     {
         if ($Category -ieq "NodeConnectivity")
         {
-            $local:Health | Select-Object -ExpandProperty "ClusterConnectivity" | Select-Object -ExpandProperty $Category
+            $local:Health | Select-Object -ExpandProperty "ClusterConnectivity" | Select-Object -ExpandProperty $Category | Format-List
         }
         else
         {
-            $local:Health | Select-Object -ExpandProperty $Category
+            $local:Health | Select-Object -ExpandProperty $Category | Format-List
         }
     }
     else
     {
-        $local:Health
+        $local:Health | Format-List
     }
 }
 

--- a/src/clustering.psm1
+++ b/src/clustering.psm1
@@ -249,7 +249,7 @@ function Get-SafeguardClusterMember
 Get health of cluster members from Safeguard via the Web API.
 
 .DESCRIPTION
-Retrieve the information based on most recent health check for all Safeguard appliances 
+Retrieve the information based on most recent health check for all Safeguard appliances
 in this cluster via the Web API.
 
 .PARAMETER Appliance
@@ -770,7 +770,7 @@ function Get-SafeguardClusterOperationStatus
 Attempt to force the completion of a currently running Safeguard cluster operation via the Safeguard Web API.
 
 .DESCRIPTION
-This cmdlet can be used to force a cluster operation to complete that is not being acknowledged by all 
+This cmdlet can be used to force a cluster operation to complete that is not being acknowledged by all
 appliances in the cluster.  This is not always possible with the current connection.  You may need to
 connect to a different appliance in the cluster to perform this operation depending on which appliance is
 having trouble.

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -105,7 +105,7 @@ function Resolve-SafeguardServiceAccountCredentialType
 Get the identity provider types defined in Safeguard via the Web API.
 
 .DESCRIPTION
-Get the identity provider types defined in Safeguard that can be used 
+Get the identity provider types defined in Safeguard that can be used
 for creating users and assigning authentication methods.
 
 .PARAMETER Appliance

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardPlatform
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($Platform.Id -as [int])
+    {
+        $Platform = $Platform.Id
+    }
+
     while (-not $($Platform -as [int]))
     {
         Write-Host "Searching for platforms with '$Platform'"

--- a/src/diagnostics.psm1
+++ b/src/diagnostics.psm1
@@ -429,7 +429,7 @@ function Get-SafeguardDiagnosticPackageLog
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET DiagnosticPackage/Log -OutFile $OutputPath
 }
 

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -241,6 +241,60 @@ function Get-SafeguardDirectoryIdentityProvider
 
 <#
 .SYNOPSIS
+Get domains of a directory identity provider used by Safeguard via the Web API.
+
+.DESCRIPTION
+Safeguard directory users can be added from Safeguard directory identity providers to
+enable domain users to log into Safeguard.  This cmdlet will report on which domains
+are included within that directory identity provider.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER DirectoryToGet
+An integer containing the ID of the directory to get or a string containing the name.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardDirectoryIdentityProviderDomain -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardDirectoryIdentityProviderDomain x.domain.corp
+#>
+function Get-SafeguardDirectoryIdentityProviderDomain
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$DirectoryToGet
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    (Get-SafeguardDirectoryIdentityProvider -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+        $DirectoryToGet).DirectoryProperties.Domains
+}
+
+<#
+.SYNOPSIS
 Create new directory identity provider in Safeguard via the Web API.
 
 .DESCRIPTION

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -286,7 +286,7 @@ function Get-SafeguardDirectoryIdentityProviderDomain
         [object]$DirectoryToGet
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     (Get-SafeguardDirectoryIdentityProvider -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardDirectoryIdentityProviderId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($Directory.Id -as [int])
+    {
+        $Directory = $Directory.Id
+    }
+
     if (-not ($Directory -as [int]))
     {
         try
@@ -66,6 +71,11 @@ function Resolve-SafeguardDirectoryId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Directory.Id -as [int])
+    {
+        $Directory = $Directory.Id
+    }
 
     if (-not ($Directory -as [int]))
     {
@@ -124,6 +134,11 @@ function Resolve-SafeguardDirectoryAccountId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Account.Id -as [int])
+    {
+        $Account = $Account.Id
+    }
 
     if (-not ($Account -as [int]))
     {

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -786,7 +786,7 @@ function Set-SafeguardDirectoryIdentityProviderSchemaMapping
                 -Body $local:IdpObject).DirectoryProperties.SchemaProperties.GroupProperties | Format-List
         }
     }
-    
+
 }
 
 
@@ -852,7 +852,7 @@ function Get-SafeguardDirectory
         $local:Parameters = @{ fields = ($Fields -join ",")}
     }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
         {
@@ -866,7 +866,7 @@ function Get-SafeguardDirectory
                 Directories -Version 2 -Parameters $local:Parameters
         }
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1125,17 +1125,17 @@ function Test-SafeguardDirectory
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToTest
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
             POST "Directories/$($local:DirectoryId)/TestConnection" -LongRunningTask -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
-            Test-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToTest $DirectoryToTest        
+            Test-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToTest $DirectoryToTest
         }
         else
         {
@@ -1193,12 +1193,12 @@ function Remove-SafeguardDirectory
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         $local:DirectoryId = Resolve-SafeguardDirectoryId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToDelete
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "Directories/$($local:DirectoryId)" -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1361,11 +1361,11 @@ function Edit-SafeguardDirectory
         if ($PSBoundParameters.ContainsKey("NetworkAddress")) { $DirectoryObject.NetworkAddress = $NetworkAddress }
     }
 
-    try 
+    try
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Directories/$($DirectoryObject.Id)" -Body $DirectoryObject -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1428,13 +1428,13 @@ function Sync-SafeguardDirectory
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         $local:Directory = Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSync
         Write-Host "Triggering sync for directory: $($local:Directory.Name)"
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Directories/$($local:Directory.Id)/Synchronize" -Version 2
     }
-    catch 
+    catch
     {
         Write-Host "Exception while triggering sync for directory: $($local:Directory.Name). Retrying..."
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
@@ -1514,7 +1514,7 @@ function Get-SafeguardDirectoryAccount
         $local:Parameters = @{ fields = ($Fields -join ",")}
     }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
         {
@@ -1659,7 +1659,7 @@ function Find-SafeguardDirectoryAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         if ($PSCmdlet.ParameterSetName -eq "Search")
         {
@@ -1672,7 +1672,7 @@ function Find-SafeguardDirectoryAccount
                 -Parameters @{ filter = $QueryFilter } -Version 2) | Where-Object {($_.PlatformId -eq $local:LdapPlatformId) -or ($_.PlatformId -eq $local:AdPlatformId)}
         }
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1698,7 +1698,7 @@ Create a new account on a directory managed by Safeguard via the Web API.
 
 .DESCRIPTION
 Create a representation of an account on a managed directory.  Accounts passwords can
-be managed, and Safeguard can be configured to check and change those passwords.  
+be managed, and Safeguard can be configured to check and change those passwords.
 Policy can be created to allow access to passwords and sessions based on those passwords.
 
 .PARAMETER Appliance
@@ -1759,7 +1759,7 @@ function New-SafeguardDirectoryAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         $local:Directory = (Get-SafeguardDirectory -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $ParentDirectory)
 
@@ -1769,7 +1769,7 @@ function New-SafeguardDirectoryAccount
                 "DirectoryId" = $local:Directory.Id;
             }
         }
-    
+
         if ($PSBoundParameters.ContainsKey("DomainName"))
         {
             $local:Body.DirectoryProperties.DomainName = $DomainName
@@ -1795,10 +1795,10 @@ function New-SafeguardDirectoryAccount
                 $DomainName = $local:Directory.Domains[0].DomainName
             }
         }
-    
+
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts" -Body $local:Body -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1866,11 +1866,11 @@ function Edit-SafeguardDirectoryAccount
     {
         throw "AccountObject must not be null"
     }
-    try 
+    try
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($AccountObject.Id)" -Body $AccountObject -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -1949,7 +1949,7 @@ function Set-SafeguardDirectoryAccountPassword
         $NewPassword = (Read-Host -AsSecureString "NewPassword")
     }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToSet"))
         {
@@ -1965,7 +1965,7 @@ function Set-SafeguardDirectoryAccountPassword
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($local:AccountId)/Password" `
             -Body $local:PasswordPlainText -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -2040,7 +2040,7 @@ function New-SafeguardDirectoryAccountRandomPassword
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
         {
@@ -2053,7 +2053,7 @@ function New-SafeguardDirectoryAccountRandomPassword
         }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/GeneratePassword" -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -2127,7 +2127,7 @@ function Test-SafeguardDirectoryAccountPassword
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
         {
@@ -2140,7 +2140,7 @@ function Test-SafeguardDirectoryAccountPassword
         }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/CheckPassword" -LongRunningTask -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -2214,7 +2214,7 @@ function Invoke-SafeguardDirectoryAccountPasswordChange
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
         {
@@ -2227,7 +2227,7 @@ function Invoke-SafeguardDirectoryAccountPasswordChange
         }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "DirectoryAccounts/$($local:AccountId)/ChangePassword" -LongRunningTask -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {
@@ -2301,7 +2301,7 @@ function Remove-SafeguardDirectoryAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         if ($PSBoundParameters.ContainsKey("DirectoryToUse"))
         {
@@ -2314,7 +2314,7 @@ function Remove-SafeguardDirectoryAccount
         }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "DirectoryAccounts/$($local:AccountId)" -Version 2
     }
-    catch 
+    catch
     {
         if ($_.Exception.HttpStatusCode -eq 404 -or $_.Exception.HttpStatusCode -eq 405)
         {

--- a/src/entitlements.psm1
+++ b/src/entitlements.psm1
@@ -70,6 +70,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER EntitlementToGet
 An integer containing the ID or a string containing the name of the entitlement to get.
 
+.PARAMETER Fields
+An array of the entitlement property names to return.
+
 .INPUTS
 None.
 
@@ -96,20 +99,30 @@ function Get-SafeguardEntitlement
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [object]$EntitlementToGet
+        [object]$EntitlementToGet,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
     if ($PSBoundParameters.ContainsKey("EntitlementToGet"))
     {
         $local:EntitlementId = Resolve-SafeguardEntitlementId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $EntitlementToGet
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Roles/$($local:EntitlementId)"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            GET "Roles/$($local:EntitlementId)" -Parameters $local:Parameters
     }
     else
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Roles
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            GET Roles -Parameters $local:Parameters
     }
 }
 

--- a/src/entitlements.psm1
+++ b/src/entitlements.psm1
@@ -114,7 +114,8 @@ Create a new Entitlement in Safeguard via the Web API.
 
 .DESCRIPTION
 Create a new Entitlement in Safeguard. Access policies can be attached 
-to Entitlements. Users and groups can be  
+to Entitlements. Users and groups can be created using separate cmdlets
+and added as members via this cmdlet.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -128,7 +129,7 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER Name
 The name of the entitlement.
 
-.PARAMETER $MemberUsers
+.PARAMETER MemberUsers
 Array of Id or name of the users to be added to the entitlement
 
 .INPUTS

--- a/src/entitlements.psm1
+++ b/src/entitlements.psm1
@@ -118,7 +118,7 @@ function Get-SafeguardEntitlement
 Create a new Entitlement in Safeguard via the Web API.
 
 .DESCRIPTION
-Create a new Entitlement in Safeguard. Access policies can be attached 
+Create a new Entitlement in Safeguard. Access policies can be attached
 to Entitlements. Users and groups can be created using separate cmdlets
 and added as members via this cmdlet.
 
@@ -135,7 +135,10 @@ Ignore verification of Safeguard appliance SSL certificate.
 The name of the entitlement.
 
 .PARAMETER MemberUsers
-Array of Id or name of the users to be added to the entitlement
+Array of IDs or names of the users to be added to the entitlement.
+
+.PARAMETER MemberGroups
+Array of IDs or names of the users to be added to the entitlement.
 
 .INPUTS
 None.
@@ -191,6 +194,8 @@ function New-SafeguardEntitlement
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST Roles `
         -Body @{ Name = $Name; Members = $local:Members}
 }
+
+
 
 <#
 .SYNOPSIS

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -15,7 +15,7 @@ function Resolve-SubscriptionEvent
         [string[]]$EventsToValidate
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     [string[]]$InvalidEvents = $null

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -26,7 +26,7 @@ function Resolve-SubscriptionEvent
     {
         if (-not $EventNames.Contains($IndividualEvent))
         {
-            $InvalidEvents += $IndividualEvent 
+            $InvalidEvents += $IndividualEvent
         }
         $local:SubscriptionEvent = @{
             Name = $IndividualEvent
@@ -142,8 +142,8 @@ function Get-SafeguardEventName
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false, Position=0)]
-        [ValidateSet('Asset', 'AssetAccount', 'Directory', 'DirectoryAccount', 'IdentityProvider', 'User', 'UserGroup', 'AssetPartition', 'PartitionProfileAccountDiscoverySchedule', 
-        'PartitionAccountPasswordRule', 'PartitionProfileChangeSchedule', 'PartitionProfileCheckSchedule', 'PartitionProfile','AccessPolicy', 'AccountGroup', 'AssetGroup', 
+        [ValidateSet('Asset', 'AssetAccount', 'Directory', 'DirectoryAccount', 'IdentityProvider', 'User', 'UserGroup', 'AssetPartition', 'PartitionProfileAccountDiscoverySchedule',
+        'PartitionAccountPasswordRule', 'PartitionProfileChangeSchedule', 'PartitionProfileCheckSchedule', 'PartitionProfile','AccessPolicy', 'AccountGroup', 'AssetGroup',
         'Role', 'ReasonCode', 'DirectoryAccountDiscoveryJob', 'DirectoryAccountPasswordRule', 'DirectoryProfileChangeSchedule', 'DirectoryProfileCheckSchedule', 'DirectoryProfile',
         'ArchiveServer', 'TicketSystem', 'PartitionTag', 'PartitionTaggingRule', 'DirectoryTag', 'DirectoryTaggingRule', 'DynamicGroupingRule', IgnoreCase=$true)]
         [object]$TypeofEvent
@@ -176,8 +176,8 @@ Get event subscription in Safeguard via the Web API.
 
 .DESCRIPTION
 Event subscription is a subscription to receive notifications when an event occurs.
-Event subscription can be created for all type of users but can only be created by 
-an administrative user. One event subscriber can subscribe to multiple events. 
+Event subscription can be created for all type of users but can only be created by
+an administrative user. One event subscriber can subscribe to multiple events.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -219,7 +219,7 @@ function Get-SafeguardEventSubscription
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     if ($PSBoundParameters.ContainsKey("SubscriptionId"))
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "EventSubscribers/$SubscriptionId"
@@ -309,8 +309,8 @@ Create a new event subscription in Safeguard via the Web API.
 
 .DESCRIPTION
 Event subscription is a subscription to receive notifications when an event occurs.
-Event subscription can be created for all type of users but can only be created by 
-an administrative user. One event subscriber can subscribe to multiple events. 
+Event subscription can be created for all type of users but can only be created by
+an administrative user. One event subscriber can subscribe to multiple events.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -423,21 +423,21 @@ function New-SafeguardEventSubscription
         [Parameter(ParameterSetName='SyslogEvent')][switch]$IsSyslogEvent,
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$true)][string]$SyslogNetworkAddress,
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$false)][Int]$SyslogPort,
-        [ValidateSet('Kernel', 'User', 'Mail', 'Daemons', 'Authorization', 'Syslog', 'Printer', 'News', 'Uucp', 'Clock', 'Authorization2', 'Ftp', 
+        [ValidateSet('Kernel', 'User', 'Mail', 'Daemons', 'Authorization', 'Syslog', 'Printer', 'News', 'Uucp', 'Clock', 'Authorization2', 'Ftp',
         'Ntp', 'Audit','Alert', 'Clock2', 'Local0', 'Local1', 'Local2', 'Local3', 'Local4', 'Local5', 'Local6', 'Local7', IgnoreCase=$true)]
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$false)][object]$SyslogFacility
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     #Resolve events to be subscribed
     [object[]]$SubscriptionEvents = Resolve-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $ObjectTypeToSubscribe -EventsToValidate $SubscriptionEvent
-    
+
     #Resolve the object to be subscribed
     switch ($ObjectTypeToSubscribe)
     {
-        "Asset"{ $ObjectIdToSubscribe = (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $ObjectIdToSubscribe).Id; break } 
+        "Asset"{ $ObjectIdToSubscribe = (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $ObjectIdToSubscribe).Id; break }
         "AssetAccount"{ $ObjectIdToSubscribe = (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $ObjectIdToSubscribe).Id;  break }
         "DirectoryAccount"{ $ObjectIdToSubscribe = (Get-SafeguardDirectoryAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $ObjectIdToSubscribe).Id; break }
     }
@@ -451,10 +451,10 @@ function New-SafeguardEventSubscription
     }
 
     #Common parameters
-    if ($PSBoundParameters.ContainsKey("UserToSubscribe")) 
+    if ($PSBoundParameters.ContainsKey("UserToSubscribe"))
     {
         $local:User = Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $UserToSubscribe
-        $local:Body.UserId = $($local:User).Id  
+        $local:Body.UserId = $($local:User).Id
     }
     if ($PSBoundParameters.ContainsKey("Description")) {$local:Body.Description = $Description}
     if ($PSBoundParameters.ContainsKey("EmailAddress")) {$local:Body.EmailAddress = $EmailAddress}
@@ -474,7 +474,7 @@ function New-SafeguardEventSubscription
         NetworkAddress = $null
     }
     if ($PSBoundParameters.ContainsKey("SyslogNetworkAddress")) {$local:SyslogProperties.NetworkAddress = $SyslogNetworkAddress}
-    if ($PSBoundParameters.ContainsKey("SyslogPort")) {$local:SyslogProperties.Port = $SyslogPort}  
+    if ($PSBoundParameters.ContainsKey("SyslogPort")) {$local:SyslogProperties.Port = $SyslogPort}
     if ($PSBoundParameters.ContainsKey("SyslogFacility")) {$local:SyslogProperties.Facility = $SyslogFacility}
     $local:Body.SyslogProperties = $local:SyslogProperties
 
@@ -505,8 +505,8 @@ Update an existing event subscription in Safeguard via the Web API.
 
 .DESCRIPTION
 Event subscription is a subscription to receive notifications when an event occurs.
-Event subscription can be created for all type of users but can only be created by 
-an administrative user. One event subscriber can subscribe to multiple events. 
+Event subscription can be created for all type of users but can only be created by
+an administrative user. One event subscriber can subscribe to multiple events.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -614,7 +614,7 @@ function Edit-SafeguardEventSubscription
         [string]$Description,
         [Parameter(Mandatory=$false)]
         [switch]$IsSignalrEvent,
-        
+
         [Parameter(ParameterSetName='Object', Mandatory=$false)]
         [object]$SubscriptionObject,
 
@@ -630,7 +630,7 @@ function Edit-SafeguardEventSubscription
         [Parameter(ParameterSetName='SyslogEvent')][switch]$IsSyslogEvent,
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$true)][string]$SyslogNetworkAddress,
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$false)][Int]$SyslogPort,
-        [ValidateSet('Kernel', 'User', 'Mail', 'Daemons', 'Authorization', 'Syslog', 'Printer', 'News', 'Uucp', 'Clock', 'Authorization2', 'Ftp', 
+        [ValidateSet('Kernel', 'User', 'Mail', 'Daemons', 'Authorization', 'Syslog', 'Printer', 'News', 'Uucp', 'Clock', 'Authorization2', 'Ftp',
         'Ntp', 'Audit','Alert', 'Clock2', 'Local0', 'Local1', 'Local2', 'Local3', 'Local4', 'Local5', 'Local6', 'Local7', IgnoreCase=$true)]
         [Parameter(ParameterSetName='SyslogEvent', Mandatory=$false)][object]$SyslogFacility
     )
@@ -643,22 +643,22 @@ function Edit-SafeguardEventSubscription
         #Resolve events contained in the SubscriptionObject
         ForEach($IndividualEvent in $SubscriptionObject.Subscriptions)
         {
-            [string[]]$local:Events += $IndividualEvent.Name          
+            [string[]]$local:Events += $IndividualEvent.Name
         }
         [object[]]$SubscriptionEvents = Resolve-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $SubscriptionObject.ObjectType -EventsToValidate $Events
         $SubscriptionObject.Subscriptions = $SubscriptionEvents
-        
+
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "EventSubscribers/$($SubscriptionObject.Id)" -Body $SubscriptionObject
         return
     }
-    
+
     if(-not $PSBoundParameters.ContainsKey("SubscriptionId"))
     {
         $SubscriptionId = (Read-Host "SubscriptionId")
     }
-    
+
     $local:Body = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "EventSubscribers/$SubscriptionId"
-    
+
     if($PSBoundParameters.ContainsKey("ObjectTypeToSubscribe")) {$local:Body.ObjectType = $ObjectTypeToSubscribe}
 
     #Resolve events to be subscribed
@@ -670,7 +670,7 @@ function Edit-SafeguardEventSubscription
     {
         ForEach($IndividualEvent in $local:Body.Subscriptions)
         {
-            [string[]]$local:Events += $IndividualEvent.Name          
+            [string[]]$local:Events += $IndividualEvent.Name
         }
         [object[]]$SubscriptionEvents = Resolve-SubscriptionEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $local:Body.ObjectType -EventsToValidate $Events
     }
@@ -681,7 +681,7 @@ function Edit-SafeguardEventSubscription
     {
         switch ($local:Body.ObjectType)
         {
-            "Asset"{ $ObjectIdToSubscribe = (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $ObjectIdToSubscribe).Id; break } 
+            "Asset"{ $ObjectIdToSubscribe = (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $ObjectIdToSubscribe).Id; break }
             "AssetAccount"{ $ObjectIdToSubscribe = (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $ObjectIdToSubscribe).Id;  break }
             "DirectoryAccount"{ $ObjectIdToSubscribe = (Get-SafeguardDirectoryAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AccountToGet $ObjectIdToSubscribe).Id; break }
         }
@@ -690,10 +690,10 @@ function Edit-SafeguardEventSubscription
     if ($PSBoundParameters.ContainsKey("IsSignalrEvent")) {$local:Body.Type = "SignalR"}
 
     #Common parameters
-    if ($PSBoundParameters.ContainsKey("UserToSubscribe")) 
+    if ($PSBoundParameters.ContainsKey("UserToSubscribe"))
     {
         $local:User = Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $UserToSubscribe
-        $local:Body.UserId = $($local:User).Id  
+        $local:Body.UserId = $($local:User).Id
     }
     if ($PSBoundParameters.ContainsKey("Description")) {$local:Body.Description = $Description}
     if ($PSBoundParameters.ContainsKey("EmailAddress")) {$local:Body.EmailAddress = $EmailAddress}
@@ -713,7 +713,7 @@ function Edit-SafeguardEventSubscription
         NetworkAddress = $null
     }
     if ($PSBoundParameters.ContainsKey("SyslogNetworkAddress")) {$local:SyslogProperties.NetworkAddress = $SyslogNetworkAddress}
-    if ($PSBoundParameters.ContainsKey("SyslogPort")) {$local:SyslogProperties.Port = $SyslogPort}  
+    if ($PSBoundParameters.ContainsKey("SyslogPort")) {$local:SyslogProperties.Port = $SyslogPort}
     if ($PSBoundParameters.ContainsKey("SyslogFacility")) {$local:SyslogProperties.Facility = $SyslogFacility}
     $local:Body.SyslogProperties = $local:SyslogProperties
 
@@ -751,8 +751,8 @@ Remove an event subscription in Safeguard via the Web API.
 
 .DESCRIPTION
 Event subscription is a subscription to receive notifications when an event occurs.
-Event subscription can be created for all type of users but can only be created by 
-an administrative user. One event subscriber can subscribe to multiple events. 
+Event subscription can be created for all type of users but can only be created by
+an administrative user. One event subscriber can subscribe to multiple events.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -791,7 +791,7 @@ function Remove-SafeguardEventSubscription
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "EventSubscribers/$SubscriptionId"
 
 }

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -14,13 +14,17 @@ function Resolve-SubscriptionEvent
         [Parameter(Mandatory=$true,Position=1)]
         [string[]]$EventsToValidate
     )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
     [string[]]$InvalidEvents = $null
     [object[]]$SubscriptionEvents = $null
     [string[]]$EventNames = Get-SafeguardEventName -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -TypeOfEvent $TypeOfEvent
-    
-    ForEach ($IndividualEvent in $EventsToValidate)
+
+    foreach ($IndividualEvent in $EventsToValidate)
     {
-        if(-Not $EventNames.Contains($IndividualEvent))
+        if (-not $EventNames.Contains($IndividualEvent))
         {
             $InvalidEvents += $IndividualEvent 
         }
@@ -30,7 +34,7 @@ function Resolve-SubscriptionEvent
         $SubscriptionEvents += $local:SubscriptionEvent
     }
 
-    if($InvalidEvents -ne $null)
+    if ($null -ne $InvalidEvents)
     {
         $InvalidEventsList = $InvalidEvents -join ","
         Write-Error -Message "The following are not valid $ObjectTypeToSubscribe events: $InvalidEventsList." -Category InvalidArgument -ErrorAction Stop

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -419,7 +419,7 @@ function Remove-SafeguardUserGroup
 Edits a user group to add or remove an existing user in Safeguard via the Web API.
 
 .DESCRIPTION
-When a user group is edited the changes also propagates to any entitlements where it may have been used
+When a user group is edited the changes also propagates to any entitlements where it may have been used.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -431,14 +431,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER GroupToEdit
-Name of the group to edit
+Name of the user group to edit
 
 .PARAMETER Operation
 String of type of operation to be perfomed on the user group. 'Add' to add users to the user group
-'Remove' to removed users from the user group
+'Remove' to removed users from the user group.
 
 .PARAMETER UserList
-An array of usernames of the users to be added or removed in the users group
+An array of user IDs or names of the users to be added or removed in the user group.
 
 .INPUTS
 None.
@@ -474,14 +474,14 @@ function Edit-SafeguardUserGroup
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
     
-    [object[]]$Users = $null
-    ForEach($user in $UserList)
+    [object[]]$local:Users = $null
+    foreach ($local:User in $UserList)
     {
-        $local:ResolvedUser = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $User)
+        $local:ResolvedUser = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $local:User)
         $local:Users += $($local:ResolvedUser)
     }
 
-    Edit-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure User $GroupToEdit $Operation $Users
+    Edit-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure User $GroupToEdit $Operation $local:Users
 }
 
 <#
@@ -650,6 +650,76 @@ function Remove-SafeguardAssetGroup
 
 <#
 .SYNOPSIS
+Edits an asset group to add or remove an existing assets in Safeguard via the Web API.
+
+.DESCRIPTION
+When an asset group is edited the changes also propagates to any entitlements where it may have been used.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER GroupToEdit
+Name of the asset group to edit.
+
+.PARAMETER Operation
+String of type of operation to be perfomed on the asset group. 'Add' to add assets to the asset group
+'Remove' to removed assets from the asset group.
+
+.PARAMETER AssetList
+An array of names or IDs of the assets to be added or removed in the asset group.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Edit-SafeguardAssetGroup testassetgroup add testasset1,testasset2
+
+.EXAMPLE
+Edit-SafeguardAssetGroup testassetgroup remove testasset1
+#>
+function Edit-SafeguardAssetGroup
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [object]$GroupToEdit,
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateSet("Add", "Remove", IgnoreCase=$true)]
+        [string]$Operation,
+        [Parameter(Mandatory=$true, Position=2)]
+        [object[]]$AssetList
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+    
+    [object[]]$local:Assets = $null
+    foreach ($local:Asset in $AssetList)
+    {
+        $local:ResolvedAsset = (Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $local:Asset)
+        $local:Assets += $($local:ResolvedAsset)
+    }
+
+    Edit-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Asset $GroupToEdit $Operation $local:Assets
+}
+
+<#
+.SYNOPSIS
 Get account groups as defined by policy administrators that can added to access policy scopes
 via the Web API.
 
@@ -809,4 +879,80 @@ function Remove-SafeguardAccountGroup
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Remove-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Account $GroupToDelete
+}
+
+<#
+.SYNOPSIS
+Edits an account group to add or remove an existing accounts in Safeguard via the Web API.
+
+.DESCRIPTION
+When an account group is edited the changes also propagates to any entitlements where it may have been used.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER GroupToEdit
+Name of the account group to edit.
+
+.PARAMETER Operation
+String of type of operation to be perfomed on the account group. 'Add' to add accounts to the account group
+'Remove' to removed accounts from the account group.
+
+.PARAMETER AccountList
+An array of ID or name pairs of the format '<asset>\<account>' to be added or removed in the account group.
+For example: 23\55,asset1\account1,asset1\342
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Edit-SafeguardAccountGroup testaccountgroup add testaccount1,testaccount2
+
+.EXAMPLE
+Edit-SafeguardAccountGroup testaccountgroup remove testaccount1
+#>
+function Edit-SafeguardAccountGroup
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [object]$GroupToEdit,
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateSet("Add", "Remove", IgnoreCase=$true)]
+        [string]$Operation,
+        [Parameter(Mandatory=$true, Position=2)]
+        [object[]]$AccountList
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+    
+    [object[]]$local:Accounts = $null
+    foreach ($local:AccountPair in $AccountList)
+    {
+        $local:Pair = ($local:AccountPair -split "\\")
+        if ($local:Pair.Length -ne 2)
+        {
+            throw "Unable to parse account '$($local:AccountPair)' into asset and account"
+        }
+        $local:ResolvedAccount = (Get-SafeguardAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetToGet $local:Pair[0] -AccountToGet $local:Pair[1])
+        $local:Accounts += $($local:ResolvedAccount)
+    }
+
+    Edit-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Account $GroupToEdit $Operation $local:Accounts
 }

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -29,6 +29,11 @@ function Resolve-SafeguardGroupId
 
     $local:RelativeUrl = "$($GroupType)Groups"
 
+    if ($Group.Id -as [int])
+    {
+        $Group = $Group.Id
+    }
+
     if (-not ($Group -as [int]))
     {
         $local:Groups = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -37,7 +37,7 @@ function Resolve-SafeguardGroupId
     if (-not ($Group -as [int]))
     {
         $local:Groups = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                                -Parameters @{ filter = "Name ieq '$Group'" } -RetryVersion 2 -RetryUrl "$local:RelativeUrl") 
+                                                -Parameters @{ filter = "Name ieq '$Group'" } -RetryVersion 2 -RetryUrl "$local:RelativeUrl")
         if (-not $local:Groups)
         {
             throw "Unable to find $($GroupType.ToLower()) group matching '$Group'"
@@ -282,7 +282,7 @@ A string containing the bearer token to be used with Safeguard Web API.
 Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER Name
-A string containing the name for the new group.  For groups based on a directory, this must 
+A string containing the name for the new group.  For groups based on a directory, this must
 match the sAMAccountName for Active Directory or the unique naming attribute of the group
 for LDAP.
 
@@ -484,7 +484,7 @@ function Edit-SafeguardUserGroup
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     [object[]]$local:Users = $null
     foreach ($local:User in $UserList)
     {
@@ -718,7 +718,7 @@ function Edit-SafeguardAssetGroup
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     [object[]]$local:Assets = $null
     foreach ($local:Asset in $AssetList)
     {
@@ -952,7 +952,7 @@ function Edit-SafeguardAccountGroup
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     [object[]]$local:Accounts = $null
     foreach ($local:AccountPair in $AccountList)
     {

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -716,7 +716,7 @@ function Edit-SafeguardAssetGroup
         [object[]]$AssetList
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     [object[]]$local:Assets = $null
@@ -950,7 +950,7 @@ function Edit-SafeguardAccountGroup
         [object[]]$AccountList
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     [object[]]$local:Accounts = $null

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -85,11 +85,13 @@ function Get-SafeguardGroup
     if ($PSBoundParameters.ContainsKey("GroupToGet") -and $GroupToGet)
     {
         $local:GroupId = Resolve-SafeguardGroupId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $GroupType $GroupToGet
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$local:RelativeUrl/$($local:GroupId)" -RetryVersion 2 -RetryUrl "$local:RelativeUrl/$($local:GroupId)"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$local:RelativeUrl/$($local:GroupId)" `
+            -RetryVersion 2 -RetryUrl "$local:RelativeUrl/$($local:GroupId)"
     }
     else
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl -RetryVersion 2 -RetryUrl "$local:RelativeUrl"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+            -RetryVersion 2 -RetryUrl "$local:RelativeUrl"
     }
 }
 function New-SafeguardGroup
@@ -126,7 +128,8 @@ function New-SafeguardGroup
     $local:Body = @{ Name = $Name }
     if ($PSBoundParameters.ContainsKey("Description")) { $local:Body.Description = $Description }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST $local:RelativeUrl -Body $local:Body -RetryVersion 2 -RetryUrl "$local:RelativeUrl"
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST $local:RelativeUrl `
+        -Body $local:Body -RetryVersion 2 -RetryUrl "$local:RelativeUrl"
 }
 function Remove-SafeguardGroup
 {
@@ -158,7 +161,8 @@ function Remove-SafeguardGroup
     $local:RelativeUrl = "$($GroupType)Groups"
     $local:GroupId = (Resolve-SafeguardGroupId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $GroupType $GroupToDelete)
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "$($local:RelativeUrl)/$($local:GroupId)" -Body $local:Body -RetryVersion 2 -RetryUrl "$($local:RelativeUrl)/$($local:GroupId)"
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "$($local:RelativeUrl)/$($local:GroupId)" `
+        -Body $local:Body -RetryVersion 2 -RetryUrl "$($local:RelativeUrl)/$($local:GroupId)"
 }
 function Edit-SafeguardGroup
 {
@@ -195,7 +199,12 @@ function Edit-SafeguardGroup
     $local:RelativeUrl = "$($GroupType)Groups"
     $local:GroupId = (Resolve-SafeguardGroupId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $GroupType $GroupToEdit)
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "$($local:RelativeUrl)/$($local:GroupId)/Members/$Operation" -Body $ObjectToOperate -RetryVersion 2 -RetryUrl "$($local:RelativeUrl)/$($local:GroupId)/Members/$Operation"
+    # Modify the group using add or remove endpoint
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "$($local:RelativeUrl)/$($local:GroupId)/Members/$Operation" `
+        -Body $ObjectToOperate -RetryVersion 2 -RetryUrl "$($local:RelativeUrl)/$($local:GroupId)/Members/$Operation" | Out-Null
+
+    # Get the result by fetching the group
+    Get-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -GroupType $GroupType -GroupToGet $local:GroupId
 }
 
 <#

--- a/src/licensing.psm1
+++ b/src/licensing.psm1
@@ -64,7 +64,7 @@ function Install-SafeguardLicense
         $local:LicenseBase64 = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($local:LicenseContents))
         Write-Host "Uploading license file..."
         $local:StagedLicense = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST Licenses -Body @{
-                Base64Data = "$($local:LicenseBase64)" 
+                Base64Data = "$($local:LicenseBase64)"
             })
 
         if ($StageOnly)

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -161,7 +161,7 @@ function Get-SafeguardApplianceState
 Get the version of a Safeguard appliance via the Web API.
 
 .DESCRIPTION
-Get the version information from a Safeguard appliance which will 
+Get the version information from a Safeguard appliance which will
 be returned as an object containing major.minor.revision.build
 portions separated into different properties.
 
@@ -1146,7 +1146,7 @@ function Install-SafeguardPatch
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    
+
     if ($SafeguardSession)
     {
         $Insecure = $SafeguardSession["Insecure"]

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardPolicyAssetId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($Asset.Id -as [int])
+    {
+        $Asset = $Asset.Id
+    }
+
     if (-not ($Asset -as [int]))
     {
         try
@@ -68,6 +73,11 @@ function Resolve-SafeguardPolicyAccountId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Account.Id -as [int])
+    {
+        $Account = $Account.Id
+    }
 
     if (-not ($Account -as [int]))
     {
@@ -123,6 +133,11 @@ function Resolve-SafeguardAccessPolicyId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($AccessPolicy.Id -as [int])
+    {
+        $AccessPolicy = $AccessPolicy.Id
+    }
 
     if (-not ($AccessPolicy -as [int]))
     {

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -572,7 +572,7 @@ function Get-SafeguardAccessPolicy
 Get scope items of an access policy in Safeguard via the Web API.
 
 .DESCRIPTION
-Scope items is a set of accounts, assets, account groups and asset groups that are explicitely assigned to an access policy 
+Scope items is a set of accounts, assets, account groups and asset groups that are explicitely assigned to an access policy
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.

--- a/src/ps-utilities.psm1
+++ b/src/ps-utilities.psm1
@@ -19,7 +19,7 @@ function Get-Confirmation
     $Yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", $YesDescription
     $No = New-Object System.Management.Automation.Host.ChoiceDescription "&No", $NoDescription
     $Options = [System.Management.Automation.Host.ChoiceDescription[]]($Yes, $No)
-    $Result = $host.ui.PromptForChoice($Title, $Message, $Options, 0) 
+    $Result = $host.ui.PromptForChoice($Title, $Message, $Options, 0)
     switch ($result)
     {
         0 {$true}
@@ -101,7 +101,7 @@ function Get-CertificateFileContents
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    try 
+    try
     {
         $local:CertificateFullPath = (Resolve-Path $CertificateFile).ToString()
         if ((Get-Item $local:CertificateFullPath).Length -gt 100kb)
@@ -141,7 +141,7 @@ function Get-Tool
     {
         Write-Host "Searching $($local:SearchPath) for $Tool"
         $local:ToolPath = (Get-ChildItem -Recurse -EA SilentlyContinue $local:SearchPath | Where-Object { $_.Name -eq $Tool })
-        if ($local:ToolPath.Length -gt 0) 
+        if ($local:ToolPath.Length -gt 0)
         {
             $local:ToolPath[-1].Fullname
             return

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -406,6 +406,9 @@ function New-SafeguardAccessRequest
         {
             $AccountToUse = (Read-Host "AccountToUse")
         }
+    }
+    if ($AccountToUse)
+    {
         $local:AccountId = (Resolve-SafeguardRequestableAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
     }
     else 

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1253,6 +1253,64 @@ function Get-SafeguardAccessRequestSshUrl
 
 <#
 .SYNOPSIS
+Generate an RDP URL for an access request via the Web API.
+
+.DESCRIPTION
+POST to the AccessRequests endpoint.  This script allows you to InitializeSession
+on an approved access request and generate an RDP URL that can be used with an
+RDP client.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.PARAMETER 
+
+.INPUTS
+None.
+
+.OUTPUTS
+A string containing the RDP URL.
+
+.EXAMPLE
+Get-SafeguardAccessRequestRdpUrl 8518-1-18B1694CF1C0-0026
+#>
+function Get-SafeguardAccessRequestRdpUrl
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:SessionData = (Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId InitializeSession)
+    if (-not $local:SessionData.RdpConnectionString)
+    {
+        throw "Initialized session did not return RDP connection information"
+    }
+
+    $local:SessionData.ConnectionUri
+}
+
+<#
+.SYNOPSIS
 Launch an SSH or RDP session for an access request via the Web API.
 
 .DESCRIPTION

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardRequestableAssetId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($Asset.Id -as [int])
+    {
+        $Asset = $Asset.Id
+    }
+
     if (-not ($Asset -as [int]))
     {
         try
@@ -68,6 +73,11 @@ function Resolve-SafeguardRequestableAccountId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Account.Id -as [int])
+    {
+        $Account = $Account.Id
+    }
 
     if (-not ($Account -as [int]))
     {

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1496,3 +1496,101 @@ function Deny-SafeguardAccessRequest
     Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Deny
 }
 New-Alias -Name Revoke-SafeguardAccessRequest -Value Deny-SafeguardAccessRequest
+
+<#
+.SYNOPSIS
+Get action log to review an access request via the Web API.
+
+.DESCRIPTION
+You can use this cmdlet to review before calling the
+Assert-SafeguardAccessRequest cmdlet.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardAccessRequestActionLog 8518-1-18B1694CF1C0-0026
+#>
+function Get-SafeguardAccessRequestActionLog
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    (Get-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId -AllFields).WorkflowActions
+}
+
+<#
+.SYNOPSIS
+Mark an access request as reviewed via the Web API.
+
+.DESCRIPTION
+This cmdlet marks an access request as reviewed.  You can use the
+Get-SafeguardAccessRequestActionLog to review before calling this cmdlet.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Assert-SafeguardAccessRequest 8518-1-18B1694CF1C0-0026
+#>
+function Assert-SafeguardAccessRequest
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Review
+}

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1003,7 +1003,7 @@ A string containing the ID of the access request.
 None.
 
 .OUTPUTS
-JSON response from Safeguard Web API.
+A string containing the password.
 
 .EXAMPLE
 Get-SafeguardAccessRequestPassword 8518-1-18B1694CF1C0-0026
@@ -1028,6 +1028,55 @@ function Get-SafeguardAccessRequestPassword
     Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId CheckOutPassword
 }
 New-Alias -Name Get-SafeguardAccessRequestCheckoutPassword -Value Get-SafeguardAccessRequestPassword
+
+<#
+.SYNOPSIS
+Checks out the password for an access request via the Web API and copies it to the clipboard.
+
+.DESCRIPTION
+POST to the AccessRequests endpoint.  This script allows you to CheckoutPassword
+on an approved access request.  Then puts the value on the clipboard without displaying it.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.INPUTS
+None.
+
+.OUTPUTS
+None.
+
+.EXAMPLE
+Copy-SafeguardAccessRequestPassword 8518-1-18B1694CF1C0-0026
+#>
+function Copy-SafeguardAccessRequestPassword
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Set-Clipboard -Value (Get-SafeguardAccessRequestPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
+}
 
 <#
 .SYNOPSIS
@@ -1056,7 +1105,7 @@ A string containing the ID of the access request.
 None.
 
 .OUTPUTS
-JSON response from Safeguard Web API.
+Path to the RDP file.
 
 .EXAMPLE
 Get-SafeguardAccessRequestRdpFile 8518-1-18B1694CF1C0-0026
@@ -1151,7 +1200,7 @@ A string containing the ID of the access request.
 None.
 
 .OUTPUTS
-JSON response from Safeguard Web API.
+A string containing the SSH URL.
 
 .EXAMPLE
 Get-SafeguardAccessRequestSshUrl 8518-1-18B1694CF1C0-0026
@@ -1209,7 +1258,7 @@ A string containing the ID of the access request.
 None.
 
 .OUTPUTS
-JSON response from Safeguard Web API.
+None.
 
 .EXAMPLE
 Start-SafeguardAccessRequestSession 8518-1-18B1694CF1C0-0026

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -133,7 +133,8 @@ function New-RequestableAccountObject
             PlatformDisplayName = $Asset.PlatformDisplayName;
             SshHostKey = $Asset.SshHostKey;
             SshHostKeyFingerprint = $Asset.SshHostKeyFingerprint;
-            SessionAccessProperties = $Asset.SessionAccessProperties;
+            SshSessionPort = $Asset.SessionAccessProperties.SshSessionPort;
+            RdpSessionPort = $Asset.SessionAccessProperties.RemoteDesktopSessionPort;
             AccountId = $Account.Id;
             AccountNetBiosName = $Account.NetBiosName;
             AccountDomainName = $Account.DomainName;
@@ -149,6 +150,7 @@ function New-RequestableAccountObject
             AssetId = $Asset.Id;
             AssetName = $Asset.Name;
             NetworkAddress = $Asset.NetworkAddress;
+            PlatformDisplayName = $Asset.PlatformDisplayName;
             AccountId = $Account.Id;
             AccountDomainName = $Account.DomainName;
             AccountName = $Account.Name;

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1309,6 +1309,7 @@ function Start-SafeguardAccessRequestSession
         }
         "RemoteDesktop" {
             $local:OutFile = "$(Join-Path $([System.IO.Path]::GetTempPath()) "$($local:AccessRequest.Id).rdp")"
+            Write-Verbose "RDP file location: $($local:OutFile)"
             & (Get-SafeguardAccessRequestRdpFile $RequestId -OutFile $local:OutFile)
             break
         }

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -545,10 +545,13 @@ function Edit-SafeguardAccessRequest
 
 <#
 .SYNOPSIS
-Get all requestable Safeguard accounts for this user via the Web API.
+Get all access requests that this user can take action on via the Web API.
 
 .DESCRIPTION
-Call the Me endpoint to see all actionable requests.
+Call the Me endpoint to see all actionable requests.  This will return access
+requests for which this user is the requester, an approver, or a reviewer.  If
+this user is a policy admininstrator all access requests will also be returned
+in the admin context.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -644,6 +647,161 @@ function Get-SafeguardActionableRequest
     }
 }
 
+<#
+.SYNOPSIS
+Get all access requests that this user has requested via the Web API.
+
+.DESCRIPTION
+Call the Me endpoint to see all actionable requests.  This will return access
+requests for which this user is the requester.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardMyRequest -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardMyRequest
+#>
+function Get-SafeguardMyRequest
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Requester -AllFields:$AllFields
+}
+
+<#
+.SYNOPSIS
+Get all access requests that this user can approve via the Web API.
+
+.DESCRIPTION
+Call the Me endpoint to see all actionable requests.  This will return access
+requests for which this user is an approver.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardMyApproval -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardMyApproval
+#>
+function Get-SafeguardMyApproval
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Approver -AllFields:$AllFields
+}
+
+<#
+.SYNOPSIS
+Get all access requests that this user can review via the Web API.
+
+.DESCRIPTION
+Call the Me endpoint to see all actionable requests.  This will return access
+requests for which this user is a reviewer.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardMyReview -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardMyReview
+#>
+function Get-SafeguardMyReview
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Reviewer -AllFields:$AllFields
+}
 
 <#
 .SYNOPSIS
@@ -703,6 +861,7 @@ function Get-SafeguardRequestableAccount
         }
     }
 }
+New-Alias -Name Get-SafeguardMyRequestable -Value Get-SafeguardRequestableAccount
 
 <#
 .SYNOPSIS
@@ -818,6 +977,7 @@ function Find-SafeguardRequestableAccount
         }
     }
 }
+New-Alias -Name Find-SafeguardMyRequestable -Value Find-SafeguardRequestableAccount
 
 <#
 .SYNOPSIS

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -413,9 +413,9 @@ function New-SafeguardAccessRequest
     {
         $local:AccountId = (Resolve-SafeguardRequestableAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
     }
-    else 
+    else
     {
-        if ($PSBoundParameters.ContainsKey("AccountToUse")) 
+        if ($PSBoundParameters.ContainsKey("AccountToUse"))
         {
             # Try to resolve AccountId, but do not fail on error
             try {
@@ -870,7 +870,7 @@ New-Alias -Name Get-SafeguardMyRequestable -Value Get-SafeguardRequestableAccoun
 Find requestable accounts in Safeguard for this user via the Web API.
 
 .DESCRIPTION
-Search for a requestable account 
+Search for a requestable account
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -1117,7 +1117,7 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER 
+.PARAMETER
 
 .INPUTS
 None.
@@ -1214,7 +1214,7 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER 
+.PARAMETER
 
 .INPUTS
 None.
@@ -1272,7 +1272,7 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER 
+.PARAMETER
 
 .INPUTS
 None.
@@ -1330,7 +1330,7 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER 
+.PARAMETER
 
 .INPUTS
 None.
@@ -1450,7 +1450,7 @@ function Close-SafeguardAccessRequest
             }
             { "RequestCheckedIn","Terminated","PendingReview","PendingAccountSuspended" -contains $_ } {
                 Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Close -AllFields:$AllFields
-            } 
+            }
             { "Expired","PendingAcknowledgment" -contains $_ } {
                 Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Acknowledge -AllFields:$AllFields
             }

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1342,8 +1342,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER 
-
 .INPUTS
 None.
 
@@ -1351,7 +1349,7 @@ None.
 JSON response from Safeguard Web API.
 
 .EXAMPLE
-Start-SafeguardAccessRequestSession 8518-1-18B1694CF1C0-0026
+Close-SafeguardAccessRequest 8518-1-18B1694CF1C0-0026
 #>
 function Close-SafeguardAccessRequest
 {
@@ -1401,3 +1399,100 @@ function Close-SafeguardAccessRequest
         throw "You didn't request '$RequestId' and you are not a policy admin"
     }
 }
+
+<#
+.SYNOPSIS
+Approve an access request via the Web API.
+
+.DESCRIPTION
+This cmdlet approves an access request.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Approve-SafeguardAccessRequest 8518-1-18B1694CF1C0-0026
+#>
+function Approve-SafeguardAccessRequest
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Approve
+}
+
+<#
+.SYNOPSIS
+Deny an access request via the Web API.
+
+.DESCRIPTION
+This cmdlet denies or revokes an access request.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Deny-SafeguardAccessRequest 8518-1-18B1694CF1C0-0026
+#>
+function Deny-SafeguardAccessRequest
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Deny
+}
+New-Alias -Name Revoke-SafeguardAccessRequest -Value Deny-SafeguardAccessRequest

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -695,7 +695,7 @@ function Get-SafeguardMyRequest
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Requester -AllFields:$AllFields
@@ -747,7 +747,7 @@ function Get-SafeguardMyApproval
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Approver -AllFields:$AllFields
@@ -799,7 +799,7 @@ function Get-SafeguardMyReview
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Get-SafeguardActionableRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Reviewer -AllFields:$AllFields
@@ -1074,7 +1074,7 @@ function Copy-SafeguardAccessRequestPassword
         [string]$RequestId
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:Password = (Get-SafeguardAccessRequestPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
@@ -1144,7 +1144,7 @@ function Get-SafeguardAccessRequestRdpFile
         [string]$OutFile
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:SessionData = (Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId InitializeSession)
@@ -1239,7 +1239,7 @@ function Get-SafeguardAccessRequestSshUrl
         [string]$RequestId
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:SessionData = (Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId InitializeSession)
@@ -1297,7 +1297,7 @@ function Get-SafeguardAccessRequestRdpUrl
         [string]$RequestId
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:SessionData = (Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId InitializeSession)
@@ -1355,7 +1355,7 @@ function Start-SafeguardAccessRequestSession
         [string]$RequestId
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:AccessRequest = (Get-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
@@ -1431,7 +1431,7 @@ function Close-SafeguardAccessRequest
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:AccessRequest = (Get-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -1513,7 +1513,7 @@ function Approve-SafeguardAccessRequest
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Approve -AllFields:$AllFields
@@ -1566,7 +1566,7 @@ function Deny-SafeguardAccessRequest
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Deny -AllFields:$AllFields
@@ -1616,7 +1616,7 @@ function Get-SafeguardAccessRequestActionLog
         [string]$RequestId
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     (Get-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId -AllFields).WorkflowActions
@@ -1670,7 +1670,7 @@ function Assert-SafeguardAccessRequest
         [switch]$AllFields
     )
 
-    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Review -AllFields:$AllFields

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1006,7 +1006,7 @@ None.
 JSON response from Safeguard Web API.
 
 .EXAMPLE
-Get-SafeguardAccessRequestPassword 123
+Get-SafeguardAccessRequestPassword 8518-1-18B1694CF1C0-0026
 #>
 function Get-SafeguardAccessRequestPassword
 {
@@ -1031,7 +1031,7 @@ New-Alias -Name Get-SafeguardAccessRequestCheckoutPassword -Value Get-SafeguardA
 
 <#
 .SYNOPSIS
-Checkouts out password for an access request via the Web API.
+Generate an RDP file for an access request via the Web API.
 
 .DESCRIPTION
 POST to the AccessRequests endpoint.  This script allows you to InitializeSession
@@ -1059,7 +1059,7 @@ None.
 JSON response from Safeguard Web API.
 
 .EXAMPLE
-Get-SafeguardAccessRequestPassword 123
+Get-SafeguardAccessRequestRdpFile 8518-1-18B1694CF1C0-0026
 #>
 function Get-SafeguardAccessRequestRdpFile
 {
@@ -1121,5 +1121,135 @@ public class RdpPasswordEncrypter {
     $local:FakePassword = $local:Encrypter.GetEncryptedPassword("sg")
 
     Write-Output "password 51:b:$($local:FakePassword)" | Out-File -Append -Encoding ASCII -FilePath $OutFile
-    Write-Host "RDP file saved to '$OutFile'"
+    # return outfile name
+    (Resolve-Path $OutFile).Path
+}
+
+<#
+.SYNOPSIS
+Generate an SSH URL for an access request via the Web API.
+
+.DESCRIPTION
+POST to the AccessRequests endpoint.  This script allows you to InitializeSession
+on an approved access request and generate an SSH URL that works with OpenSSH client.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.PARAMETER 
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardAccessRequestSshUrl 8518-1-18B1694CF1C0-0026
+#>
+function Get-SafeguardAccessRequestSshUrl
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:SessionData = (Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId InitializeSession)
+    if (-not $local:SessionData.SshConnectionString)
+    {
+        throw "Initialized session did not return SSH connection information"
+    }
+
+    $local:SessionData.ConnectionUri
+}
+
+<#
+.SYNOPSIS
+Launch an SSH or RDP session for an access request via the Web API.
+
+.DESCRIPTION
+This cmdlet launches an SSH or RDP session from an approved access request.
+It requires the OpenSSH client for SSH sessions.  It is installed be default
+on the latest versions of Windows 10.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+A string containing the ID of the access request.
+
+.PARAMETER 
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Start-SafeguardAccessRequestSession 8518-1-18B1694CF1C0-0026
+#>
+function Start-SafeguardAccessRequestSession
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$RequestId
+    )
+
+    $ErrorActionPreference = "Stop"
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:AccessRequest = (Get-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
+    switch ($local:AccessRequest.AccessRequestType)
+    {
+        "Ssh" {
+            & ssh (Get-SafeguardAccessRequestSshUrl $RequestId)
+            break
+        }
+        "RemoteDesktop" {
+            $local:OutFile = "$(Join-Path $env:TEMP "$($local:AccessRequest.Id).rdp")"
+            & open (Get-SafeguardAccessRequestRdpFile $RequestId -OutFile $local:OutFile)
+            break
+        }
+        "Password" {
+            throw "You cannot launch a session for a password request"
+            break
+        }
+        default {
+            throw "Unrecognized access request type '$($local:AccessRequest.AccessRequestType)', don't know how to launch it"
+            break
+        }
+    }
 }

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1342,6 +1342,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
 .INPUTS
 None.
 
@@ -1362,7 +1365,9 @@ function Close-SafeguardAccessRequest
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true, Position=0)]
-        [string]$RequestId
+        [string]$RequestId,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
     )
 
     $ErrorActionPreference = "Stop"
@@ -1377,16 +1382,16 @@ function Close-SafeguardAccessRequest
         {
             { "New","PendingApproval","Approved","PendingTimeRequested","RequestAvailable","PendingAccountRestored","PendingPasswordReset" `
                     -contains $_ } {
-                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Cancel
+                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Cancel -AllFields:$AllFields
             }
             { "PasswordCheckedOut","SessionInitialized" -contains $_ } {
-                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId CheckIn
+                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId CheckIn -AllFields:$AllFields
             }
             { "RequestCheckedIn","Terminated","PendingReview","PendingAccountSuspended" -contains $_ } {
-                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Close
+                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Close -AllFields:$AllFields
             } 
             { "Expired","PendingAcknowledgment" -contains $_ } {
-                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Acknowledge
+                Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Acknowledge -AllFields:$AllFields
             }
             default {
                 # "Closed","Complete","Reclaimed"
@@ -1419,6 +1424,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
 .INPUTS
 None.
 
@@ -1439,13 +1447,15 @@ function Approve-SafeguardAccessRequest
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true, Position=0)]
-        [string]$RequestId
+        [string]$RequestId,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Approve
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Approve -AllFields:$AllFields
 }
 
 <#
@@ -1467,6 +1477,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
 .INPUTS
 None.
 
@@ -1487,13 +1500,15 @@ function Deny-SafeguardAccessRequest
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true, Position=0)]
-        [string]$RequestId
+        [string]$RequestId,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Deny
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Deny -AllFields:$AllFields
 }
 New-Alias -Name Revoke-SafeguardAccessRequest -Value Deny-SafeguardAccessRequest
 
@@ -1566,6 +1581,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
+.PARAMETER AllFields
+Return all properties that can be displayed.
+
 .INPUTS
 None.
 
@@ -1586,11 +1604,13 @@ function Assert-SafeguardAccessRequest
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true, Position=0)]
-        [string]$RequestId
+        [string]$RequestId,
+        [Parameter(Mandatory=$false)]
+        [switch]$AllFields
     )
 
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Review
+    Edit-SafeguardAccessRequest -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId Review -AllFields:$AllFields
 }

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1077,7 +1077,23 @@ function Copy-SafeguardAccessRequestPassword
     $ErrorActionPreference = "Stop"
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Set-Clipboard -Value (Get-SafeguardAccessRequestPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
+    $local:Password = (Get-SafeguardAccessRequestPassword -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $RequestId)
+    try
+    {
+        Set-Clipboard -Value $local:Password
+    }
+    catch
+    {
+        try
+        {
+            Set-ClipboardText $local:Password
+        }
+        catch
+        {
+            Write-Host -ForegroundColor Yellow "Try to use the ClipboardText module, run 'Install-Module -Name ClipboardText'"
+            throw $_
+        }
+    }
 }
 
 <#

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -151,6 +151,7 @@ FunctionsToExport = @(
     'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
     'Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
     'Close-SafeguardAccessRequest','Approve-SafeguardAccessRequest','Deny-SafeguardAccessRequest',
+    'Get-SafeguardAccessRequestActionLog','Assert-SafeguardAccessRequest',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -176,7 +176,9 @@ FunctionsToExport = @(
     'Get-SafeguardUserGroup','New-SafeguardUserGroup','Remove-SafeguardUserGroup',
     'Edit-SafeguardUserGroup',
     'Get-SafeguardAssetGroup','New-SafeguardAssetGroup','Remove-SafeguardAssetGroup',
+    'Edit-SafeguardAssetGroup',
     'Get-SafeguardAccountGroup','New-SafeguardAccountGroup','Remove-SafeguardAccountGroup',
+    'Edit-SafeguardAccountGroup',
     # policies.psm1
     'Get-SafeguardPolicyAsset','Find-SafeguardPolicyAsset','Get-SafeguardPolicyAccount','Find-SafeguardPolicyAccount',
     'Get-SafeguardAccessPolicy','Get-SafeguardAccessPolicyScopeItem','Get-SafeguardAccessPolicyAccessRequestProperty',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -150,6 +150,7 @@ FunctionsToExport = @(
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
     'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
     'Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
+    'Close-SafeguardAccessRequest',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -165,6 +165,7 @@ FunctionsToExport = @(
     # directories.psm1
     'Get-SafeguardDirectoryIdentityProvider','New-SafeguardDirectoryIdentityProvider',
     'Remove-SafeguardDirectoryIdentityProvider','Edit-SafeguardDirectoryIdentityProvider',
+    'Get-SafeguardDirectoryIdentityProviderDomain',
     'Get-SafeguardDirectoryIdentityProviderSchemaMapping','Set-SafeguardDirectoryIdentityProviderSchemaMapping',
     'Get-SafeguardDirectory','New-SafeguardDirectory','Test-SafeguardDirectory',
     'Remove-SafeguardDirectory','Edit-SafeguardDirectory','Sync-SafeguardDirectory',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -149,7 +149,7 @@ FunctionsToExport = @(
     'Get-SafeguardActionableRequest','Get-SafeguardRequestableAccount','Find-SafeguardRequestableAccount',
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
     'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
-    'Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
+    'Get-SafeguardAccessRequestRdpUrl','Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
     'Close-SafeguardAccessRequest','Approve-SafeguardAccessRequest','Deny-SafeguardAccessRequest',
     'Get-SafeguardAccessRequestActionLog','Assert-SafeguardAccessRequest',
     # users.psm1

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -149,7 +149,7 @@ FunctionsToExport = @(
     'Get-SafeguardActionableRequest','Get-SafeguardRequestableAccount','Find-SafeguardRequestableAccount',
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
     'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
-    'Start-SafeguardAccessRequestSession',
+    'Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -150,7 +150,7 @@ FunctionsToExport = @(
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
     'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
     'Start-SafeguardAccessRequestSession','Copy-SafeguardAccessRequestPassword',
-    'Close-SafeguardAccessRequest',
+    'Close-SafeguardAccessRequest','Approve-SafeguardAccessRequest','Deny-SafeguardAccessRequest',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',
@@ -243,7 +243,8 @@ AliasesToExport = @(
     'Get-SafeguardCsr','New-SafeguardCsr','Remove-SafeguardCsr',
     # requests.psm1
     'Get-SafeguardAccessRequestCheckoutPassword',
-    'Get-SafeguardMyRequestable','Find-SafeguardMyRequestable'
+    'Get-SafeguardMyRequestable','Find-SafeguardMyRequestable',
+    'Revoke-SafeguardAccessRequest'
 )
 
 # DSC resources to export from this module

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -148,7 +148,7 @@ FunctionsToExport = @(
     'Get-SafeguardAccessRequest','Find-SafeguardAccessRequest','New-SafeguardAccessRequest','Edit-SafeguardAccessRequest'
     'Get-SafeguardActionableRequest','Get-SafeguardRequestableAccount','Find-SafeguardRequestableAccount',
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
-    'Get-SafeguardAccessRequestPassword',
+    'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -145,17 +145,18 @@ FunctionsToExport = @(
     'Get-SafeguardArchiveServer','New-SafeguardArchiveServer','Test-SafeguardArchiveServer',
     'Remove-SafeguardArchiveServer','Edit-SafeguardArchiveServer',
     # requests.psm1
-    'Get-SafeguardAccessRequest','Find-SafeguardAccessRequest','New-SafeguardAccessRequest','Edit-SafeguardAccessRequest'
+    'Get-SafeguardAccessRequest','Find-SafeguardAccessRequest','New-SafeguardAccessRequest','Edit-SafeguardAccessRequest',
     'Get-SafeguardActionableRequest','Get-SafeguardRequestableAccount','Find-SafeguardRequestableAccount',
     'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
-    'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile',
+    'Get-SafeguardAccessRequestPassword','Get-SafeguardAccessRequestRdpFile','Get-SafeguardAccessRequestSshUrl',
+    'Start-SafeguardAccessRequestSession',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
     'Get-SafeguardUser','Find-SafeguardUser','New-SafeguardUser','Remove-SafeguardUser','Set-SafeguardUserPassword',
     'Edit-SafeguardUser','Enable-SafeguardUser','Disable-SafeguardUser','Rename-SafeguardUser',
     # assets.psm1
     'Get-SafeguardAsset','Find-SafeguardAsset','New-SafeguardAsset','Test-SafeguardAsset',
-    'Remove-SafeguardAsset','Edit-SafeguardAsset', 'Sync-SafeguardDirectoryAsset'
+    'Remove-SafeguardAsset','Edit-SafeguardAsset', 'Sync-SafeguardDirectoryAsset',
     'Get-SafeguardAssetAccount','Find-SafeguardAssetAccount','New-SafeguardAssetAccount','Edit-SafeguardAssetAccount',
     'Set-SafeguardAssetAccountPassword','New-SafeguardAssetAccountRandomPassword',
     'Test-SafeguardAssetAccountPassword','Invoke-SafeguardAssetAccountPasswordChange',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -147,6 +147,7 @@ FunctionsToExport = @(
     # requests.psm1
     'Get-SafeguardAccessRequest','Find-SafeguardAccessRequest','New-SafeguardAccessRequest','Edit-SafeguardAccessRequest'
     'Get-SafeguardActionableRequest','Get-SafeguardRequestableAccount','Find-SafeguardRequestableAccount',
+    'Get-SafeguardMyRequest','Get-SafeguardMyApproval','Get-SafeguardMyReview',
     'Get-SafeguardAccessRequestPassword',
     # users.psm1
     'Get-SafeguardIdentityProvider','New-SafeguardStarling2faAuthentication',
@@ -239,7 +240,8 @@ AliasesToExport = @(
     # certificates.psm1
     'Get-SafeguardCsr','New-SafeguardCsr','Remove-SafeguardCsr',
     # requests.psm1
-    'Get-SafeguardAccessRequestCheckoutPassword'
+    'Get-SafeguardAccessRequestCheckoutPassword',
+    'Get-SafeguardMyRequestable','Find-SafeguardMyRequestable'
 )
 
 # DSC resources to export from this module

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -409,7 +409,7 @@ function Invoke-Internal
         {
             {$_ -in "get","delete"} {
                 Invoke-WithoutBody $Appliance $Service $Method $Version $RelativeUrl $Headers `
-                    -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout 
+                    -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
                 break
             }
             {$_ -in "put","post"} {
@@ -663,7 +663,7 @@ function Connect-Safeguard
                     {
                         Write-Host "($($local:IdentityProviders -join ", "))"
                     }
-                    else 
+                    else
                     {
                         Write-Warning "Unable to detect identity providers -- report this as an issue"
                     }
@@ -683,7 +683,7 @@ function Connect-Safeguard
                     $IdentityProvider = $_.Id
                 }
             }
-    
+
             if ($IdentityProvider -ieq "certificate")
             {
                 if (-not $Thumbprint -and -not $CertificateFile)
@@ -702,7 +702,7 @@ function Connect-Safeguard
                             $Username = (Read-Host "Username")
                         }
                         if (-not $Password)
-                        { 
+                        {
                             $Password = (Read-Host "Password" -AsSecureString)
                         }
                         $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
@@ -719,7 +719,7 @@ function Connect-Safeguard
                     }
                 }
             }
-        
+
             if ($Username)
             {
                 try
@@ -1366,7 +1366,7 @@ function Get-SafeguardAccessTokenStatus
             Disable-SslVerification
             if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
-        $local:Response = (Invoke-WebRequest -Method GET -Headers @{ 
+        $local:Response = (Invoke-WebRequest -Method GET -Headers @{
                 "Authorization" = "Bearer $AccessToken"
             } -Uri "https://$Appliance/service/core/v3/Me")
         $local:TimeRemaining = (New-TimeSpan -Minutes $local:Response.Headers["X-TokenLifetimeRemaining"])

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1472,6 +1472,9 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
+.PARAMETER Fields
+An array of the user property names to return.
+
 .INPUTS
 None.
 
@@ -1482,7 +1485,7 @@ JSON response from Safeguard Web API.
 Get-SafeguardLoggedInUser -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
-Get-SafeguardLoggedInUser
+Get-SafeguardLoggedInUser -Fields Id
 #>
 function Get-SafeguardLoggedInUser
 {
@@ -1493,13 +1496,21 @@ function Get-SafeguardLoggedInUser
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Me
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Me -Parameters $local:Parameters
 }
 
 <#

--- a/src/sessionmodule.psm1
+++ b/src/sessionmodule.psm1
@@ -643,7 +643,7 @@ Set-SafeguardSessionSshAlgorithms ServerSide Cipher 3des-cbc,arcfour,aes128-ctr,
 #>
 function Set-SafeguardSessionSshAlgorithms
 {
-    [CmdletBinding()] 
+    [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -502,6 +502,11 @@ function Resolve-ReasonCodeId
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($ReasonCode.Id -as [int])
+    {
+        $ReasonCode = $ReasonCode.Id
+    }
+
     if (-not ($ReasonCode -as [int]))
     {
         try

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -7,7 +7,7 @@ function Out-SafeguardExceptionIfPossible
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ThrownException
     )
-    
+
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
@@ -69,7 +69,7 @@ namespace Ex
         }
         elseif ($ThrownException.Response | Get-Member Content -MemberType Properties)
         { # different properties and methods on net core
-            try 
+            try
             {
                 $local:ResponseBody = $ThrownException.Response.Content.ReadAsStringAsync().Result
             }
@@ -271,7 +271,7 @@ function Wait-ForSessionModuleState
                 $local:StateFound = $true
             }
         }
-        catch 
+        catch
         {
             $local:StatusString = "Unreachable, Unreachable"
         }
@@ -394,7 +394,7 @@ function Resolve-SafeguardSystemId
     catch
     {
         Write-Verbose "Unable to resolve to asset ID, trying directories"
-        try 
+        try
         {
             Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
             Resolve-SafeguardDirectoryId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System
@@ -432,7 +432,7 @@ function Resolve-SafeguardAccountIdWithoutSystemId
     catch
     {
         Write-Verbose "Unable to resolve to asset account ID, trying directories"
-        try 
+        try
         {
             Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
             Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Account
@@ -472,7 +472,7 @@ function Resolve-SafeguardAccountIdWithSystemId
     catch
     {
         Write-Verbose "Unable to resolve to asset account ID, trying directories"
-        try 
+        try
         {
             Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
             Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -DirectoryId $SystemId $Account

--- a/src/starling.psm1
+++ b/src/starling.psm1
@@ -126,7 +126,7 @@ function Get-SafeguardStarlingSubscription
 
 <#
 .SYNOPSIS
-Create a new One Identity Starling subscription using the Safeguard 
+Create a new One Identity Starling subscription using the Safeguard
 Web API.
 
 .DESCRIPTION
@@ -204,7 +204,7 @@ function New-SafeguardStarlingSubscription
 
 <#
 .SYNOPSIS
-Remove a One Identity Starling subscription using the Safeguard 
+Remove a One Identity Starling subscription using the Safeguard
 Web API.
 
 .DESCRIPTION
@@ -282,7 +282,7 @@ Get a join URL for subscribing this Safeguard instance to One Identity Starling.
 .DESCRIPTION
 This cmdlet will return a join URL which must be accessed via an interactive
 browser session.  The result of authenticating with the information in the join
-URL will be a new Starling subscription on the Starling side; however, you need to call 
+URL will be a new Starling subscription on the Starling side; however, you need to call
 New-SafeguardStarlingSubscription to configure the subscription information in
 Safeguard as well.  Or, you may call Invoke-SafeguardStarlingJoin which will do all
 of these steps for you, including opening the browser.

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -16,6 +16,11 @@ function Resolve-SafeguardUserObject
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    if ($User.Id -as [int])
+    {
+        $User = $User.Id
+    }
+
     if (-not ($User -as [int]))
     {
         try
@@ -61,6 +66,11 @@ function Resolve-SafeguardUserId
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($User.Id -as [int])
+    {
+        $User = $User.Id
+    }
 
     if (-not ($User -as [int]))
     {

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -236,8 +236,8 @@ function New-SafeguardStarling2faAuthentication
 
     $local:ProviderObject = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
         Core POST IdentityProviders -Body @{
-            Name = $ProviderName; 
-            TypeReferenceName = "StarlingTwoFactor" 
+            Name = $ProviderName;
+            TypeReferenceName = "StarlingTwoFactor"
         })
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
         Core PUT "IdentityProviders/$($local:ProviderObject.Id)/ApiKey" -Body $ApiKey
@@ -439,7 +439,7 @@ A string containing a mobile phone number for the user.
 An array of strings containing the permissions (admin roles) to assign to the user.  You may also specify
 'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'DirectoryAdmin', 'Auditor',
 'AssetAdmin', 'ApplianceAdmin', 'PolicyAdmin', 'UserAdmin', 'HelpdeskAdmin', 'OperationsAdmin'.
-'DirectoryAdmin' has been deprecated. 'All' does not grant 'DirectoryAdmin' permission. 
+'DirectoryAdmin' has been deprecated. 'All' does not grant 'DirectoryAdmin' permission.
 Add 'DirectoryAdmin' permission individually for older Safeguard appliance.
 
 .PARAMETER Password
@@ -739,7 +739,7 @@ function Set-SafeguardUserPassword
     }
     $local:UserId = (Resolve-SafeguardUserId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $UserToEdit)
     if (-not $PSBoundParameters.ContainsKey("Password") -or $null -eq $Password)
-    { 
+    {
         $Password = (Read-Host "Password" -AsSecureString)
     }
 
@@ -791,7 +791,7 @@ A string containing a mobile phone number for the user.
 .PARAMETER AdminRoles
 An array of strings containing the permissions (admin roles) to assign to the user.  You may also specify
 'All' to grant all permissions. Other permissions are: 'GlobalAdmin', 'DirectoryAdmin','Auditor',
-'AssetAdmin', 'ApplianceAdmin', 'PolicyAdmin', 'UserAdmin', 'HelpdeskAdmin', 'OperationsAdmin'. 
+'AssetAdmin', 'ApplianceAdmin', 'PolicyAdmin', 'UserAdmin', 'HelpdeskAdmin', 'OperationsAdmin'.
 'DirectoryAdmin' has been deprecated. 'All' does not grant 'DirectoryAdmin' permission.
 Add 'DirectoryAdmin' permission individually for older Safeguard appliance.
 
@@ -860,7 +860,7 @@ function Edit-SafeguardUser
         }
         $local:UserId = (Resolve-SafeguardUserId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $UserToEdit)
     }
-    
+
     if (-not ($PsCmdlet.ParameterSetName -eq "Object"))
     {
         $UserObject = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $local:UserId)
@@ -1072,7 +1072,7 @@ function Rename-SafeguardUser
     }
     $local:UserId = (Resolve-SafeguardUserId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $UserToEdit)
     if (-not $PSBoundParameters.ContainsKey("NewUserName") -or -not $NewUserName)
-    { 
+    {
         $NewUserName = (Read-Host "NewUserName")
     }
 

--- a/test/certificates-test.ps1
+++ b/test/certificates-test.ps1
@@ -1,11 +1,12 @@
 # This script assumes that the bootstrap admin account has the default password
 # It also uses some test data underneath this directory
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$true)]
     [string]$Appliance
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 $local:Password = (ConvertTo-SecureString -AsPlainText "Admin123" -Force)
 $local:AccessToken = (Connect-Safeguard -Appliance $Appliance -IdentityProvider Local -Username Admin -Password $local:Password -Insecure -NoSessionVariable)

--- a/test/licensing-test.ps1
+++ b/test/licensing-test.ps1
@@ -1,5 +1,5 @@
 # This script assumes that the bootstrap admin account has the default password
-
+[CmdletBinding()]
 Param(
     [Parameter(Mandatory=$true)]
     [string]$Appliance,
@@ -9,7 +9,7 @@ Param(
     [string]$SessionsLicenseFile
 )
 
-$ErrorActionPreference = "Stop"
+if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
 
 $local:Password = (ConvertTo-SecureString -AsPlainText "Admin123" -Force)
 $local:AccessToken = (Connect-Safeguard -Appliance $Appliance -IdentityProvider Local -Username Admin -Password $local:Password -Insecure -NoSessionVariable)


### PR DESCRIPTION
- Add / remove user groups from entitlement membership
- Add / remove assets from asset groups
- Add / remove accounts from account groups
- Support for the -Fields parameter on many `Get-Safeguard*` cmdlets
- Fixed install-local.ps1 and other development tooling to work on macOs
- Fixed a bug with access requests as a directory/linked account
- Cluster and health improvements
- Many new access request cmdlets:
  - `Get-SafeguardMyRequest`, `Find-SafeguardRequestableAccount`, `Get-SafeguardMyApproval`, and `Get-SafeguardMyReview` to provide a better experience for state of workflow
  - `Approve-SafeguardAccessRequest` and `Deny-SafeguardAccessRequest` for approver experience
  - `Get-SafeguardAccessRequestActionLog` and `Asset-SafeguardAccessRequest` for reviewer experience
  - `Close-SafeguardAccessRequest` for better check-in experience
  - `Get-SafeguardAccessRequestRdpFile`, `Get-SafeguardAccessRequestRdpUrl`, `Get-SafeguardAccessRequestSshUrl`, and `Start-SafeguardAccessRequestSession` for better session experience
  - `Copy-SafeguardAccessRequestPassword` for putting the password directly on the clipboard
