### PR TITLE
The new web client silently redirects on bad url

### DIFF
--- a/src/desktopclient.psm1
+++ b/src/desktopclient.psm1
@@ -90,6 +90,11 @@ function Install-SafeguardDesktopClient
         try
         {
             $WebClient.DownloadFile("https://$Appliance/en-US/Safeguard.msi", $TempFile)
+            if ((Get-Item $TempFile).Length -lt 1MB)
+            {
+                Remove-Item -Force $TempFile -EA SilentlyContinue
+                throw "Wrong URL"
+            }
         }
         catch
         {


### PR DESCRIPTION
Different requirements for downloading and installing automatically for 2.11 with new web client.