### PR TITLE
Modified a2a for v4 -- removed reference to SystemId and SystemName in favor of Asset

### DIFF
--- a/samples/simulate-webui-login.ps1
+++ b/samples/simulate-webui-login.ps1
@@ -35,15 +35,15 @@ Write-Host -ForegroundColor Yellow  "GET Cluster Status:"
 $status = Invoke-SafeguardMethod Core GET "Cluster/Status"
 
 # GET core/v3/Me
-Write-Host -ForegroundColor Yellow  "GET Me" 
+Write-Host -ForegroundColor Yellow  "GET Me"
 $me = Invoke-SafeguardMethod Core GET "Me"
 
 # GET core/v3/DailyMessage
-Write-Host -ForegroundColor Yellow  "GET Daily Message:" 
+Write-Host -ForegroundColor Yellow  "GET Daily Message:"
 $dm = Invoke-SafeguardMethod Core GET "DailyMessage"
 
 # GET core/v3/LoginMessage
-Write-Host -ForegroundColor Yellow  "GET Login Message:" 
+Write-Host -ForegroundColor Yellow  "GET Login Message:"
 $lm = Invoke-SafeguardMethod Core GET "LoginMessage"
 
 # GET core/v3/RequestFavorites
@@ -55,7 +55,7 @@ Write-Host -ForegroundColor Yellow  "GET Actionable Requests:"
 $actionableRequests = Invoke-SafeguardMethod Core GET "Me/ActionableRequests"
 
 # GET core/v3/Me?fields=Id
-Write-Host -ForegroundColor Yellow  "GET Me.Id" 
+Write-Host -ForegroundColor Yellow  "GET Me.Id"
 $userId = Invoke-SafeguardMethod Core GET "Me?fields=Id"
 
 # GET core/v3/Me/AccessRequestAssets?filter=Disabled%20eq%20false&fields=Id,Name,NetworkAddress,PlatformDisplayName&orderby=Name
@@ -91,7 +91,7 @@ $body = @( @{
     RequestedDurationDays = 0
     RequestedDurationHours = 10
     RequestedDurationMinutes = 0
-    SystemId = $($selectedAsset.Id)
+    AssetId = $($selectedAsset.Id)
     AccountId = $($selectedAccount.Id)
     AccessRequestType = "Password"
     })
@@ -124,7 +124,7 @@ Write-Host -ForegroundColor Yellow  "POST CheckIn"
 $checkInResponse = Invoke-SafeguardMethod Core POST "AccessRequests/$($batchCreateResponse.Response.Id)/CheckIn"
 
 # GET core/v3/Me/ActionableRequests
-Write-Host -ForegroundColor Yellow  "GET Actionable Request" 
+Write-Host -ForegroundColor Yellow  "GET Actionable Request"
 $actionableRequests = Invoke-SafeguardMethod Core GET "Me/ActionableRequests"
 
 # -- Logout --

--- a/src/a2a.psm1
+++ b/src/a2a.psm1
@@ -71,7 +71,7 @@ function Resolve-SafeguardA2aAccountId
         [Parameter(Mandatory=$true,Position=1)]
         [object]$Account,
         [Parameter(Mandatory=$false)]
-        [object]$System
+        [object]$Asset
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -85,9 +85,9 @@ function Resolve-SafeguardA2aAccountId
     if (-not ($Account -as [int]))
     {
         $local:Filter = "AccountName ieq '$Account'"
-        if ($PSBoundParameters.ContainsKey("System") -and $System)
+        if ($PSBoundParameters.ContainsKey("Asset") -and $Asset)
         {
-            $local:Filter += "and SystemName ieq '$System'"
+            $local:Filter += "and AssetName ieq '$Asset'"
         }
         try
         {
@@ -589,8 +589,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -620,7 +620,7 @@ function Get-SafeguardA2aCredentialRetrieval
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -651,7 +651,7 @@ function Get-SafeguardA2aCredentialRetrieval
         else
         {
             $local:AccountId = (Resolve-SafeguardA2aAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-                $local:A2aId $Account -System $System)
+                $local:A2aId $Account -Asset $Asset)
         }
 
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -684,8 +684,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -718,7 +718,7 @@ function Add-SafeguardA2aCredentialRetrieval
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -752,21 +752,21 @@ function Add-SafeguardA2aCredentialRetrieval
     if ($PsCmdlet.ParameterSetName -eq "Object")
     {
         $local:Body.AccountId = $AccountObj.Id
-        $local:Body.SystemId = $AccountObj.SystemId
+        $local:Body.AssetId = $AccountObj.AssetId
     }
     else
     {
         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-        if ($System)
+        if ($Asset)
         {
-            $local:Body.SystemId = (Resolve-SafeguardSystemId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System)
-            $local:Body.AccountId = (Resolve-SafeguardAccountIdWithSystemId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure `
-                $local:Body.SystemId $Account)
+            $local:Body.AssetId = (Resolve-SafeguardAssetId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Asset)
+            $local:Body.AccountId = (Resolve-SafeguardAccountIdWithAssetId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure `
+                $local:Body.AssetId $Account)
         }
         else
         {
             Import-Module -Name "$PSScriptRoot\assets.psm1" -Scope Local
-            $local:Body.AccountId = (Resolve-SafeguardAccountIdWithoutSystemId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Account)
+            $local:Body.AccountId = (Resolve-SafeguardAccountIdWithoutAssetId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Account)
         }
     }
 
@@ -804,8 +804,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -835,7 +835,7 @@ function Remove-SafeguardA2aCredentialRetrieval
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -859,7 +859,7 @@ function Remove-SafeguardA2aCredentialRetrieval
     else
     {
         $local:AccountId = (Resolve-SafeguardA2aAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-            $local:A2aId $Account -System $System)
+            $local:A2aId $Account -Asset $Asset)
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -890,8 +890,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -921,7 +921,7 @@ function Get-SafeguardA2aCredentialRetrievalIpRestriction
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -944,7 +944,7 @@ function Get-SafeguardA2aCredentialRetrievalIpRestriction
     else
     {
         (Get-SafeguardA2aCredentialRetrieval -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-            $local:A2aId $System $Account).IpRestrictions
+            $local:A2aId $Asset $Account).IpRestrictions
     }
 }
 
@@ -972,8 +972,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -1006,7 +1006,7 @@ function Set-SafeguardA2aCredentialRetrievalIpRestriction
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -1044,7 +1044,7 @@ function Set-SafeguardA2aCredentialRetrievalIpRestriction
     else
     {
         $local:A2aCr = (Get-SafeguardA2aCredentialRetrieval -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-                            $local:A2aId $System $Account)
+                            $local:A2aId $Asset $Account)
     }
 
     $local:A2aCr.IpRestrictions = $IpRestrictions
@@ -1077,8 +1077,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -1108,7 +1108,7 @@ function Clear-SafeguardA2aCredentialRetrievalIpRestriction
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -1131,7 +1131,7 @@ function Clear-SafeguardA2aCredentialRetrievalIpRestriction
     else
     {
         $local:A2aCr = (Get-SafeguardA2aCredentialRetrieval -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-                            $local:A2aId $System $Account)
+                            $local:A2aId $Asset $Account)
     }
 
     $local:A2aCr.IpRestrictions = $null
@@ -1164,8 +1164,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -1192,7 +1192,7 @@ function Reset-SafeguardA2aCredentialRetrievalApiKey
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -1216,7 +1216,7 @@ function Reset-SafeguardA2aCredentialRetrievalApiKey
     else
     {
         $local:AccountId = (Resolve-SafeguardA2aAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-            $local:A2aId $Account -System $System)
+            $local:A2aId $Account -Asset $Asset)
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -1247,8 +1247,8 @@ An integer containing the ID of the A2A registration to get or a string containi
 .PARAMETER AccountObj
 An object representing the account to get the credential retrieval configuration for.
 
-.PARAMETER System
-An integer containing the ID of the system or a string containing the name.
+.PARAMETER Asset
+An integer containing the ID of the asset or a string containing the name.
 
 .PARAMETER Account
 An integer containing the ID of the account or a string containing the name.
@@ -1275,7 +1275,7 @@ function Get-SafeguardA2aCredentialRetrievalApiKey
         [Parameter(Mandatory=$true,Position=0)]
         [object]$ParentA2a,
         [Parameter(ParameterSetName="Names",Mandatory=$false,Position=1)]
-        [object]$System,
+        [object]$Asset,
         [Parameter(ParameterSetName="Names",Mandatory=$true,Position=2)]
         [object]$Account,
         [Parameter(ParameterSetName="Object",Mandatory=$true)]
@@ -1299,7 +1299,7 @@ function Get-SafeguardA2aCredentialRetrievalApiKey
     else
     {
         $local:AccountId = (Resolve-SafeguardA2aAccountId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-            $local:A2aId $Account -System $System)
+            $local:A2aId $Account -Asset $Asset)
     }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
@@ -1361,7 +1361,7 @@ function Get-SafeguardA2aCredentialRetrievalInformation
                 Description = $local:A2a.Description;
                 CertificateUserThumbPrint = $local:A2a.CertificateUserThumbPrint;
                 ApiKey = $_.ApiKey;
-                AssetName = $_.SystemName;
+                AssetName = $_.AssetName;
                 AccountName = $_.AccountName;
                 DomainName = $_.DomainName;
             }

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -253,8 +253,8 @@ function Get-SafeguardA2aRetrievableAccount
                 CertificateUser = $local:Reg.CertificateUser;
                 CertificateUserThumbprint = $local:Reg.CertificateUserThumbprint;
                 ApiKey = $_.ApiKey;
-                AssetId = $_.SystemId;
-                AssetName = $_.SystemName;
+                AssetId = $_.AssetId;
+                AssetName = $_.AssetName;
                 NetworkAddress = $_.NetworkAddress;
                 AccountId = $_.AccountId;
                 AccountName = $_.AccountName;
@@ -590,7 +590,7 @@ function New-SafeguardA2aAccessRequest
     {
         $local:Body = @{
             ForUser = $ForUserName;
-            SystemName = $AssetToUse;
+            AssetName = $AssetToUse;
             AccessRequestType = "$AccessRequestType"
         }
         if ($AccountToUse) { $local:Body["AccountName"] = $AccountToUse }
@@ -599,7 +599,7 @@ function New-SafeguardA2aAccessRequest
     {
         $local:Body = @{
             ForUserId = $ForUserId;
-            SystemId = $AssetIdToUse;
+            AssetId = $AssetIdToUse;
             AccessRequestType = "$AccessRequestType"
         }
         if ($AccountIdToUse) { $local:Body["AccountId"] = $AccountIdToUse }

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -84,7 +84,7 @@ function Resolve-SafeguardPolicyAccountId
         $local:RelativeUrl = "PolicyAccounts"
         if ($PSBoundParameters.ContainsKey("AssetId"))
         {
-            $local:PreFilter = "SystemId eq $AssetId and "
+            $local:PreFilter = "Asset.Id eq $AssetId and "
         }
         else
         {
@@ -390,7 +390,7 @@ function Get-SafeguardPolicyAccount
         else
         {
             Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "PolicyAccounts" `
-                -Parameters @{ Filter = "SystemId eq $($local:AssetId)"}
+                -Parameters @{ Filter = "Asset.Id eq $($local:AssetId)"}
         }
     }
     else
@@ -951,7 +951,7 @@ function Remove-SafeguardUserLinkedAccount
 
     $local:LinkedAccountsToSet = @()
     $local:LinkedAccounts | ForEach-Object {
-        if (-not ($_.SystemId -eq $local:PolicyAccount.SystemId -and $_.Id -eq $local:PolicyAccount.Id))
+        if (-not ($_.Asset.Id -eq $local:PolicyAccount.Asset.Id -and $_.Id -eq $local:PolicyAccount.Id))
         {
             $local:LinkedAccountsToSet += $_
         }

--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -949,9 +949,9 @@ function Get-SafeguardReportAccountGroupMembership
                 AccountName = $_.Name;
                 AccountDescription = $_.Description;
                 AccountId = $_.AccountId;
-                AssetName = $_.SystemName;
-                NetworkAddress = $_.SystemNetworkAddress;
-                AssetId = $_.SystemId;
+                AssetName = $_.Asset.Name;
+                NetworkAddress = $_.Asset.NetworkAddress;
+                AssetId = $_.Asset.Id;
                 IsServiceAccount = $_.IsServiceAccount;
                 HasPassword = $_.HasPassword;
                 HasSshKey = $_.HasSshKey;
@@ -1168,9 +1168,9 @@ function Get-SafeguardReportA2aEntitlement
                 CertificateUserId = $local:A2a.CertificateUserId;
                 CertificateUser = $local:A2a.CertificateUser;
                 CertificateUserThumbprint = $local:A2a.CertificateUserThumbprint;
-                AssetId = $_.SystemId;
+                AssetId = $_.Asset.Id;
                 AccountId = $_.AccountId;
-                AssetName = $_.SystemName;
+                AssetName = $_.Asset.Name;
                 AccountName = $_.AccountName;
                 DomainName = $_.DomainName;
                 AccountType = $_.AccountType;

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -398,7 +398,7 @@ function New-SafeguardAccessRequest
 
     $local:AssetId = (Resolve-SafeguardRequestableAssetId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure $AssetToUse)
     $local:Body = @{
-        SystemId = $local:AssetId;
+        AssetId = $local:AssetId;
         AccessRequestType = "$AccessRequestType"
     }
 

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -473,7 +473,7 @@ function Wait-ForPatchDistribution
     Write-Host "Safeguard patch distribution completed...~$($local:TimeElapsed) seconds"
 }
 
-function Resolve-SafeguardSystemId
+function Resolve-SafeguardAssetId
 {
     [CmdletBinding()]
     Param(
@@ -484,7 +484,7 @@ function Resolve-SafeguardSystemId
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true,Position=0)]
-        [object]$System
+        [object]$Asset
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -493,7 +493,7 @@ function Resolve-SafeguardSystemId
     try
     {
         Import-Module -Name "$PSScriptRoot\assets.psm1" -Scope Local
-        Resolve-SafeguardAssetId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System
+        Resolve-SafeguardAssetId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Asset
     }
     catch
     {
@@ -501,17 +501,17 @@ function Resolve-SafeguardSystemId
         try
         {
             Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
-            Resolve-SafeguardDirectoryId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $System
+            Resolve-SafeguardDirectoryId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure $Asset
         }
         catch
         {
             Write-Verbose "Unable to resolve to directory ID"
-            throw "Cannot determine system ID for '$System'"
+            throw "Cannot determine asset ID for '$Asset'"
         }
     }
 }
 
-function Resolve-SafeguardAccountIdWithoutSystemId
+function Resolve-SafeguardAccountIdWithoutAssetId
 {
     [CmdletBinding()]
     Param(
@@ -549,7 +549,7 @@ function Resolve-SafeguardAccountIdWithoutSystemId
     }
 }
 
-function Resolve-SafeguardAccountIdWithSystemId
+function Resolve-SafeguardAccountIdWithAssetId
 {
     [CmdletBinding()]
     Param(
@@ -560,7 +560,7 @@ function Resolve-SafeguardAccountIdWithSystemId
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$true,Position=0)]
-        [int]$SystemId,
+        [int]$AssetId,
         [Parameter(Mandatory=$true,Position=1)]
         [object]$Account
     )
@@ -571,7 +571,7 @@ function Resolve-SafeguardAccountIdWithSystemId
     try
     {
         Import-Module -Name "$PSScriptRoot\assets.psm1" -Scope Local
-        Resolve-SafeguardAssetAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -AssetId $SystemId $Account
+        Resolve-SafeguardAssetAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -AssetId $AssetId $Account
     }
     catch
     {
@@ -579,12 +579,12 @@ function Resolve-SafeguardAccountIdWithSystemId
         try
         {
             Import-Module -Name "$PSScriptRoot\directories.psm1" -Scope Local
-            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -DirectoryId $SystemId $Account
+            Resolve-SafeguardDirectoryAccountId -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -DirectoryId $AssetId $Account
         }
         catch
         {
             Write-Verbose "Unable to resolve to directory account ID"
-            throw "Cannot determine system ID for '$System'"
+            throw "Cannot determine asset ID for '$Asset'"
         }
     }
 }


### PR DESCRIPTION
Fix for #397

There is a change to the cmdlet interface here.  A few a2a cmdlets had parameters called System.  Those have been changed to Asset.