### PR TITLE
Fix Edit-SafeguardUserGroup cmdlet

### DIFF
--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -488,7 +488,7 @@ function Edit-SafeguardUserGroup
     [object[]]$local:Users = $null
     foreach ($local:User in $UserList)
     {
-        $local:ResolvedUser = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $local:User -Fields Id,Name)
+        $local:ResolvedUser = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $local:User -Fields Id,UserName,PrimaryAuthenticationProviderId)
         $local:Users += $($local:ResolvedUser)
     }
 


### PR DESCRIPTION
A user object has "Username" instead of "Name" property. Also, PrimaryAuthenticationProviderId is a required field when add/removing users to a user group 