### PR TITLE
intercept Read-Host to prevent CLI prompts when possible.  don't secu…

### DIFF
--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -2382,6 +2382,11 @@ function Import-SafeguardAsset
         [string]$Path
     )
 
+	# Intercept Read-Host and return an empty string
+	function Read-Host {
+		return ""
+	}
+
     $local:Assets = Import-Csv -Path $Path
 
     $local:FailedImports = New-Object System.Collections.ArrayList
@@ -2432,7 +2437,7 @@ function Import-SafeguardAsset
                 $local:Args.Add("ServiceAccountName", $local:Asset.ServiceAccountName)
             }
 
-            if($null -ne $local:Asset.ServiceAccountPassword) 
+            if(![string]::IsNullOrEmpty($local:Asset.ServiceAccountPassword))
             {
                 $local:SecureServiceAccountPassword = $local:Asset.ServiceAccountPassword | ConvertTo-SecureString -AsPlainText -Force
                 $local:Args.Add("ServiceAccountPassword", $local:SecureServiceAccountPassword)
@@ -2601,6 +2606,11 @@ function Import-SafeguardAssetAccount
         [string]$Path
     )
 
+	# Intercept Read-Host and return an empty string
+	function Read-Host {
+		return ""
+	}
+
     $local:Accounts = Import-Csv -Path $Path
 
     $local:FailedImports = New-Object System.Collections.ArrayList
@@ -2757,6 +2767,11 @@ function Import-SafeguardAssetAccountPassword
         [string]$Path
     )
 
+	# Intercept Read-Host and return an empty string
+	function Read-Host {
+		return ""
+	}
+
     $local:Passwords = Import-Csv -Path $Path
 
     $local:FailedImports = New-Object System.Collections.ArrayList
@@ -2768,8 +2783,6 @@ function Import-SafeguardAssetAccountPassword
     {
         try 
         {
-            $local:NewSecurePassword = $local:Password.NewPassword | ConvertTo-SecureString -AsPlainText -Force
-
             $local:Args = @{
                 AccessToken = $AccessToken
                 Appliance = $Appliance
@@ -2777,7 +2790,12 @@ function Import-SafeguardAssetAccountPassword
                 AssetPartition = $local:Password.AssetPartition
                 AssetToSet = $local:Password.AssetToSet
                 AccountToSet = $local:Password.AccountToSet
-                NewPassword = $local:NewSecurePassword
+            }
+
+            if(![string]::IsNullOrEmpty($local:Password.NewPassword))
+            {
+                $local:NewSecurePassword = $local:Password.NewPassword | ConvertTo-SecureString -AsPlainText -Force
+                $local:Args.Add("NewPassword", $local:NewSecurePassword)
             }
         
             Set-SafeguardAssetAccountPassword @local:Args
@@ -2905,6 +2923,11 @@ function Import-SafeguardAssetAccountSshKey
         [string]$Path
     )
 
+	# Intercept Read-Host and return an empty string
+	function Read-Host {
+		return ""
+	}
+
     $local:SshKeys = Import-Csv -Path $Path
 
     $local:FailedImports = New-Object System.Collections.ArrayList
@@ -2926,7 +2949,7 @@ function Import-SafeguardAssetAccountSshKey
                 PrivateKey = $local:SshKey.PrivateKey
             }
 
-            if($null -ne $local:SshKey.Passphrase) 
+            if(![string]::IsNullOrEmpty($local:SshKey.Passphrase))
             {
                 $local:NewSecurePassphrase = $local:SshKey.Passphrase | ConvertTo-SecureString -AsPlainText -Force
                 $local:Args.Add("Passphrase", $local:NewSecurePassphrase)

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -1689,6 +1689,11 @@ function Import-SafeguardUser
         [string]$Path
     )
 
+	# Intercept Read-Host and return an empty string
+	function Read-Host {
+		return ""
+	}
+
     $local:Users = Import-Csv -Path $Path
 
     $local:FailedImports = New-Object System.Collections.ArrayList
@@ -1748,7 +1753,7 @@ function Import-SafeguardUser
                 $local:Args.Add("AdminRoles", $local:User.AdminRoles)
             }
 
-            if($null -ne $local:User.Password) 
+            if(![string]::IsNullOrEmpty($local:User.Password))
             {
                 $local:SecurePassword = $local:User.Password | ConvertTo-SecureString -AsPlainText -Force
                 $local:Args.Add("Password", $local:SecurePassword)


### PR DESCRIPTION
…re empty string

- To prevent CLI prompts from freezing the script, intercept Read-Host calls and return an empty string.  The cmdlet that calls it will validate on an empty string and provide an appropriate error
- Don't convert an empty string to a secure string