### PR TITLE
Updates for PowerShell Core 7.x

### DIFF
--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -89,7 +89,7 @@ function Invoke-SafeguardA2aMethodWithCertificate
         Write-Warning "store, otherwise Windows doesn't think you have a matching certificate to send in the initial client"
         Write-Warning "connection. This occurs even if you pass in a PFX file specifying exactly which certificate to use."
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
     finally
     {

--- a/src/archives.psm1
+++ b/src/archives.psm1
@@ -241,7 +241,7 @@ function New-SafeguardArchiveServer
         Port = $Port;
         ServiceAccountCredentialType = $ServiceAccountCredentialType;
         ServiceAccountName = "$ServiceAccountName";
-        ServiceAccountPassword = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+        ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
     }
 
     if ($PSBoundParameters.ContainsKey("ServiceAccountDomainName"))
@@ -561,8 +561,7 @@ function Edit-SafeguardArchiveServer
         if ($PSBoundParameters.ContainsKey("ServiceAccountName")) { $ArchiveServerObject.ConnectionProperties.ServiceAccountName = "$ServiceAccountName" }
         if ($PSBoundParameters.ContainsKey("ServiceAccountPassword"))
         {
-            $ArchiveServerObject.ConnectionProperties.ServiceAccountName = `
-                [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+            $ArchiveServerObject.ConnectionProperties.ServiceAccountName = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
         }
         # Body
         if ($PSBoundParameters.ContainsKey("DisplayName")) { $ArchiveServerObject.Name = "$DisplayName" }

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -733,8 +733,7 @@ function New-SafeguardAsset
                     {
                         $ServiceAccountPassword = (Read-Host -AsSecureString "ServiceAccountPassword")
                     }
-                    $local:ConnectionProperties.ServiceAccountPassword = `
-                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                    $local:ConnectionProperties.ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
                 }
             }
             {$_ -eq "directorypassword"} {
@@ -1137,8 +1136,7 @@ function Edit-SafeguardAsset
 
         if ($PSBoundParameters.ContainsKey("ServiceAccountPassword"))
         {
-            $AssetObject.ConnectionProperties.ServiceAccountPassword = `
-                [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+            $AssetObject.ConnectionProperties.ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
         }
         if ($PSBoundParameters.ContainsKey("ServiceAccountSecretKey")) { AssetObject.ConnectionProperties.ServiceAccountSecretKey = $ServiceAccountSecretKey }
 
@@ -1742,7 +1740,7 @@ function Set-SafeguardAssetAccountPassword
     {
         $NewPassword = (Read-Host -AsSecureString "NewPassword")
     }
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($NewPassword))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $NewPassword).Password
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "AssetAccounts/$($local:AccountId)/Password" `
         -Body $local:PasswordPlainText
 }

--- a/src/certificates.psm1
+++ b/src/certificates.psm1
@@ -322,7 +322,7 @@ function Install-SafeguardAuditLogSigningCertificate
         Write-Host "For no password just press enter..."
         $Password = (Read-host "Password" -AsSecureString)
     }
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
 
     Write-Host "Uploading Certificate..."
     if ($local:PasswordPlainText)
@@ -464,7 +464,7 @@ function Install-SafeguardSslCertificate
         Write-Host "For no password just press enter..."
         $Password = (Read-host "Password" -AsSecureString)
     }
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
 
     Write-Host "Uploading Certificate..."
     if ($local:PasswordPlainText)
@@ -1148,7 +1148,7 @@ function New-SafeguardTestCertificatePki
     Write-Host "This cmdlet can be annoying because you have to type your password a lot... this is a limitation of the underlying tools"
     Write-Host -ForegroundColor Yellow "Just type the same password at all of the prompts!!! It can be as simple as one letter."
     $local:PasswordSecure = (Read-Host "Password" -AsSecureString)
-    $local:Password = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($local:PasswordSecure))
+    $local:Password = [System.Net.NetworkCredential]::new("", $local:PasswordSecure).Password
 
     $local:Name = "RootCA"
     $local:Subject = "CN=$($local:Name),$($local:SubjectBaseDn)"

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -422,8 +422,7 @@ function New-SafeguardDirectoryIdentityProvider
                     UseSslEncryption = $true;
                     VerifySslCertificate = $true;
                     ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName;
-                    ServiceAccountPassword = `
-                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                    ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
                 }
             }
         }
@@ -454,8 +453,7 @@ function New-SafeguardDirectoryIdentityProvider
                 ConnectionProperties = @{
                     ServiceAccountDomainName = $ServiceAccountDomainName;
                     ServiceAccountName = $ServiceAccountName;
-                    ServiceAccountPassword = `
-                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                    ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
                 }
             }
         }
@@ -1083,8 +1081,7 @@ function New-SafeguardDirectory
                     UseSslEncryption = $true;
                     VerifySslCertificate = $true;
                     ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName;
-                    ServiceAccountPassword = `
-                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                    ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
                 }
             }
             if ($PSBoundParameters.ContainsKey("NetworkAddress"))
@@ -1113,8 +1110,7 @@ function New-SafeguardDirectory
                 ConnectionProperties = @{
                     ServiceAccountDomainName = $ServiceAccountDomainName;
                     ServiceAccountName = $ServiceAccountName;
-                    ServiceAccountPassword = `
-                        [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+                    ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
                 }
             }
         }
@@ -1394,8 +1390,7 @@ function Edit-SafeguardDirectory
         if ($PSBoundParameters.ContainsKey("ServiceAccountName")) { $DirectoryObject.ConnectionProperties.ServiceAccountName = $ServiceAccountName }
         if ($PSBoundParameters.ContainsKey("ServiceAccountPassword"))
         {
-            $DirectoryObject.ConnectionProperties.ServiceAccountPassword = `
-                [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($ServiceAccountPassword))
+            $DirectoryObject.ConnectionProperties.ServiceAccountPassword = [System.Net.NetworkCredential]::new("", $ServiceAccountPassword).Password
         }
         if ($PSBoundParameters.ContainsKey("ServiceAccountDistinguishedName")) { $DirectoryObject.ConnectionProperties.ServiceAccountDistinguishedName = $ServiceAccountDistinguishedName }
         if ($NoSslEncryption)
@@ -2028,7 +2023,7 @@ function Set-SafeguardDirectoryAccountPassword
             $local:AccountId = (Resolve-SafeguardDirectoryAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AccountToSet)
         }
 
-        $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($NewPassword))
+        $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $NewPassword).Password
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DirectoryAccounts/$($local:AccountId)/Password" `
             -Body $local:PasswordPlainText -Version 2
     }

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -2469,7 +2469,7 @@ function Enable-SafeguardBmcConfiguration
     }
     if ($PSBoundParameters.ContainsKey("Password"))
     {
-        $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+        $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
         $local:Body.AdminPassword = $local:PasswordPlainText
     }
 
@@ -2581,7 +2581,7 @@ function Set-SafeguardBmcAdminPassword
         $Password = Read-Host -AsSecureString "Password"
     }
 
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
     $local:Body.AdminPassword = $local:PasswordPlainText
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT BmcConfiguration -Body $local:Body

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -1218,7 +1218,7 @@ function Get-SafeguardSupportBundle
     catch [System.Net.WebException]
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
     catch
     {
@@ -1479,7 +1479,7 @@ function Install-SafeguardPatch
         catch [System.Net.WebException]
         {
             Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-            Out-SafeguardExceptionIfPossible $_.Exception
+            Out-SafeguardExceptionIfPossible $_
         }
         finally
         {
@@ -1708,7 +1708,7 @@ function Set-SafeguardPatch
     catch [System.Net.WebException]
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
     finally
     {
@@ -1990,7 +1990,7 @@ function Export-SafeguardBackup
     catch [System.Net.WebException]
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
     catch
     {
@@ -2118,7 +2118,7 @@ function Import-SafeguardBackup
     catch [System.Net.WebException]
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
     catch
     {

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -429,7 +429,7 @@ function Invoke-Internal
     catch
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        Out-SafeguardExceptionIfPossible $_.Exception
+        Out-SafeguardExceptionIfPossible $_
     }
 }
 
@@ -748,7 +748,7 @@ function Connect-Safeguard
                 catch
                 {
                     Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-                    Out-SafeguardExceptionIfPossible $_.Exception
+                    Out-SafeguardExceptionIfPossible $_
                 }
             }
             else # Assume Client Certificate Authentication
@@ -793,7 +793,7 @@ function Connect-Safeguard
                     Write-Verbose "certificate to send in the initial client connection. This occurs even if you pass in a PFX file specifying"
                     Write-Verbose "exactly which certificate to use."
                     Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-                    Out-SafeguardExceptionIfPossible $_.Exception
+                    Out-SafeguardExceptionIfPossible $_
                 }
             }
         }

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -703,12 +703,12 @@ function Connect-Safeguard
                         {
                             $Password = (Read-Host "Password" -AsSecureString)
                         }
-                        $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+                        $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
                         break
                     }
                     "PSCredential" {
                         $Username = $Credential.UserName
-                        $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Credential.Password))
+                        $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Credential.Password).Password
                         break
                     }
                     "Certificate" {

--- a/src/sessionjoin.psm1
+++ b/src/sessionjoin.psm1
@@ -83,7 +83,7 @@ function Connect-Sps
         if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
     }
 
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($SessionPassword))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $SessionPassword).Password
 
     $local:BasicAuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $SessionUsername, $local:PasswordPlainText)))
     Remove-Variable -Scope local PasswordPlainText

--- a/src/sessionmodule.psm1
+++ b/src/sessionmodule.psm1
@@ -469,7 +469,7 @@ function Install-SafeguardSessionCertificate
         Write-Host "For no password just press enter..."
         $Password = (Read-host "Password" -AsSecureString)
     }
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT $local:RelativeUrl -Body @{
             Base64CertificateData = "$($local:CertificateContents)";

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -71,7 +71,7 @@ namespace Ex
         { # different properties and methods on net core
             try
             {
-                $local:ReadResult = $ThrownException.Response.Content.ReadAsStringAsync()
+                $local:ReadResult = $ThrownException.Response.Content.ReadAsStreamAsync()
                 $local:ReadResult.Wait()
                 if ($local:ReadResult.IsFaulted)
                 {
@@ -79,7 +79,12 @@ namespace Ex
                 }
                 else
                 {
-                    $local:ResponseBody = $local:ReadResult.Result
+                    $local:Stream = $local:ReadResult.Result
+                    $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+                    $local:Reader.BaseStream.Position = 0
+                    $local:Reader.DiscardBufferedData()
+                    $local:ResponseBody = $local:Reader.ReadToEnd()
+                    $local:Reader.Dispose()
                 }
             }
             catch

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -71,9 +71,21 @@ namespace Ex
         { # different properties and methods on net core
             try
             {
-                $local:ResponseBody = $ThrownException.Response.Content.ReadAsStringAsync().Result
+                $local:ReadResult = $ThrownException.Response.Content.ReadAsStringAsync()
+                $local:ReadResult.Wait()
+                if ($local:ReadResult.IsFaulted)
+                {
+                    Write-Verbose "Exception async fault reading response body: $($local:ReadResult.Exception)"
+                }
+                else
+                {
+                    $local:ResponseBody = $local:ReadResult.Result
+                }
             }
-            catch {}
+            catch
+            {
+                Write-Verbose "Exception thrown reading response body: $_"
+            }
         }
         if ($local:ResponseBody)
         {

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -5,11 +5,13 @@ function Out-SafeguardExceptionIfPossible
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory=$true,Position=0)]
-        [object]$ThrownException
+        [object]$PsExceptionObject
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:ThrownException = $PsExceptionObject.Exception
 
     if (-not ([System.Management.Automation.PSTypeName]"Ex.SafeguardMethodException").Type)
     {
@@ -44,54 +46,21 @@ namespace Ex
 }
 "@
     }
-    $local:ExceptionToThrow = $ThrownException
-    if ($ThrownException.Response)
+    $local:ExceptionToThrow = $local:ThrownException
+    if ($local:ThrownException.Response)
     {
         Write-Verbose "---Response Status---"
-        if ($ThrownException.Response | Get-Member StatusDescription -MemberType Properties)
+        if ($local:ThrownException.Response | Get-Member StatusDescription -MemberType Properties)
         {
             $local:StatusDescription = $ThrownException.Response.StatusDescription
         }
-        elseif ($ThrownException.Response | Get-Member ReasonPhrase -MemberType Properties)
+        elseif ($local:ThrownException.Response | Get-Member ReasonPhrase -MemberType Properties)
         {
             $local:StatusDescription = $ThrownException.Response.ReasonPhrase
         }
-        Write-Verbose "$([int]$ThrownException.Response.StatusCode) $($local:StatusDescription)"
+        Write-Verbose "$([int]$local:ThrownException.Response.StatusCode) $($local:StatusDescription)"
         Write-Verbose "---Response Body---"
-        if ($ThrownException.Response | Get-Member GetResponseStream -MemberType Methods)
-        {
-            $local:Stream = $ThrownException.Response.GetResponseStream()
-            $local:Reader = New-Object System.IO.StreamReader($local:Stream)
-            $local:Reader.BaseStream.Position = 0
-            $local:Reader.DiscardBufferedData()
-            $local:ResponseBody = $local:Reader.ReadToEnd()
-            $local:Reader.Dispose()
-        }
-        elseif ($ThrownException.Response | Get-Member Content -MemberType Properties)
-        { # different properties and methods on net core
-            try
-            {
-                $local:ReadResult = $ThrownException.Response.Content.ReadAsStreamAsync()
-                $local:ReadResult.Wait()
-                if ($local:ReadResult.IsFaulted)
-                {
-                    Write-Verbose "Exception async fault reading response body: $($local:ReadResult.Exception)"
-                }
-                else
-                {
-                    $local:Stream = $local:ReadResult.Result
-                    $local:Reader = New-Object System.IO.StreamReader($local:Stream)
-                    $local:Reader.BaseStream.Position = 0
-                    $local:Reader.DiscardBufferedData()
-                    $local:ResponseBody = $local:Reader.ReadToEnd()
-                    $local:Reader.Dispose()
-                }
-            }
-            catch
-            {
-                Write-Verbose "Exception thrown reading response body: $_"
-            }
-        }
+        $local:ResponseBody = $PsExceptionObject.ErrorDetails.Message
         if ($local:ResponseBody)
         {
             Write-Verbose $local:ResponseBody
@@ -126,7 +95,7 @@ namespace Ex
             {
                 $local:ExceptionToThrow = (New-Object Ex.SafeguardMethodException -ArgumentList @(
                     [int]$ThrownException.Response.StatusCode, $local:StatusDescription,
-                    0, "", $local:ResponseBody
+                    0, "<could not parse body>", $local:ResponseBody
                 ))
             }
         }
@@ -134,7 +103,7 @@ namespace Ex
         {
             $local:ExceptionToThrow = (New-Object Ex.SafeguardMethodException -ArgumentList @(
                 [int]$ThrownException.Response.StatusCode, $local:StatusDescription,
-                0, "", "<unable to retrieve response content>"
+                0, "<could not read body>", "<unable to retrieve response content>"
             ))
         }
     }

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -702,7 +702,7 @@ function New-SafeguardUser
         # Check the password complexity before creating the user so you don't end up with a user without a password
         try
         {
-            $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+            $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
             Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "Users/ValidatePassword" -Body `
                 $local:PasswordPlainText -RetryVersion 2 -RetryUrl "Users/ValidatePassword"
             $local:PasswordPlainText = ""
@@ -899,7 +899,7 @@ function Set-SafeguardUserPassword
         $Password = (Read-Host "Password" -AsSecureString)
     }
 
-    $local:PasswordPlainText = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password))
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Users/$($local:UserId)/Password" `
         -Body $local:PasswordPlainText -RetryVersion 2 -RetryUrl "Users/$($local:UserId)/Password"


### PR DESCRIPTION
This addresses the Connect-Safeguard issue in #288

I also found that there were some changes to .NET Core that affected the ability to get good error messages.  safeguard-ps wasn't able to get the response body from an exception so detailed error messages were hidden.