### PR TITLE
Support for RDP applications in PowerShell access requests

### DIFF
--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -555,7 +555,7 @@ function New-SafeguardA2aAccessRequest
         [Parameter(ParameterSetName="CertStoreAndIds",Mandatory=$false,Position=4)]
         [int]$AccountIdToUse,
         [Parameter(Mandatory=$false,Position=5)]
-        [ValidateSet("Password", "SSHKey", "SSH", "RemoteDesktop", "RDP", "Telnet", IgnoreCase=$true)]
+        [ValidateSet("Password", "SSHKey", "SSH", "RemoteDesktop", "RDP", "RemoteDesktopApplication", "RDPApplication", "RDPApp", "Telnet", IgnoreCase=$true)]
         [string]$AccessRequestType,
         [Parameter(Mandatory=$false)]
         [switch]$Emergency = $false,
@@ -584,6 +584,10 @@ function New-SafeguardA2aAccessRequest
     if ($AccessRequestType -ieq "RDP")
     {
         $AccessRequestType = "RemoteDesktop"
+    }
+    elseif ($AccessRequestType -ieq "RDPApplication" -or $AccessRequestType -ieq "RDPApp")
+    {
+        $AccessRequestType = "RemoteDesktopApplication"
     }
 
     if ($PsCmdlet.ParameterSetName -eq "CertStoreAndNames" -or $PsCmdlet.ParameterSetName -eq "FileAndNames")

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -944,8 +944,8 @@ function Find-SafeguardRequestableAccount
                 GET "Me/AccessRequestAssets") | ForEach-Object {
             $local:Asset = $_
             (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-                    GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; q = $SearchString }).Account | ForEach-Object {
-                New-RequestableAccountObject $local:Asset $_ -AllFields:$AllFields
+                    GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; q = $SearchString }) | ForEach-Object {
+                New-RequestableAccountObject $local:Asset $_.Account $_.Policy -AllFields:$AllFields
             }
         }
     }
@@ -959,8 +959,8 @@ function Find-SafeguardRequestableAccount
                         GET "Me/AccessRequestAssets" -Parameters @{ filter = $AssetQueryFilter }) | ForEach-Object {
                     $local:Asset = $_
                     (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-                            GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; filter = $AccountQueryFilter }).Account | ForEach-Object {
-                        New-RequestableAccountObject $local:Asset $_ -AllFields:$AllFields
+                            GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; filter = $AccountQueryFilter }) | ForEach-Object {
+                        New-RequestableAccountObject $local:Asset $_.Account $_.Policy -AllFields:$AllFields
                     }
                 }
             }
@@ -970,8 +970,8 @@ function Find-SafeguardRequestableAccount
                         GET "Me/AccessRequestAssets" -Parameters @{ filter = $AssetQueryFilter }) | ForEach-Object {
                     $local:Asset = $_
                     (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-                            GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)" }).Account | ForEach-Object {
-                        New-RequestableAccountObject $local:Asset $_ -AllFields:$AllFields
+                            GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)" }) | ForEach-Object {
+                        New-RequestableAccountObject $local:Asset $_.Account $_.Policy -AllFields:$AllFields
                     }
                 }
             }
@@ -982,8 +982,8 @@ function Find-SafeguardRequestableAccount
                     GET "Me/AccessRequestAssets") | ForEach-Object {
                 $local:Asset = $_
                 (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-                        GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; filter = $AccountQueryFilter }).Account | ForEach-Object {
-                    New-RequestableAccountObject $local:Asset $_ -AllFields:$AllFields
+                        GET "Me/RequestEntitlements" -Parameters @{ assetIds = "$($local:Asset.Id)"; filter = $AccountQueryFilter }) | ForEach-Object {
+                    New-RequestableAccountObject $local:Asset $_.Account $_.Policy -AllFields:$AllFields
                 }
             }
         }

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -133,9 +133,6 @@ function New-RequestableAccountObject
             PlatformId = $Asset.Platform.Id;
             PlatformType = $Asset.Platform.PlatformType;
             PlatformDisplayName = $Asset.Platform.DisplayName;
-            SshHostKey = $Asset.SshHostKey.SshHostKey;
-            SshHostKeyFingerprint = $Asset.SshHostKey.Fingerprint;
-            SshHostKeyFingerprintSha256 = $Asset.SshHostKey.FingerprintSha256;
             SshSessionPort = $Asset.SessionAccessProperties.SshSessionPort;
             RdpSessionPort = $Asset.SessionAccessProperties.RemoteDesktopSessionPort;
             AccountId = $Account.Id;

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -133,14 +133,15 @@ function New-RequestableAccountObject
             PlatformId = $Asset.Platform.Id;
             PlatformType = $Asset.Platform.PlatformType;
             PlatformDisplayName = $Asset.Platform.DisplayName;
+            SshHostKey = $Asset.SshHostKey.SshHostKey;
+            SshHostKeyFingerprint = $Asset.SshHostKey.Fingerprint;
+            SshHostKeyFingerprintSha256 = $Asset.SshHostKey.FingerprintSha256;
             SshSessionPort = $Asset.SessionAccessProperties.SshSessionPort;
             RdpSessionPort = $Asset.SessionAccessProperties.RemoteDesktopSessionPort;
             AccountId = $Account.Id;
-            AccountNetBiosName = $Account.NetBiosName;
             AccountDomainName = $Account.DomainName;
             AccountName = $Account.Name;
             AccountDescription = $Account.Description;
-            SuspendAccountWhenCheckedIn = $Account.SuspendAccountWhenCheckedIn;
             AccountRequestType = $Policy.AccessRequestProperties.AccessRequestType;
             RequireReasonCode = $Policy.RequesterProperties.RequireReasonCode;
             RequireReasonComment = $Policy.RequesterProperties.RequireReasonComment;

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1306,7 +1306,7 @@ function Connect-Safeguard
             }
             if (-not $NoWindowTitle)
             {
-                $Host.UI.RawUI.WindowTitle = "Windows PowerShell -- Safeguard Connection: $(Get-SessionConnectionIdentifier)"
+                $Host.UI.RawUI.WindowTitle = "PowerShell -- Safeguard Connection: $(Get-SessionConnectionIdentifier)"
             }
             Write-Host "Login Successful."
         }
@@ -1435,7 +1435,7 @@ function Disconnect-Safeguard
             }
             if (-not $NoWindowTitle)
             {
-                $Host.UI.RawUI.WindowTitle = "Windows PowerShell"
+                $Host.UI.RawUI.WindowTitle = "PowerShell"
             }
             Write-Host "Log out Successful."
         }

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1736,8 +1736,8 @@ function Invoke-SafeguardMethod
         }
         else
         {
-            Write-Verbose "NOT FOUND: YOU MAY BE USING AN OLDER VERSION OF SAFEGUARD API:"
-            Write-Verbose "    TRY CONNECTING WITH THE Version PARAMETER SET TO $($Version - 1), OR"
+            Write-Verbose "NOT FOUND: YOU MAY BE TRYING TO USE A DIFFERENT VERSION OF SAFEGUARD API:"
+            Write-Verbose "    TRY CONNECTING WITH THE Version PARAMETER SET SOMETHING OTHER THAN $Version, OR"
             Write-Verbose "    DOWNLOAD THE VERSION OF safeguard-ps MATCHING YOUR VERSION OF SAFEGUARD"
             throw
         }


### PR DESCRIPTION
You can now use New-SafeguardAccessRequest with -AccessRequestType set to RemoteDesktopApplication or RdpApp or RdpApplication to use the new feature.

Moved the code to use v4 API which resulted in slightly different DTOs returned from the Get-SafeguardRequestableAccount and Find-SafeguardRequestableAccount cmdlets

Also add support in the A2A module.  New-SafeguardA2aAccessRequest