### PR TITLE
Issue 261: Active Directory Certificate Authentication

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -712,8 +712,17 @@ function Connect-Safeguard
                         break
                     }
                     "Certificate" {
-                        $IdentityProvider = "certificate"
-                        $local:Scope = "rsts:sts:primaryproviderid:certificate"
+                        # If the user manually entered an Identity Provider ID, use it.
+                        # Otherwise, we'll default to the built-in Certificate provider.
+                        if ($IdentityProvider)
+                        {
+                            $local:Scope = "rsts:sts:primaryproviderid:$($IdentityProvider)"
+                        }
+                        else
+                        {
+                            $IdentityProvider = "certificate"
+                            $local:Scope = "rsts:sts:primaryproviderid:certificate"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
If an `-IdentityProvider` parameter was explicitly specified, use it for certificate authentication instead of always defaulting to the built-in `certificate` provider.