### PR TITLE
Bug fixes

### DIFF
--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -1719,6 +1719,9 @@ function Find-SafeguardDirectoryAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
+    $local:LdapPlatformId = (Find-SafeguardPlatform "OpenLDAP" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+    $local:AdPlatformId = (Find-SafeguardPlatform "Active Directory" -Appliance $Appliance -AccessToken $AccessToken)[0].Id
+
     try
     {
         if ($PSCmdlet.ParameterSetName -eq "Search")

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -1408,6 +1408,14 @@ function Edit-SafeguardDirectory
         if ($PSBoundParameters.ContainsKey("NetworkAddress")) { $DirectoryObject.NetworkAddress = $NetworkAddress }
     }
 
+    # Need AssetPartitionId to PUT a directory/asset object. Object returned from Directories endpoint does not contain AssetPartitionId property.
+    # Get the directory object from Asset endpoint instead
+    if(-not $DirectoryObject.AssetPartitionId) 
+    {
+        $AssetObject = Get-SafeguardAsset -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $DirectoryObject.Id
+        $DirectoryObject | Add-Member -MemberType ScriptProperty -Name 'AssetPartitionId' -Value { $AssetObject.AssetPartitionId }
+    }
+
     try
     {
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Directories/$($DirectoryObject.Id)" -Body $DirectoryObject -Version 2

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -1871,7 +1871,7 @@ function Edit-SafeguardDynamicAccountGroup
         CreatedDate = $local:Group.CreatedDate;
         CreatedByUserId = $local:Group.CreatedByUserId;
         CreatedByUserDisplayName = $local:Group.CreatedByUserDisplayName;
-        GroupingRule = (Convert-RuleToString $local:Group.AssetGroupingRule "account");
+        GroupingRule = (Convert-RuleToString $local:Group.GroupingRule "account");
     }
     New-Object PSObject -Property $local:Hash
 }

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -1810,8 +1810,8 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
-.PARAMETER Name
-A string containing the name for the new group.
+.PARAMETER GroupToEdit
+Name of the dynamic account group to edit.
 
 .PARAMETER Description
 A string containing the description for a new group specific to Safeguard.
@@ -1839,7 +1839,7 @@ function Edit-SafeguardDynamicAccountGroup
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [object]$GroupToGet,
+        [object]$GroupToEdit,
         [Parameter(Mandatory=$false)]
         [string]$Description,
         [Parameter(Mandatory=$false, Position=1)]
@@ -1849,7 +1849,7 @@ function Edit-SafeguardDynamicAccountGroup
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Group = (Get-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Account $GroupToGet)
+    $local:Group = (Get-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Account $GroupToEdit)
     if (-not $local:Group.IsDynamic)
     {
         throw "$($local:Group.Name) is not a dynamic account group"
@@ -2082,8 +2082,8 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
-.PARAMETER Name
-A string containing the name for the new group.
+.PARAMETER GroupToEdit
+Name of the dynamic asset group to edit.
 
 .PARAMETER Description
 A string containing the description for a new group specific to Safeguard.
@@ -2111,7 +2111,7 @@ function Edit-SafeguardDynamicAssetGroup
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [object]$GroupToGet,
+        [object]$GroupToEdit,
         [Parameter(Mandatory=$false)]
         [string]$Description,
         [Parameter(Mandatory=$false, Position=1)]
@@ -2121,7 +2121,7 @@ function Edit-SafeguardDynamicAssetGroup
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Group = (Get-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Asset $GroupToGet)
+    $local:Group = (Get-SafeguardGroup -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Asset $GroupToEdit)
     if (-not $local:Group.IsDynamic)
     {
         throw "$($local:Group.Name) is not a dynamic asset group"

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -127,9 +127,9 @@ function Add-UploadFileStreamType
                             log = sr.ReadToEnd();
                             sr.Close();
                         }
+                        throw new System.Exception(log);
                     }
-
-                    return log;
+                    throw;
                 }
                 finally
                 {
@@ -1458,6 +1458,7 @@ function Install-SafeguardPatch
                 if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
             }
 
+            # This will throw System.Exception if there is an error staging the patch
             Add-UploadFileStreamType
             $local:JsonData = ([UploadFileStream]::Upload((Resolve-Path $Patch), $Appliance, $AccessToken, $Version))
             try
@@ -1477,7 +1478,7 @@ function Install-SafeguardPatch
                 throw $local:ErrMsg
             }
         }
-        catch [System.Net.WebException]
+        catch [System.Exception]
         {
             Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
             Out-SafeguardExceptionIfPossible $_
@@ -1703,10 +1704,11 @@ function Set-SafeguardPatch
             if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
         }
 
+        # This will throw System.Exception if there is an error staging the patch
         Add-UploadFileStreamType
         [UploadFileStream]::Upload((Resolve-Path $Patch), $Appliance, $AccessToken, $Version)
     }
-    catch [System.Net.WebException]
+    catch [System.Exception]
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
         Out-SafeguardExceptionIfPossible $_

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -2222,11 +2222,10 @@ function Restore-SafeguardBackup
 
 <#
 .SYNOPSIS
-Delete a backup from a Safeguard appliance via the Web API.
+Save a Safeguard backup on an archive server via the Web API.
 
 .DESCRIPTION
-This cmdlet will delete a backup stored on a Safeguard appliance.  Only
-delete backups that you have either downloaded or archived.
+This cmdlet will archive a Safeguard backup by saving it to an archive server configured in Safeguard.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.


### PR DESCRIPTION
Fixes the following Issues:

- https://github.com/OneIdentity/safeguard-ps/issues/275 : Edit-SafeguardDirectory always gives error
- https://github.com/OneIdentity/safeguard-ps/issues/276 : Edit-SafeguardDynamicAccountGroup always returns an error
- https://github.com/OneIdentity/safeguard-ps/issues/277 : Find-SafeguardDirectoryAccount never returns anything
- https://github.com/OneIdentity/safeguard-ps/issues/279 : Edit-SafeguardDynamicAccountGroup and Edit-SafeguardDynamicAssetGroup parameter names
- https://github.com/OneIdentity/safeguard-ps/issues/284 : Save-SafeguardBackupToArchive description is the same as Remove-SafeguardBackup
- https://github.com/OneIdentity/safeguard-ps/issues/280 : Set-SafeguardPatch and Install-SafeguardPatch return JSON string but don't throw exceptions for errors