### PR TITLE
Issue 215: New-SafeguardAsset does not accept Appliance parameter in v2.10.399

### DIFF
--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -505,7 +505,7 @@ function New-SafeguardAsset
     Import-Module -Name "$PSScriptRoot\datatypes.psm1" -Scope Local
 
     $local:PlatformId = (Resolve-SafeguardPlatform -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Platform)
-    $local:PlatformObject = (Get-SafeguardPlatform $local:PlatformId)
+    $local:PlatformObject = (Get-SafeguardPlatform -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $local:PlatformId)
 
     if ($PSCmdlet.ParameterSetName -ne "Ad" -and -not $local:PlatformObject.PlatformType.StartsWith("Other"))
     {


### PR DESCRIPTION
If you do not first use `Connect-Safeguard` and instead manually use an `accessToken` variable when calling Safeguard commands, then a call to the `New-SafeguardAsset` command will cause the `-Appliance` parameter and others to be re-propmted for.  This is because in the 2.10 release, the code to resolve the `PlatformId` was moved up ([line 502](https://github.com/OneIdentity/safeguard-ps/commit/63bccdf82435d7f4917a661e035320e53be7c9b7#diff-54b8bcc196bdb4bfb6d6d05aa999b400R502)) and a new line was added just below it to set a local `$PlatformObject` variable using the `Get-SafeguardPlatform` command ([line 503](https://github.com/OneIdentity/safeguard-ps/commit/63bccdf82435d7f4917a661e035320e53be7c9b7#diff-54b8bcc196bdb4bfb6d6d05aa999b400R503)).  But when calling that command, no additional connection parameters were specified.  Therefore, it would cause them to be prompted for.

So now, we simply include/explicitly specify the additional connection parameters when making a call to the `Get-SafeguardPlatform` command, just like in the previous call to `Resolve-SafeguardPlatform`.