### PR TITLE
Couldn't upload patch to a 2.11 VM w/o enough disk space

### DIFF
--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -1461,7 +1461,8 @@ function Install-SafeguardPatch
             $local:JsonData = ([UploadFileStream]::Upload((Resolve-Path $Patch), $Appliance, $AccessToken, $Version))
             try
             {
-                Write-Verbose (ConvertFrom-Json $local:JsonData)
+                $local:JsonData = (ConvertFrom-Json $local:JsonData)
+                Write-Verbose $local:JsonData
             }
             catch
             {

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -1460,7 +1460,17 @@ function Install-SafeguardPatch
 
             Add-UploadFileStreamType
             $local:JsonData = ([UploadFileStream]::Upload((Resolve-Path $Patch), $Appliance, $AccessToken, $Version))
-            Write-Verbose (ConvertFrom-Json $local:JsonData)
+            try
+            {
+                Write-Verbose (ConvertFrom-Json $local:JsonData)
+            }
+            catch
+            {
+                Write-Verbose "[UploadFileStream]::Upload() didn't return valid JSON"
+                Write-Verbose "Output:"
+                Write-Verbose $local:JsonData
+            }
+
         }
         catch [System.Net.WebException]
         {

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -122,10 +122,9 @@ function Add-UploadFileStreamType
 
                         if (httpResponse != null)
                         {
+                            Console.WriteLine(log);
                             StreamReader sr = new StreamReader(httpResponse.GetResponseStream());
-
-                            log = sr.ReadToEnd() + "\r\n" + log;
-
+                            log = sr.ReadToEnd();
                             sr.Close();
                         }
                     }

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -1469,7 +1469,11 @@ function Install-SafeguardPatch
                 Write-Verbose "Output:"
                 Write-Verbose $local:JsonData
             }
-
+            if ($local:JsonData.Code)
+            {
+                $local:ErrMsg = "$($local:JsonData.Code): $($local:JsonData.Message)"
+                throw $local:ErrMsg
+            }
         }
         catch [System.Net.WebException]
         {


### PR DESCRIPTION
The error handling was wrong for this case in the upload code.  The response comes back weird with embedded json and a bunch of exception output attached.