### PR TITLE
Issue #384 -- long-running task location header is array

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -612,7 +612,7 @@ function Wait-LongRunningTask
 
     $local:StartTime = (Get-Date)
     $local:TaskResult = $null
-    $local:TaskToPoll = $Response.Headers.Location
+    $local:TaskToPoll = $($Response.Headers.Location)
     do {
         $local:TaskResponse = (Invoke-RestMethod -Method GET -Headers $Headers -Uri $local:TaskToPoll)
         Write-Verbose $local:TaskResponse


### PR DESCRIPTION
Fix for #384 
In PSCore this is an array in the response header.  It cannot be directly converted to a URL.  