### PR TITLE
Added support for entering an asset partition for administration

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ update this list.
 - New-SafeguardDirectoryIdentityProvider
 - Remove-SafeguardDirectoryIdentityProvider
 - Edit-SafeguardDirectoryIdentityProvider
+- Sync-SafeguardDirectoryIdentityProvider
 - Get-SafeguardDirectoryIdentityProviderDomain
 - Get-SafeguardDirectoryIdentityProviderSchemaMapping
 - Set-SafeguardDirectoryIdentityProviderSchemaMapping

--- a/README.md
+++ b/README.md
@@ -451,6 +451,9 @@ update this list.
 - New-SafeguardAssetPartition
 - Remove-SafeguardAssetPartition
 - Edit-SafeguardAssetPartition
+- Enter-SafeguardAssetPartition
+- Exit-SafeguardAssetPartition
+- Get-SafeguardCurrentAssetPartition
 
 ### Assets
 

--- a/src/assetpartitions.psm1
+++ b/src/assetpartitions.psm1
@@ -26,14 +26,14 @@ function Resolve-SafeguardAssetPartitionId
         try
         {
             $local:Partitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
-                                 -Parameters @{ filter = "Name ieq '$AssetPartition'" })
+                                 -Parameters @{ filter = "Name ieq '$AssetPartition'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
             $local:Partitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
-                                     -Parameters @{ q = $AssetPartition })
+                                     -Parameters @{ q = $AssetPartition; fields = "Id" })
         }
         if (-not $local:Partitions)
         {

--- a/src/assetpartitions.psm1
+++ b/src/assetpartitions.psm1
@@ -375,3 +375,69 @@ function Edit-SafeguardAssetPartition
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "AssetPartitions/$($AssetPartitionObject.Id)" -Body $AssetPartitionObject
 }
+
+function Enter-SafeguardAssetPartition
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false,Position=0)]
+        [object]$AssetPartitionToEnter
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $SafeguardSession)
+    {
+        throw "This cmdlet requires that you log in with the Connect-Safeguard cmdlet"
+    }
+
+    $local:Partition = (Get-SafeguardAssetPartition -Appliance $AccessToken -AccessToken $AccessToken -Insecure:$Insecure $AssetPartitionToEnter)
+    if ($local:Partition)
+    {
+        $SafeguardSession["AssetPartitionId"] = $local:Partition.Id
+        $local:Partition
+    }
+}
+
+function Exit-SafeguardAssetPartition
+{
+    [CmdletBinding()]
+    Param(
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $SafeguardSession)
+    {
+        throw "This cmdlet requires that you log in with the Connect-Safeguard cmdlet"
+    }
+
+    if (-not $SafeguardSession["AssetPartitionId"])
+    {
+        throw "You have not entered an asset partition"
+    }
+
+    $SafeguardSession["AssetPartitionId"] = $null
+}
+
+function Get-SafeguardCurrentAssetPartition
+{
+    [CmdletBinding()]
+    Param(
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $SafeguardSession)
+    {
+        throw "This cmdlet requires that you log in with the Connect-Safeguard cmdlet"
+    }
+
+    if ($SafeguardSession["AssetPartitionId"])
+    {
+        Get-SafeguardAssetPartition $SafeguardSession["AssetPartitionId"]
+    }
+}

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -1846,6 +1846,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to check the asset account password in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to check the asset account password in.
+(If specified, this will override the AssetPartition parameter)
+
 .PARAMETER AssetToUse
 An integer containing the ID of the asset to check password for or a string containing the name.
 
@@ -1874,6 +1882,10 @@ function Test-SafeguardAssetAccountPassword
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToUse,
         [Parameter(Mandatory=$true,Position=1)]
@@ -1883,15 +1895,8 @@ function Test-SafeguardAssetAccountPassword
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("AssetToUse"))
-    {
-        $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToUse)
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
-    }
+    $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $AssetToUse -Account $AccountToUse)
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "AssetAccounts/$($local:AccountId)/CheckPassword" -LongRunningTask
 }
 
@@ -1911,6 +1916,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to change the asset account password in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to change the asset account password in.
+(If specified, this will override the AssetPartition parameter)
 
 .PARAMETER AssetToUse
 An integer containing the ID of the asset to change password for or a string containing the name.
@@ -1940,6 +1953,10 @@ function Invoke-SafeguardAssetAccountPasswordChange
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToUse,
         [Parameter(Mandatory=$true,Position=1)]
@@ -1949,15 +1966,8 @@ function Invoke-SafeguardAssetAccountPasswordChange
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("AssetToUse"))
-    {
-        $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToUse)
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
-    }
+    $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $AssetToUse -Account $AccountToUse)
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "AssetAccounts/$($local:AccountId)/ChangePassword" -LongRunningTask
 }
 
@@ -1977,6 +1987,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to change the asset account password in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to change the asset account password in.
+(If specified, this will override the AssetPartition parameter)
 
 .PARAMETER AssetToUse
 An integer containing the ID of the asset to remove the account from or a string containing the name.
@@ -2006,6 +2024,10 @@ function Remove-SafeguardAssetAccount
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToUse,
         [Parameter(Mandatory=$true,Position=1)]
@@ -2015,14 +2037,7 @@ function Remove-SafeguardAssetAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("AssetToUse"))
-    {
-        $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToUse)
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToDelete)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToDelete)
-    }
+    $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $AssetToUse -Account $AccountToDelete)
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "AssetAccounts/$($local:AccountId)"
 }

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -1692,6 +1692,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to set the asset account password in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to set the asset account password in.
+(If specified, this will override the AssetPartition parameter)
+
 .PARAMETER AssetToSet
 An integer containing the ID of the asset to set account password on or a string containing the name.
 
@@ -1723,6 +1731,10 @@ function Set-SafeguardAssetAccountPassword
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToSet,
         [Parameter(Mandatory=$true,Position=1)]
@@ -1734,15 +1746,8 @@ function Set-SafeguardAssetAccountPassword
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("AssetToSet"))
-    {
-        $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToSet)
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToSet)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToSet)
-    }
+    $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $AssetToSet -Account $AccountToSet)
     if (-not $NewPassword)
     {
         $NewPassword = (Read-Host -AsSecureString "NewPassword")

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -1775,6 +1775,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to generate the asset account password in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to generate the asset account password in.
+(If specified, this will override the AssetPartition parameter)
+
 .PARAMETER AssetToUse
 An integer containing the ID of the asset to generate password for or a string containing the name.
 
@@ -1803,6 +1811,10 @@ function New-SafeguardAssetAccountRandomPassword
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$false,Position=0)]
         [object]$AssetToUse,
         [Parameter(Mandatory=$true,Position=1)]
@@ -1812,15 +1824,8 @@ function New-SafeguardAssetAccountRandomPassword
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    if ($PSBoundParameters.ContainsKey("AssetToUse"))
-    {
-        $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToUse)
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -AssetId $local:AssetId $AccountToUse)
-    }
-    else
-    {
-        $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToUse)
-    }
+    $local:AccountId = (Resolve-SafeguardAssetAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $AssetToUse -Account $AccountToUse)
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "AssetAccounts/$($local:AccountId)/GeneratePassword"
 }
 

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -1356,7 +1356,7 @@ function Get-SafeguardAssetAccount
         }
         else
         {
-            $local:RelPath = "Accounts"
+            $local:RelPath = "AssetAccounts"
         }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" -Parameters $local:Parameters
     }
@@ -1482,6 +1482,14 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
+.PARAMETER AssetPartition
+An integer containing an ID or a string containing the name of the asset partition
+to create the new asset account in.
+
+.PARAMETER AssetPartitionId
+An integer containing the asset partition ID to create the new asset account in.
+(If specified, this will override the AssetPartition parameter)
+
 .PARAMETER ParentAsset
 An integer containing the ID of the asset to get accounts from or a string containing the name.
 
@@ -1516,6 +1524,10 @@ function New-SafeguardAssetAccount
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$AssetPartition,
+        [Parameter(Mandatory=$false)]
+        [int]$AssetPartitionId = $null,
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentAsset,
         [Parameter(Mandatory=$true,Position=1)]
@@ -1531,7 +1543,8 @@ function New-SafeguardAssetAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $ParentAsset)
+    $local:AssetId = (Resolve-SafeguardAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                          -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -Asset $ParentAsset)
 
     $local:Body = @{
         "AssetId" = $local:AssetId;

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -510,7 +510,7 @@ function Remove-SafeguardDirectoryIdentityProvider
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
+        [Parameter(Mandatory=$true,Position=0)]
         [object]$DirectoryToDelete
     )
 
@@ -647,6 +647,58 @@ function Edit-SafeguardDirectoryIdentityProvider
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "IdentityProviders/$($DirectoryObject.Id)" -Body $DirectoryObject
+}
+
+<#
+.SYNOPSIS
+Synchronize a directory identity provider in Safeguard via the Web API.
+
+.DESCRIPTION
+Synchronize a directory identity provider to update the information in Safeguard.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER DirectoryToSync
+An integer containing the ID of the directory identity provider to synchronize or a string containing the name.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Sync-SafeguardDirectoryIdentityProvider 5
+
+.EXAMPLE
+Sync-SafeguardDirectoryIdentityProvider internal.domain.corp
+#>
+function Sync-SafeguardDirectoryIdentityProvider
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$DirectoryToSync
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:IdpId = (Resolve-SafeguardDirectoryIdentityProviderId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryToSync)
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "IdentityProviders/$($local:IdpId)/Synchronize"
 }
 
 <#

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -177,6 +177,7 @@ FunctionsToExport = @(
     # assetpartitions.psm1
     'Get-SafeguardAssetPartition','New-SafeguardAssetPartition','Remove-SafeguardAssetPartition',
     'Edit-SafeguardAssetPartition',
+    'Get-SafeguardCurrentAssetPartition','Enter-SafeguardAssetPartition','Exit-SafeguardAssetPartition',
     # directories.psm1
     'Get-SafeguardDirectoryIdentityProvider','New-SafeguardDirectoryIdentityProvider',
     'Remove-SafeguardDirectoryIdentityProvider','Edit-SafeguardDirectoryIdentityProvider',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -181,7 +181,7 @@ FunctionsToExport = @(
     # directories.psm1
     'Get-SafeguardDirectoryIdentityProvider','New-SafeguardDirectoryIdentityProvider',
     'Remove-SafeguardDirectoryIdentityProvider','Edit-SafeguardDirectoryIdentityProvider',
-    'Get-SafeguardDirectoryIdentityProviderDomain',
+    'Get-SafeguardDirectoryIdentityProviderDomain','Sync-SafeguardDirectoryIdentityProvider',
     'Get-SafeguardDirectoryIdentityProviderSchemaMapping','Set-SafeguardDirectoryIdentityProviderSchemaMapping',
     'Get-SafeguardDirectory','New-SafeguardDirectory','Test-SafeguardDirectory',
     'Remove-SafeguardDirectory','Edit-SafeguardDirectory','Sync-SafeguardDirectory',

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -864,7 +864,8 @@ function Connect-Safeguard
                 "CertificateFile" = $CertificateFile;
                 "Insecure" = $Insecure;
                 "Gui" = $Gui;
-                "NoWindowTitle" = $NoWindowTitle
+                "NoWindowTitle" = $NoWindowTitle;
+                "AssetPartitionId" = $null
             }
             if (-not $NoWindowTitle)
             {


### PR DESCRIPTION
Enter-SafeguardAssetPartition sets the administrative context to a single partition

This makes it so you cannot operate on assets outside of that partition and default object creation will occur inside the partition

Exit-SafeguardAssetPartition sets the administrative context back to global