### PR TITLE
Fix v4 compatibility with network DNS suffix; add support for user-defined DNS name

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ update this list.
 - Get-SafeguardApplianceName
 - Set-SafeguardApplianceName
 - Get-SafeguardApplianceDnsSuffix
+- Set-SafeguardApplianceDnsSuffix
+- Get-SafeguardApplianceDnsName
 - Invoke-SafeguardApplianceShutdown
 - Invoke-SafeguardApplianceReboot
 - Invoke-SafeguardApplianceFactoryReset

--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ update this list.
 - Get-SafeguardHealth
 - Get-SafeguardApplianceName
 - Set-SafeguardApplianceName
+- Get-SafeguardApplianceDnsSuffix
 - Invoke-SafeguardApplianceShutdown
 - Invoke-SafeguardApplianceReboot
 - Invoke-SafeguardApplianceFactoryReset

--- a/install-local.ps1
+++ b/install-local.ps1
@@ -57,8 +57,9 @@ if (-not (Test-Path $ModuleDir))
 else
 {
     Write-Host "Removing module directory '$ModuleDir' contents"
-    (Get-ChildItem -recurse $ModuleDir) | Sort-Object -Property FullName -Descending | ForEach-Object {
-        $_.Delete()
+    (Get-ChildItem -Recurse $ModuleDir) | Sort-Object -Property FullName -Descending | ForEach-Object {
+        Write-Verbose "Removing $_"
+        $_.Delete($true)
     }
 }
 $VersionDir = (Join-Path $ModuleDir $ModuleDef["ModuleVersion"])

--- a/install-local.ps1
+++ b/install-local.ps1
@@ -59,7 +59,8 @@ else
     Write-Host "Removing module directory '$ModuleDir' contents"
     (Get-ChildItem -Recurse $ModuleDir) | Sort-Object -Property FullName -Descending | ForEach-Object {
         Write-Verbose "Removing $_"
-        $_.Delete($true)
+        if ($_ -is [System.IO.DirectoryInfo]) { $_.Delete($true) }
+        else { $_.Delete() }
     }
 }
 $VersionDir = (Join-Path $ModuleDir $ModuleDef["ModuleVersion"])

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -1420,12 +1420,6 @@ function Get-SafeguardDirectoryAccount
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Parameters = $null
-    if ($Fields)
-    {
-        $local:Parameters = @{ fields = ($Fields -join ",")}
-    }
-
     if ($PSBoundParameters.ContainsKey("DirectoryToGet"))
     {
         if ($PSBoundParameters.ContainsKey("AccountToGet"))

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1107,7 +1107,7 @@ function Edit-SafeguardEventSubscription
             $local:Body.UserId = $null
         }
 
-        if ($local:Body.UserId -ne $null)
+        if ($null -ne $local:Body.UserId)
         {
             $local:UserEmailAddress = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -UserToGet $local:Body.UserId).EmailAddress
             If([string]::IsNullOrWhitespace($local:UserEmailAddress))
@@ -1116,7 +1116,7 @@ function Edit-SafeguardEventSubscription
             }
         }
 
-        if(($local:Body.UserId -ne $null) -and $PSBoundParameters.ContainsKey("EmailAddress"))
+        if (($null -ne $local:Body.UserId) -and $PSBoundParameters.ContainsKey("EmailAddress"))
         {
             Write-Error -Message "You cannot specify both the UserID and an EmailAddress properties simultaneously." -Category InvalidArgument -ErrorAction Stop
         }

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -884,7 +884,7 @@ Get user-defined name of a Safeguard appliance via the Web API.
 
 .DESCRIPTION
 Get user-defined name of a Safeguard appliance. This name can be specified
-using the Set-SafeguardName cmdlet. Each appliance in a cluster can have a
+using the Set-SafeguardApplianceName cmdlet. Each appliance in a cluster can have a
 unique name.
 
 .PARAMETER Appliance
@@ -934,6 +934,9 @@ cluster can have a unique name.
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
 
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate
 
@@ -974,9 +977,10 @@ function Set-SafeguardApplianceName
 Get user-defined DNS suffix of a Safeguard appliance via the Web API.
 
 .DESCRIPTION
-Get user-defined name of a Safeguard appliance. This name can be specified
-using the Set-SafeguardName cmdlet. Each appliance in a cluster can have a
-unique name.
+Get user-defined DNS suffix of a Safeguard appliance. This value can be specified
+using the Set-SafeguardApplianceDnsSuffix cmdlet. Each appliance in a cluster can have a
+unique name.  The appliance name and appliance DNS suffix can be combined to get the full
+DNS name of the appliance.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -1012,6 +1016,107 @@ function Get-SafeguardApplianceDnsSuffix
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status).HostDnsSuffix
+}
+
+<#
+.SYNOPSIS
+Set user-defined DNS suffx of a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Set user-defined DNS suffx of a Safeguard appliance. Each appliance in a
+cluster can have a unique name and a DNS suffix.  Together they specify the
+full DNS name of the appliance.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate
+
+.PARAMETER Name
+A string containing the name to give the appliance.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardApplianceDnsSuffix mycompany.corp
+#>
+function Set-SafeguardApplianceDnsSuffix
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$DnsSuffix
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT ApplianceStatus/HostDnsSuffix -Body $DnsSuffix
+}
+
+<#
+.SYNOPSIS
+Get user-defined DNS name of a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Get user-defined DNS name of a Safeguard appliance. Each appliance in a cluster can have a
+unique DNS name.  The appliance name and appliance DNS suffix are combined to get the full
+DNS name of the appliance.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardApplianceDnsName
+
+.EXAMPLE
+Get-SafeguardApplianceDnsName -Appliance 10.5.32.54 -Insecure
+#>
+function Get-SafeguardApplianceDnsName
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    $local:Status = (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status)
+    if ($local:Status.HostDnsSuffix)
+    {
+        "$($local:Status.ApplianceName).$($local:Status.HostDnsSuffix)"
+    }
+    else
+    {
+        Write-Host -ForegroundColor Yellow "Appliance DNS suffix is not set, use Set-SafeguardApplianceDnsSuffix"
+        $local:Status.ApplianceName
+    }
 }
 
 <#

--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -900,10 +900,10 @@ None.
 JSON response from Safeguard Web API.
 
 .EXAMPLE
-Get-SafeguardName
+Get-SafeguardApplianceName
 
 .EXAMPLE
-Get-SafeguardName -Appliance 10.5.32.54 -Insecure
+Get-SafeguardApplianceName -Appliance 10.5.32.54 -Insecure
 #>
 function Get-SafeguardApplianceName
 {
@@ -933,9 +933,6 @@ cluster can have a unique name.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
-
-.PARAMETER AccessToken
-A string containing the bearer token to be used with Safeguard Web API.
 
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate
@@ -970,6 +967,51 @@ function Set-SafeguardApplianceName
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT ApplianceStatus/Name -Body $Name
+}
+
+<#
+.SYNOPSIS
+Get user-defined DNS suffix of a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Get user-defined name of a Safeguard appliance. This name can be specified
+using the Set-SafeguardName cmdlet. Each appliance in a cluster can have a
+unique name.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardApplianceDnsSuffix
+
+.EXAMPLE
+Get-SafeguardApplianceDnsSuffix -Appliance 10.5.32.54 -Insecure
+#>
+function Get-SafeguardApplianceDnsSuffix
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    (Invoke-SafeguardMethod -Anonymous -Appliance $Appliance -Insecure:$Insecure Notification GET Status).HostDnsSuffix
 }
 
 <#

--- a/src/networking.psm1
+++ b/src/networking.psm1
@@ -211,17 +211,11 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
-.PARAMETER Interface
-A string containing the name of the network interface to get (e.g. X0, X1).
-
 .INPUTS
 None.
 
 .OUTPUTS
 JSON response from Safeguard Web API.
-
-.EXAMPLE
-Get-SafeguardNetworkInterface X0
 
 .EXAMPLE
 Get-SafeguardNetworkInterface

--- a/src/networking.psm1
+++ b/src/networking.psm1
@@ -235,7 +235,7 @@ function Get-SafeguardDnsSuffix
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "NetworkDnsSuffixConfig/$($Interface.ToUpper())"
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "NetworkDnsSuffixConfig"
 }
 
 <#

--- a/src/networking.psm1
+++ b/src/networking.psm1
@@ -235,10 +235,7 @@ function Get-SafeguardDnsSuffix
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [ValidateSet("Mgmt", "X0", "X1", IgnoreCase=$true)]
-        [string]$Interface
+        [switch]$Insecure
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }

--- a/src/networking.psm1
+++ b/src/networking.psm1
@@ -254,9 +254,6 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
 
-.PARAMETER Interface
-A string containing the name of the network interface to set DNS suffixes for (e.g. X0, X1).
-
 .PARAMETER DnsSuffixes
 An array of strings containing the DNS suffixes to set.
 
@@ -282,9 +279,6 @@ function Set-SafeguardDnsSuffix
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=0)]
-        [ValidateSet("Mgmt", "X0", "X1", IgnoreCase=$true)]
-        [string]$Interface,
         [Parameter(Mandatory=$true,Position=1)]
         [string[]]$DnsSuffixes
     )
@@ -292,7 +286,7 @@ function Set-SafeguardDnsSuffix
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "NetworkDnsSuffixConfig/$($Interface.ToUpper())" -Body @{
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "NetworkDnsSuffixConfig" -Body @{
         DomainNames = $DnsSuffixes
     }
 }

--- a/src/networking.psm1
+++ b/src/networking.psm1
@@ -279,7 +279,7 @@ function Set-SafeguardDnsSuffix
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,Position=1)]
+        [Parameter(Mandatory=$true,Position=0)]
         [string[]]$DnsSuffixes
     )
 

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -132,6 +132,7 @@ FunctionsToExport = @(
     'Get-SafeguardStatus','Get-SafeguardApplianceAvailability','Get-SafeguardApplianceState','Wait-SafeguardApplianceStateOnline',
     'Get-SafeguardVersion','Test-SafeguardVersion','Get-SafeguardApplianceVerification','Get-SafeguardTime','Set-SafeguardTime',
     'Get-SafeguardApplianceUptime','Get-SafeguardHealth','Get-SafeguardApplianceName','Set-SafeguardApplianceName',
+    'Get-SafeguardApplianceDnsSuffix',
     'Invoke-SafeguardApplianceShutdown','Invoke-SafeguardApplianceReboot','Invoke-SafeguardApplianceFactoryReset',
     'Get-SafeguardSupportBundle','Get-SafeguardSupportBundleQuickGlance','Get-SafeguardPatch','Clear-SafeguardPatch','Install-SafeguardPatch', 'Set-SafeguardPatch',
     'New-SafeguardBackup','Remove-SafeguardBackup','Export-SafeguardBackup','Import-SafeguardBackup',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -132,7 +132,7 @@ FunctionsToExport = @(
     'Get-SafeguardStatus','Get-SafeguardApplianceAvailability','Get-SafeguardApplianceState','Wait-SafeguardApplianceStateOnline',
     'Get-SafeguardVersion','Test-SafeguardVersion','Get-SafeguardApplianceVerification','Get-SafeguardTime','Set-SafeguardTime',
     'Get-SafeguardApplianceUptime','Get-SafeguardHealth','Get-SafeguardApplianceName','Set-SafeguardApplianceName',
-    'Get-SafeguardApplianceDnsSuffix',
+    'Get-SafeguardApplianceDnsSuffix','Set-SafeguardApplianceDnsSuffix','Get-SafeguardApplianceDnsName',
     'Invoke-SafeguardApplianceShutdown','Invoke-SafeguardApplianceReboot','Invoke-SafeguardApplianceFactoryReset',
     'Get-SafeguardSupportBundle','Get-SafeguardSupportBundleQuickGlance','Get-SafeguardPatch','Clear-SafeguardPatch','Install-SafeguardPatch', 'Set-SafeguardPatch',
     'New-SafeguardBackup','Remove-SafeguardBackup','Export-SafeguardBackup','Import-SafeguardBackup',

--- a/src/starling.psm1
+++ b/src/starling.psm1
@@ -323,54 +323,54 @@ function Remove-SafeguardStarling2FA
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-	try
-	{
-		$local:UserIds = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
-										 -Parameters @{ filter = "SecondaryAuthenticationProviderTypeReferenceName in ['StarlingSubscription', 'StarlingTwoFactor']"; fields = "Id" })
-		$local:FailedIds =@()
-		$local:SucceededIds = @()
+    try
+    {
+        $local:UserIds = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+                            -Parameters @{ filter = "SecondaryAuthenticationProviderTypeReferenceName in ['StarlingSubscription', 'StarlingTwoFactor']"; fields = "Id" })
+        $local:FailedIds =@()
+        $local:SucceededIds = @()
 
-		Foreach ($Id in $local:UserIds)
-		{
-			$UserObject = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Id)
+        Foreach ($Id in $local:UserIds)
+        {
+            $UserObject = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Id)
 
-			if ($null -ne $UserObject)
-			{
-				$UserObject.SecondaryAuthenticationProviderId = $null
-				$UserObject.SecondaryAuthenticationProviderName = $null
-				$UserObject.SecondaryAuthenticationProviderTypeReferenceName = "Unknown"
-				$UserObject.SecondaryAuthenticationIdentity = $null
-				try
-				{
-					Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Users/$($UserObject.Id)" -Body $UserObject
-					$local:SucceededIds += $UserObject.Id
-				}
-				catch
-				{
-					$local:FailedIds += $UserObject.Id
-				}
-			}
-			else
-			{
-				$local:FailedIds += $UserObject.Id
-			}
-		}
+            if ($null -ne $UserObject)
+            {
+                $UserObject.SecondaryAuthenticationProviderId = $null
+                $UserObject.SecondaryAuthenticationProviderName = $null
+                $UserObject.SecondaryAuthenticationProviderTypeReferenceName = "Unknown"
+                $UserObject.SecondaryAuthenticationIdentity = $null
+                try
+                {
+                    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Users/$($UserObject.Id)" -Body $UserObject
+                    $local:SucceededIds += $UserObject.Id
+                }
+                catch
+                {
+                    $local:FailedIds += $UserObject.Id
+                }
+            }
+            else
+            {
+                $local:FailedIds += $UserObject.Id
+            }
+        }
 
-		if ($null -ne $local:FailedIds)
-		{
-			$FIds = ($local:FailedIds -join ",")
-			Write-Host "Failed for users: $FIds"
-		}
-		if ($null -ne $local:SucceededIds)
-		{
-			$SIds = $local:SucceededIds -join ","
-			Write-Host "Succeeded for users: $SIds"
-		}
-	}
-	catch
-	{
-		Write-Host "Error occured while removing Starling Two Factor authentication from user(s)."
-	}
+        if ($null -ne $local:FailedIds)
+        {
+            $FIds = ($local:FailedIds -join ",")
+            Write-Host "Failed for users: $FIds"
+        }
+        if ($null -ne $local:SucceededIds)
+        {
+            $SIds = $local:SucceededIds -join ","
+            Write-Host "Succeeded for users: $SIds"
+        }
+    }
+    catch
+    {
+        Write-Host "Error occured while removing Starling Two Factor authentication from user(s)."
+    }
 }
 
 <#

--- a/src/starling.psm1
+++ b/src/starling.psm1
@@ -317,25 +317,25 @@ function Remove-SafeguardStarling2FA
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure  
+        [switch]$Insecure
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-	try 
+	try
 	{
 		$local:UserIds = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
-										 -Parameters @{ filter = "SecondaryAuthenticationProviderTypeReferenceName in ['StarlingSubscription', 'StarlingTwoFactor']"; fields = "Id" })   
+										 -Parameters @{ filter = "SecondaryAuthenticationProviderTypeReferenceName in ['StarlingSubscription', 'StarlingTwoFactor']"; fields = "Id" })
 		$local:FailedIds =@()
 		$local:SucceededIds = @()
 
 		Foreach ($Id in $local:UserIds)
 		{
 			$UserObject = (Get-SafeguardUser -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $Id)
-			
-			if($UserObject -ne $null)
-			{				
+
+			if ($null -ne $UserObject)
+			{
 				$UserObject.SecondaryAuthenticationProviderId = $null
 				$UserObject.SecondaryAuthenticationProviderName = $null
 				$UserObject.SecondaryAuthenticationProviderTypeReferenceName = "Unknown"
@@ -355,15 +355,15 @@ function Remove-SafeguardStarling2FA
 				$local:FailedIds += $UserObject.Id
 			}
 		}
-		
-		if ($local:FailedIds -ne $null)
+
+		if ($null -ne $local:FailedIds)
 		{
 			$FIds = ($local:FailedIds -join ",")
 			Write-Host "Failed for users: $FIds"
 		}
-		if ($local:SucceededIds -ne $null)
+		if ($null -ne $local:SucceededIds)
 		{
-			$SIds = $local:SucceededIds -join ","           
+			$SIds = $local:SucceededIds -join ","
 			Write-Host "Succeeded for users: $SIds"
 		}
 	}


### PR DESCRIPTION
This is the fix to #389.

Also added the ability to specify the appliance DNS suffix and get the full DNS name via the API.