### PR TITLE
Allow calling A2A endpoints without a body

### DIFF
--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -72,13 +72,29 @@ function Invoke-SafeguardA2aMethodWithCertificate
     {
         if (-not $Thumbprint)
         {
-            Invoke-RestMethod -Certificate $local:Cert -Method $Method -Headers $local:Headers `
-                -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+            if (-not $local:BodyInternal)
+            {
+                Invoke-RestMethod -Certificate $local:Cert -Method $Method -Headers $local:Headers `
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl"
+            }
+            else
+            {
+                Invoke-RestMethod -Certificate $local:Cert -Method $Method -Headers $local:Headers `
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+            }
         }
         else
         {
-            Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method $Method -Headers $local:Headers `
-                -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+            if (-not $local:BodyInternal)
+            {
+                Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method $Method -Headers $local:Headers `
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl"
+            }
+            else
+            {
+                Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method $Method -Headers $local:Headers `
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+            }
         }
     }
     catch


### PR DESCRIPTION
Calling Get-SafeguardA2aRetrievableAccount makes a REST GET call without a body.  The Invoke-RestMethod call in a2acallers.psm1 expects a body and fails because $local:BodyInternal is $null.  This fix just checks for a body and calls Invoke-RestMethod appropriately.