### PR TITLE
Use OAuth2 Implicit Grant Flow Instead of Authorization Code Grant to Handle Load Balancers

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -54,7 +54,9 @@ function Show-RstsWindow
         [Parameter(Mandatory=$false,Position=1)]
         [string]$PrimaryProviderId = "",
         [Parameter(Mandatory=$false,Position=2)]
-        [string]$SecondaryProviderId = ""
+        [string]$SecondaryProviderId = "",
+        [Parameter(Mandatory=$false,Position=3)]
+        [string]$Username = ""
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -82,21 +84,19 @@ function Show-RstsWindow
                 _form.Controls.Add(_browser);
                 _browser.DocumentTitleChanged += (sender, args) => {
                     var b = (WebBrowser)sender;
-                    if (Regex.IsMatch(b.DocumentTitle, "error=[^&]*|code=[^&]*")) {
-                        AuthorizationCode = b.DocumentTitle.Substring(5);
+                    if (Regex.IsMatch(b.DocumentTitle, "error=[^&]*|access_token=[^&]*")) {
+                        var matchStart = b.DocumentTitle.StartsWith("error=") ? "error=".Length : "access_token=".Length;
+                        AuthorizationCode = b.DocumentTitle.Substring(matchStart);
                         _form.DialogResult = DialogResult.OK;
                         _form.Hide(); }
                 };
             }
             public string AuthorizationCode { get; set; }
-            public bool Show(string primaryProviderId = "", string secondaryProviderId = "") {
+            public bool Show(string primaryProviderId = "", string secondaryProviderId = "", string username = "") {
                 try {
-                    string url;
-                    if (!string.IsNullOrEmpty(primaryProviderId) && !string.IsNullOrEmpty(secondaryProviderId))
-                        url = string.Format("https://{0}/RSTS/Login?response_type=code&client_id={1}&redirect_uri={2}&primaryproviderid={3}&secondaryproviderid={4}",
-                            _appliance, ClientId, RedirectUri, HttpUtility.UrlEncode(primaryProviderId), HttpUtility.UrlEncode(secondaryProviderId));
-                    else
-                        url = string.Format("https://{0}/RSTS/Login?response_type=code&client_id={1}&redirect_uri={2}", _appliance, ClientId, RedirectUri);
+                    string url = string.Format("https://{0}/RSTS/Login?response_type=token&client_id={1}&redirect_uri={2}&primaryproviderid={3}&secondaryproviderid={4}&login_hint={5}",
+                            _appliance, ClientId, RedirectUri, HttpUtility.UrlEncode(primaryProviderId), HttpUtility.UrlEncode(secondaryProviderId), HttpUtility.UrlEncode(username));
+                    
                     _browser.Stop();
                     _browser.Navigate(url);
                     if (_form.ShowDialog() == DialogResult.OK) { return true; }
@@ -115,7 +115,7 @@ function Show-RstsWindow
     {
         $local:Browser = New-Object -TypeName RstsWindow -ArgumentList $Appliance
     }
-    if (!$local:Browser.Show($PrimaryProviderId, $SecondaryProviderId))
+    if (!$local:Browser.Show($PrimaryProviderId, $SecondaryProviderId, $Username))
     {
         throw "Unable to correctly manipulate browser"
     }
@@ -131,7 +131,9 @@ function Get-RstsTokenFromGui
         [Parameter(Mandatory=$false,Position=1)]
         [string]$PrimaryProviderId = "",
         [Parameter(Mandatory=$false,Position=2)]
-        [string]$SecondaryProviderId = ""
+        [string]$SecondaryProviderId = "",
+        [Parameter(Mandatory=$false,Position=3)]
+        [string]$Username = ""
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -142,24 +144,16 @@ function Get-RstsTokenFromGui
         throw "This -Gui parameter is not supported in PowerShell Core"
     }
 
-    Show-RstsWindow $Appliance $PrimaryProviderId $SecondaryProviderId
+    Show-RstsWindow $Appliance $PrimaryProviderId $SecondaryProviderId $Username
     $local:Code = $global:AuthorizationCode
     Remove-Variable -Name AuthorizationCode -Scope Global -Force -ErrorAction "SilentlyContinue"
     if (-not $local:Code)
     {
-        throw "Unable to obtain authorization code"
+        throw "Unable to obtain access_token"
     }
-    Invoke-RestMethod -Method POST -Headers @{
-        "Accept" = "application/json";
-        "Content-type" = "application/json"
-    } -Uri "https://$Appliance/RSTS/oauth2/token" -Body @"
-{
-"grant_type": "authorization_code",
-"client_id": "$($script:ClientId)",
-"redirect_uri": "$($script:RedirectUri)",
-"code": "$($local:Code)"
-}
-"@
+    
+    # Return as a hashtable object because other parts of the code later on will expect it.
+    @{access_token=$local:Code}
 }
 function New-SafeguardUrl
 {
@@ -582,7 +576,7 @@ function Connect-Safeguard
 
         if ($Gui)
         {
-            $local:RstsResponse = (Get-RstsTokenFromGui $Appliance)
+            $local:RstsResponse = (Get-RstsTokenFromGui $Appliance $IdentityProvider "" $Username)
         }
         else
         {

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -94,8 +94,11 @@ function Show-RstsWindow
             public string AuthorizationCode { get; set; }
             public bool Show(string primaryProviderId = "", string secondaryProviderId = "", string username = "") {
                 try {
-                    string url = string.Format("https://{0}/RSTS/Login?response_type=token&client_id={1}&redirect_uri={2}&primaryproviderid={3}&secondaryproviderid={4}&login_hint={5}",
-                            _appliance, ClientId, RedirectUri, HttpUtility.UrlEncode(primaryProviderId), HttpUtility.UrlEncode(secondaryProviderId), HttpUtility.UrlEncode(username));
+                    string url = string.Format("https://{0}/RSTS/Login?response_type=token&client_id={1}&redirect_uri={2}",
+                            _appliance, ClientId, RedirectUri);
+                    if (!string.IsNullOrEmpty(primaryProviderId))   url += string.Format("&primaryProviderId={0}",   HttpUtility.UrlEncode(primaryProviderId));
+                    if (!string.IsNullOrEmpty(secondaryProviderId)) url += string.Format("&secondaryProviderid={0}", HttpUtility.UrlEncode(secondaryProviderId));
+                    if (!string.IsNullOrEmpty(username))            url += string.Format("&login_hint={0}", HttpUtility.UrlEncode(username));
                     
                     _browser.Stop();
                     _browser.Navigate(url);


### PR DESCRIPTION
See the reported Issue #197, Connect-Safeguard with 2FA errors with "Code was already redeemed".

When the client requests are made from in front of a load balancer, there is a chance that individual requests may be directed at different nodes by the load balancer.  When using the OAuth2 Authorization Code Grant flow, it requires the client to make multiple requests in order to get, then exchange the authorization code.  Those requests may go to different nodes behind the load balancer, but we do not have a shared cache between the nodes for the authorization code.  (The problem is exacerbated here in the PowerShell script due to the web browser control effectively making one of the web requests, and then the PowerShell script itself making the second request.  An HTTP connection would not be reused between those two.

By changing to use the OAuth2 Implicit Grant flow, we will instead immediately get back an access_token from the web browser login.  Therefore, we shouldn't have any problems in a load balanced environment.

Also, see Issue #173, Enhancement Requests: Connect-Safeguard.  The point number one, "When using GUI Switch still pass through Username field" has also been included in these changes.  (Note that the embedded web browser has a display issue with the placeholder text, but that will be fixed with a later release of Safeguard itself.)

So, for example, you can enter a command like:
`Connect-Safeguard -insecure -gui -verbose 10.5.33.109 local superadmin` and all you will have to enter into the web browser is the password.