### PR TITLE
Long-running tasks not working in PS Core

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -612,7 +612,7 @@ function Wait-LongRunningTask
 
     $local:StartTime = (Get-Date)
     $local:TaskResult = $null
-    $local:TaskToPoll = $Response.Headers.Location
+    $local:TaskToPoll = $($Response.Headers.Location)
     do {
         $local:TaskResponse = (Invoke-RestMethod -Method GET -Headers $Headers -Uri $local:TaskToPoll)
         Write-Verbose $local:TaskResponse


### PR DESCRIPTION
Location header is an array and doesn't convert to a URI properly in PS Core