### PR TITLE
Add support for fields in remaining find cmdlets, improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ update this list.
 
 - Get-SafeguardEvent
 - Get-SafeguardEventName
+- Find-SafeguardEvent
 - Get-SafeguardEventSubscription
 - Find-SafeguardEventSubscription
 - New-SafeguardEventSubscription

--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ update this list.
 
 - Get-SafeguardEvent
 - Get-SafeguardEventName
+- Get-SafeguardEventProperty
 - Find-SafeguardEvent
 - Get-SafeguardEventSubscription
 - Find-SafeguardEventSubscription

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -44,7 +44,7 @@ function Resolve-SubscriptionEvent
 
 <#
 .SYNOPSIS
-Get events in Safeguard via the Web API.
+Get information on events in Safeguard via the Web API.
 
 .DESCRIPTION
 Safeguard events are events that occur as a result of an administrative activity such as created and deletion of an asset or an account.
@@ -60,6 +60,9 @@ Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER EventToGet
 A string containing the name of the event to get.
+
+.PARAMETER Fields
+An array of the event property names to return.
 
 .INPUTS
 None.
@@ -84,28 +87,36 @@ function Get-SafeguardEvent
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [object]$EventToGet
+        [object]$EventToGet,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
+
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     if ($PSBoundParameters.ContainsKey("EventToGet"))
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Events/$EventToGet"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Events/$EventToGet" -Parameters $local:Parameters
     }
     else
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events -Parameters $local:Parameters
     }
 }
 
 <#
 .SYNOPSIS
-Get the names of subscription events in Safeguard by their type via the Web API.
+Get the names of subscribable events in Safeguard by their type via the Web API.
 
 .DESCRIPTION
-Get the list of names of subscription events in Safeguard.
+Get the list of names of subscribable events in Safeguard.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -152,8 +163,8 @@ function Get-SafeguardEventName
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
     [object[]]$Names = $null
-    $local:Events = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events
-    ForEach($IndividualEvent in $Events)
+    $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events)
+    foreach ($IndividualEvent in $Events)
     {
         if ($PSBoundParameters.ContainsKey("TypeofEvent"))
         {
@@ -168,6 +179,86 @@ function Get-SafeguardEventName
         }
     }
     return $Names
+}
+
+<#
+.SYNOPSIS
+Find information on events in Safeguard via the Web API.
+
+.DESCRIPTION
+Safeguard events are events that occur as a result of an administrative activity such as created and deletion of an asset or an account.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SearchString
+A string to search for in the event information.
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER Fields
+An array of the event property names to return.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Find-SafeguardEvent -AccessToken $token -Appliance 10.5.32.54 -Insecure AssetCreated
+
+.EXAMPLE
+Find-SafeguardEvent -QueryFilter  -Fields
+#>
+function Find-SafeguardEvent
+{
+    [CmdletBinding(DefaultParameterSetName="Search")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
+        [string]$SearchString,
+        [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSCmdlet.ParameterSetName -eq "Search")
+    {
+        $local:Parameters = @{ q = $SearchString }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+            -Parameters $local:Parameters
+    }
+    else
+    {
+        $local:Parameters = @{ filter = $QueryFilter }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+            -Parameters $local:Parameters
+    }
 }
 
 <#

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1,4 +1,82 @@
 #Helper
+function Resolve-Event
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$Event
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    while (-not $local:FoundEvent)
+    {
+        Write-Host "Searching for events with '$Event'"
+        try
+        {
+            $local:FoundEvent = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET `
+                                     "Events/$Event")
+        }
+        catch {}
+        if (-not $local:FoundEvent)
+        {
+            $local:Events = ((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                                  -Parameters @{ fields = "Name,Category,Description" }) | Where-Object { $_.Name -match "$Event" })
+            if (($local:Events).Count -eq 0)
+            {
+                $local:Events = ((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                                      -Parameters @{ fields = "Name,Category,Description" }) | Where-Object { $_.Category -match "$Event" })
+            }
+            if (($local:Events).Count -eq 0)
+            {
+                try
+                {
+                    $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                                        -Parameters @{ filter = "Description icontains '$Event'"; fields = "Name,Category,Description" })
+                }
+                catch
+                {
+                    Write-Verbose $_
+                    Write-Verbose "Caught exception with icontains filter, trying with contains filter"
+                    $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                                        -Parameters @{ filter = "Description contains '$Event'"; fields = "Name,Category,Description" })
+                }
+            }
+
+            $local:Events = ($local:Events | Sort-Object -Property Name)
+
+            if (($local:Events).Count -eq 0)
+            {
+                throw "Unable to find event matching '$Event'..."
+            }
+
+            if (($local:Events).Count -ne 1)
+            {
+                $local:Longest = (($local:Events).Name | Measure-Object -Maximum -Property Length).Maximum
+                Write-Host "Found $($local:Events.Count) events matching '$Event':"
+                Write-Host "["
+                $local:Events | ForEach-Object {
+                    Write-Host ("    {0,$($local:Longest)} - {1}" -f $_.Name,$_.Description)
+                }
+                Write-Host "]"
+                $Event = (Read-Host "Enter event name or search string")
+            }
+            else
+            {
+                $local:FoundEvent = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET `
+                                         "Events/$($local:Events[0].Name)")
+            }
+        }
+    }
+    $local:FoundEvent
+}
 function Resolve-SubscriptionEvent
 {
     [CmdletBinding()]
@@ -47,7 +125,10 @@ function Resolve-SubscriptionEvent
 Get information on events in Safeguard via the Web API.
 
 .DESCRIPTION
-Safeguard events are events that occur as a result of an administrative activity such as created and deletion of an asset or an account.
+Safeguard events occur as a result of  or access request or administrative activity.
+Administrative activity includes creation and deletion of assets or accounts.  This
+cmdlet helps you get information about events.  This cmdlet tries to get a single event
+by matching name, if that doesn't work it tries category, and finally description.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -92,18 +173,18 @@ function Get-SafeguardEvent
         [string[]]$Fields
     )
 
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
     $local:Parameters = $null
     if ($Fields)
     {
         $local:Parameters = @{ fields = ($Fields -join ",")}
     }
 
-    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
-    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-
     if ($PSBoundParameters.ContainsKey("EventToGet"))
     {
-        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Events/$EventToGet" -Parameters $local:Parameters
+        Resolve-Event -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $EventToGet
     }
     else
     {
@@ -162,23 +243,76 @@ function Get-SafeguardEventName
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
-    [object[]]$Names = $null
+
+    [object[]]$local:Names = $null
     $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events)
-    foreach ($IndividualEvent in $Events)
+    foreach ($local:IndividualEvent in $local:Events)
     {
         if ($PSBoundParameters.ContainsKey("TypeofEvent"))
         {
-            if(($IndividualEvent).ObjectType -eq $TypeofEvent)
+            if (($local:IndividualEvent).ObjectType -eq $TypeofEvent)
             {
-                $Names += $(($local:IndividualEvent).Name)
+                $local:Names += $(($local:IndividualEvent).Name)
             }
         }
         else
         {
-            $Names += $(($local:IndividualEvent).Name)
+            $local:Names += $(($local:IndividualEvent).Name)
         }
     }
-    return $Names
+    $local:Names
+}
+
+<#
+.SYNOPSIS
+Get information on events in Safeguard via the Web API.
+
+.DESCRIPTION
+Safeguard events occur as a result of  or access request or administrative activity.
+Administrative activity includes creation and deletion of assets or accounts.  This
+cmdlet helps you get information about events.  This cmdlet gets the properties that
+will be sent to subscribers of an event.  This cmdlet uses Get-SafeguardEvent to
+locate a single event.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER EventToGet
+A string containing the name of the event to get.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardEventProperty AssetCreated
+#>
+function Get-SafeguardEventProperty
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$EventToGet
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    (Get-SafeguardEvent -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $EventToGet).Properties | Format-Table Name,Description
 }
 
 <#

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -256,6 +256,9 @@ A string to search for in the policy asset.
 .PARAMETER QueryFilter
 A string to pass to the -filter query parameter in the Safeguard Web API.
 
+.PARAMETER Fields
+An array of the policy asset property names to return.
+
 .INPUTS
 None.
 
@@ -272,7 +275,7 @@ Find-SafeguardPolicyAsset "HP-UX"
 Find-SafeguardPolicyAsset -QueryFilter "AllowSessionRequests eq False"
 
 .EXAMPLE
-Find-SafeguardPolicyAsset -QueryFilter "Disabled eq True"
+Find-SafeguardPolicyAsset -QueryFilter "Disabled eq True" -Fields Id,Name
 #>
 function Find-SafeguardPolicyAsset
 {
@@ -287,7 +290,9 @@ function Find-SafeguardPolicyAsset
         [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
         [string]$SearchString,
         [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
-        [string]$QueryFilter
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -295,13 +300,23 @@ function Find-SafeguardPolicyAsset
 
     if ($PSCmdlet.ParameterSetName -eq "Search")
     {
+        $local:Parameters = @{ q = $SearchString }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
-            -Parameters @{ q = $SearchString }
+            -Parameters $local:Parameters
     }
     else
     {
+        $local:Parameters = @{ filter = $QueryFilter }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
-            -Parameters @{ filter = $QueryFilter }
+            -Parameters $local:Parameters
     }
 }
 
@@ -417,6 +432,9 @@ A string to search for in the policy account.
 .PARAMETER QueryFilter
 A string to pass to the -filter query parameter in the Safeguard Web API.
 
+.PARAMETER Fields
+An array of the event property names to return.
+
 .INPUTS
 None.
 
@@ -445,7 +463,9 @@ function Find-SafeguardPolicyAccount
         [Parameter(Mandatory=$true,Position=0,ParameterSetName="Search")]
         [string]$SearchString,
         [Parameter(Mandatory=$true,Position=0,ParameterSetName="Query")]
-        [string]$QueryFilter
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -453,13 +473,23 @@ function Find-SafeguardPolicyAccount
 
     if ($PSCmdlet.ParameterSetName -eq "Search")
     {
+        $local:Parameters = @{ q = $SearchString }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAccounts `
-            -Parameters @{ q = $SearchString }
+            -Parameters $local:Parameters
     }
     else
     {
+        $local:Parameters = @{ filter = $QueryFilter }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAccounts `
-            -Parameters @{ filter = $QueryFilter }
+            -Parameters $local:Parameters
     }
 }
 

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -216,7 +216,8 @@ FunctionsToExport = @(
     'Get-SafeguardAccessPolicySessionProperty','Get-SafeguardUserLinkedAccount','Add-SafeguardUserLinkedAccount',
     'Remove-SafeguardUserLinkedAccount',
     # events.psm1
-    'Get-SafeguardEvent', 'Get-SafeguardEventName', 'Get-SafeguardEventSubscription', 'Find-SafeguardEventSubscription',
+    'Get-SafeguardEvent','Get-SafeguardEventName','Find-SafeguardEvent',
+    'Get-SafeguardEventSubscription', 'Find-SafeguardEventSubscription',
     'New-SafeguardEventSubscription', 'Remove-SafeguardEventSubscription', 'Edit-SafeguardEventSubscription',
     # clustering.psm1
     'Get-SafeguardClusterMember','Get-SafeguardClusterHealth','Get-SafeguardClusterOperationStatus',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -216,7 +216,7 @@ FunctionsToExport = @(
     'Get-SafeguardAccessPolicySessionProperty','Get-SafeguardUserLinkedAccount','Add-SafeguardUserLinkedAccount',
     'Remove-SafeguardUserLinkedAccount',
     # events.psm1
-    'Get-SafeguardEvent','Get-SafeguardEventName','Find-SafeguardEvent',
+    'Get-SafeguardEvent','Get-SafeguardEventName','Get-SafeguardEventProperty','Find-SafeguardEvent',
     'Get-SafeguardEventSubscription', 'Find-SafeguardEventSubscription',
     'New-SafeguardEventSubscription', 'Remove-SafeguardEventSubscription', 'Edit-SafeguardEventSubscription',
     # clustering.psm1

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -85,9 +85,17 @@ namespace Ex
             catch {}
             if ($local:ResponseObject.Code) # Safeguard error
             {
+                $local:Message = $local:ResponseObject.Message
+                if ($local:ResponseObject.ModelState)
+                {
+                    $local:Properties = ($local:ResponseObject.ModelState | Get-Member | Where-Object { $_.MemberType -eq "NoteProperty" }).Name
+                    $local:Properties | ForEach-Object {
+                        $local:Message += (" " + $_ + ": " + ($local:ResponseObject.ModelState."$_" -join ","))
+                    }
+                }
                 $local:ExceptionToThrow = (New-Object Ex.SafeguardMethodException -ArgumentList @(
                     [int]$ThrownException.Response.StatusCode, $local:StatusDescription,
-                    $local:ResponseObject.Code, $local:ResponseObject.Message, $local:ResponseBody
+                    $local:ResponseObject.Code, $local:Message, $local:ResponseBody
                 ))
             }
             elseif ($local:ResponseObject.error_description) # rSTS error

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -121,6 +121,10 @@ namespace Ex
             ))
         }
     }
+    if ($ThrownException.Status -eq "TrustFailure")
+    {
+        Write-Host -ForegroundColor Magenta "To ignore SSL/TLS trust failure use the -Insecure parameter to bypass server certificate validation."
+    }
     Write-Verbose "---Exception---"
     $ThrownException | Format-List * -Force | Out-String | Write-Verbose
     if ($ThrownException.InnerException)


### PR DESCRIPTION
- Added -Fields support to Get-SafeguardEvent, Find-SafeguardDirectoryAccount, Find-SafeguardPolicyAsset, Find-SafeguardPolicyAccount
- Added Find-SafeguardEvent
- Added Get-SafeguardEventProperty
- Fix for API validation errors (ModelState) only showing up in the Verbose output
- Tip for failed SSL/TLS connection to use -Insecure parameter

This includes a fix for #255 