### PR TITLE
Remove-SafeguardAccountGroup - Mark variable required so it gets prompted for

### DIFF
--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -1390,7 +1390,7 @@ function Remove-SafeguardAccountGroup
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$false,Position=0)]
+        [Parameter(Mandatory=$true,Position=0)]
         [object]$GroupToDelete
     )
 


### PR DESCRIPTION
If it's not marked required, and the user doesn't supply a value, it throws an error: "Cannot bind argument to parameter 'GroupToDelete' because it is null."