### PR TITLE
Mark this as obsolete for modern .NET

### DIFF
--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -43,6 +43,9 @@ namespace Ex
         }
         public SafeguardMethodException(string message, Exception innerException)
             : base(message, innerException) {}
+#if !NETFRAMEWORK
+        [Obsolete(DiagnosticId = "SYSLIB0051")]
+#endif
         protected SafeguardMethodException
             (SerializationInfo info, StreamingContext context)
             : base(info, context) {}


### PR DESCRIPTION
Solution for #505 -- change to the newest PowerShell broke safeguard-ps because it uses a more modern .NET runtime