### PR TITLE
Disable-SslVerification can be called twice

### DIFF
--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -18,8 +18,14 @@ function Disable-SslVerification
         else
         {
             Write-Verbose "Disabling SSL on non-Windows platform"
-            $global:PSDefaultParameterValues.Add("Invoke-RestMethod:SkipCertificateCheck",$true)
-            $global:PSDefaultParameterValues.Add("Invoke-WebRequest:SkipCertificateCheck",$true)
+            if (-not $global:PSDefaultParameterValues.Contains("Invoke-RestMethod:SkipCertificateCheck"))
+            {
+                $global:PSDefaultParameterValues.Add("Invoke-RestMethod:SkipCertificateCheck",$true)
+            }
+            if (-not $global:PSDefaultParameterValues.Contains("Invoke-WebRequest:SkipCertificateCheck"))
+            {
+                $global:PSDefaultParameterValues.Add("Invoke-WebRequest:SkipCertificateCheck",$true)
+            }
         }
     }
     else


### PR DESCRIPTION
This results in a fatal error when the dictionary tries to add a
duplicate key.