### PR TITLE
TFS 244656 : Add a new cmdlet to safeguard-ps for configuring "Trusted Servers" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,3 +659,8 @@ update this list.
 - Get-SafeguardReportUserGroupMembership
 - Get-SafeguardReportAssetManagementConfiguration
 - Get-SafeguardReportA2aEntitlement
+
+### Appliance Settings
+
+- Get-SafeguardApplianceSetting
+- Set-SafeguardApplianceSetting

--- a/README.md
+++ b/README.md
@@ -664,3 +664,5 @@ update this list.
 
 - Get-SafeguardApplianceSetting
 - Set-SafeguardApplianceSetting
+- Get-SafeguardCoreSetting
+- Set-SafeguardCoreSetting

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -265,7 +265,7 @@ FunctionsToExport = @(
     'Get-SafeguardReportUserEntitlement','Get-SafeguardReportUserGroupMembership','Get-SafeguardReportAssetManagementConfiguration',
     'Get-SafeguardReportA2aEntitlement',
 	# setting.psm1
-	'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting'
+	'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting','Get-SafeguardCoreSetting','Set-SafeguardCoreSetting'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -96,7 +96,8 @@ NestedModules = @(
     'starling.psm1',
     'entitlements.psm1',
     'accesscert.psm1',
-    'reports.psm1'
+    'reports.psm1',
+	'settings.psm1'
     )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -262,7 +263,9 @@ FunctionsToExport = @(
     'Get-SafeguardReportDailyPasswordCheckFail','Get-SafeguardReportDailyPasswordCheckSuccess',
     'Get-SafeguardReportDailyPasswordChangeFail','Get-SafeguardReportDailyPasswordChangeSuccess',
     'Get-SafeguardReportUserEntitlement','Get-SafeguardReportUserGroupMembership','Get-SafeguardReportAssetManagementConfiguration',
-    'Get-SafeguardReportA2aEntitlement'
+    'Get-SafeguardReportA2aEntitlement',
+	# setting.psm1
+	'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/settings.psm1
+++ b/src/settings.psm1
@@ -4,7 +4,7 @@
 Get Safeguard appliance settings via the Web API.
 
 .DESCRIPTION
-Get the appliance settings of a Safeguard Appliance.
+Get the settings managed by the appliance service of a Safeguard appliance.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -31,9 +31,149 @@ JSON response from Safeguard Web API.
 Get-SafeguardApplianceSetting -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
-Get-SafeguardApplianceSetting -SettingName "Trusted Servers" -Fields Name,Category,DefaultValue
+Get-SafeguardApplianceSetting -SettingName "Backup Retention Number" -Fields Name,Category,DefaultValue
 #>
 function Get-SafeguardApplianceSetting
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, Position=0)]
+        [string]$SettingName,
+		[Parameter(Mandatory=$false)]
+        [string[]]$Fields
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+	$local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
+    if ($PSBoundParameters.ContainsKey("SettingName"))
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "Settings/$SettingName" -Parameters $local:Parameters
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "Settings" -Parameters $local:Parameters
+    }
+}
+
+
+<#
+.SYNOPSIS
+Set a Safeguard appliance setting via the Web API.
+
+.DESCRIPTION
+Set the value of a setting managed by the appliance service of a Safeguard appliance.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SettingName
+A string containing the name of the appliance setting.
+
+.PARAMETER Value
+A string containing the new value for the setting.
+
+.PARAMETER SettingObject
+An object containing an existing appliance setting object with the new value set.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardApplianceSetting -AccessToken $token -Appliance 10.5.32.54 -SettingObject $obj -Insecure
+
+.EXAMPLE
+Set-SafeguardApplianceSetting -SettingName "Minimum Process Log Level" -Value "Debug"
+#>
+function Set-SafeguardApplianceSetting
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes", Mandatory=$true, Position=0)]
+        [string]$SettingName,
+		[Parameter(ParameterSetName="Attributes", Mandatory=$true, Position=1)]
+		[AllowEmptyString()]
+        [string]$Value,
+		[Parameter(ParameterSetName="Object",Mandatory=$true, Position=0)]
+        [object]$SettingObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+	if (-not ($PsCmdlet.ParameterSetName -eq "Object"))
+    {
+        $SettingObject = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "Settings/$SettingName")
+        if ($PSBoundParameters.ContainsKey("Value")) { $SettingObject.Value = $Value }
+    }
+	
+	$SettingName = $SettingObject.Name
+	Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "Settings/$SettingName" -Body $SettingObject
+}
+
+
+<#
+.SYNOPSIS
+Get the Safeguard core settings via the Web API.
+
+.DESCRIPTION
+Get the settings managed by the core service of a Safeguard appliance.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SettingName
+A string containing the name of the core setting.
+
+.PARAMETER Fields
+An array of the setting property names to return.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardCoreSetting -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardCoreSetting -SettingName "Inform User of Bad Password" -Fields Name,Category,DefaultValue
+#>
+function Get-SafeguardCoreSetting
 {
     [CmdletBinding()]
     Param(
@@ -71,10 +211,10 @@ function Get-SafeguardApplianceSetting
 
 <#
 .SYNOPSIS
-Set a Safeguard appliance setting via the Web API.
+Set a Safeguard core setting via the Web API.
 
 .DESCRIPTION
-Set the value of a Safeguard appliance setting.
+Set the value of a setting managed by the core service of a Safeguard appliance.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -86,13 +226,13 @@ A string containing the bearer token to be used with Safeguard Web API.
 Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER SettingName
-A string containing the name of the appliance setting.
+A string containing the name of the core setting.
 
 .PARAMETER Value
 A string containing the new value for the setting.
 
 .PARAMETER SettingObject
-An object containing the existing appliance setting object with the new value set.
+An object containing an existing core setting object with the new value set.
 
 .INPUTS
 None.
@@ -101,12 +241,12 @@ None.
 JSON response from Safeguard Web API.
 
 .EXAMPLE
-Set-SafeguardApplianceSetting -AccessToken $token -Appliance 10.5.32.54 -SettingObject $obj -Insecure
+Set-SafeguardCoreSetting -AccessToken $token -Appliance 10.5.32.54 -SettingObject $obj -Insecure
 
 .EXAMPLE
-Set-SafeguardApplianceSetting -SettingName "Trusted Servers" -Value "10.5.32.55,test.server"
+Set-SafeguardCoreSetting -SettingName "Trusted Servers" -Value "10.5.32.55,test.server"
 #>
-function Set-SafeguardApplianceSetting
+function Set-SafeguardCoreSetting
 {
     [CmdletBinding(DefaultParameterSetName="Attributes")]
     Param(

--- a/src/settings.psm1
+++ b/src/settings.psm1
@@ -1,0 +1,139 @@
+
+<#
+.SYNOPSIS
+Get Safeguard appliance settings via the Web API.
+
+.DESCRIPTION
+Get the appliance settings of a Safeguard Appliance.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SettingName
+A string containing the name of the appliance setting.
+
+.PARAMETER Fields
+An array of the setting property names to return.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardApplianceSetting -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardApplianceSetting -SettingName "Trusted Servers" -Fields Name,Category,DefaultValue
+#>
+function Get-SafeguardApplianceSetting
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false, Position=0)]
+        [string]$SettingName,
+		[Parameter(Mandatory=$false)]
+        [string[]]$Fields
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+	$local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",")}
+    }
+
+    if ($PSBoundParameters.ContainsKey("SettingName"))
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings/$SettingName" -Parameters $local:Parameters
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings" -Parameters $local:Parameters
+    }
+}
+
+
+<#
+.SYNOPSIS
+Set a Safeguard appliance setting via the Web API.
+
+.DESCRIPTION
+Set the value of a Safeguard appliance setting.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SettingName
+A string containing the name of the appliance setting.
+
+.PARAMETER Value
+A string containing the new value for the setting.
+
+.PARAMETER SettingObject
+An object containing the existing appliance setting object with the new value set.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardApplianceSetting -AccessToken $token -Appliance 10.5.32.54 -SettingObject $obj -Insecure
+
+.EXAMPLE
+Set-SafeguardApplianceSetting -SettingName "Trusted Servers" -Value "10.5.32.55,test.server"
+#>
+function Set-SafeguardApplianceSetting
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes", Mandatory=$true, Position=0)]
+        [string]$SettingName,
+		[Parameter(ParameterSetName="Attributes", Mandatory=$true, Position=1)]
+		[AllowEmptyString()]
+        [string]$Value,
+		[Parameter(ParameterSetName="Object",Mandatory=$true, Position=0)]
+        [object]$SettingObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+	if (-not ($PsCmdlet.ParameterSetName -eq "Object"))
+    {
+        $SettingObject = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings/$SettingName")
+        if ($PSBoundParameters.ContainsKey("Value")) { $SettingObject.Value = $Value }
+    }
+	
+	$SettingName = $SettingObject.Name
+	Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Settings/$SettingName" -Body $SettingObject
+}


### PR DESCRIPTION
@DanPeterson Instead of writing cmdlets to configure only the "Trusted Servers" setting, I created the cmdlets that can be used to configure any appliance setting at service/core/v3/Settings. Let me know if you want me to write one specifically for the "Trusted Servers" Setting.