### PR TITLE
Fix for PowerShell 7.4 Issue #20744 with -OutFile for Invoke-WebRequest and Invoke-RestMethod

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -622,26 +622,71 @@ function Invoke-WithoutBody
     {
         if ($LongRunningTask)
         {
-            $local:Response = (Invoke-WebRequest -Method $Method -Headers $Headers -Uri $local:Url `
-                                   -InFile $InFile -OutFile $OutFile -TimeoutSec $Timeout)
+            $invokeWebRequestParams = @{
+                Method = $Method
+                Headers = $Headers
+                Uri = $local:Url
+                InFile = $InFile
+                TimeoutSec = $Timeout
+            }
+
+            if ($OutFile) {
+                $invokeWebRequestParams['OutFile'] = $OutFile
+            }
+
+            $local:Response = Invoke-WebRequest @invokeWebRequestParams
             Wait-LongRunningTask $local:Response $Headers $Timeout
         }
         else
         {
-            Invoke-RestMethod -Method $Method -Headers $Headers -Uri $local:Url -InFile $InFile -OutFile $OutFile -TimeoutSec $Timeout
+            $invokeRestMethodParams = @{
+                Method = $Method
+                Headers = $Headers
+                Uri = $local:Url
+                InFile = $InFile
+                TimeoutSec = $Timeout
+            }
+
+            if ($OutFile) {
+                $invokeRestMethodParams['OutFile'] = $OutFile
+            }
+
+            Invoke-RestMethod @invokeRestMethodParams
         }
     }
     else
     {
         if ($LongRunningTask)
         {
-            $local:Response = $(Invoke-RestMethod -Method $Method -Headers $Headers -Uri $local:Url `
-                                    -InFile $InFile -OutFile $OutFile -TimeoutSec $Timeout)
+            $invokeRestMethodParams = @{
+                Method = $Method
+                Headers = $Headers
+                Uri = $local:Url
+                InFile = $InFile
+                TimeoutSec = $Timeout
+            }
+
+            if ($OutFile) {
+                $invokeRestMethodParams['OutFile'] = $OutFile
+            }
+
+            $local:Response = Invoke-RestMethod @invokeRestMethodParams
             Wait-LongRunningTask $local:Response $Headers $Timeout
         }
         else
         {
-            Invoke-RestMethod -Method $Method -Headers $Headers -Uri $local:Url -OutFile $OutFile -TimeoutSec $Timeout
+            $invokeRestMethodParams = @{
+                Method = $Method
+                Headers = $Headers
+                Uri = $local:Url
+                TimeoutSec = $Timeout
+            }
+
+            if ($OutFile) {
+                $invokeRestMethodParams['OutFile'] = $OutFile
+            }
+
+            Invoke-RestMethod @invokeRestMethodParams
         }
     }
 }
@@ -690,16 +735,36 @@ function Invoke-WithBody
     Write-Verbose "$($local:BodyInternal)"
     if ($LongRunningTask)
     {
-        $local:Response = (Invoke-WebRequest -Method $Method -Headers $Headers -Uri $local:Url `
-                           -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)) `
-                           -OutFile $OutFile -TimeoutSec $Timeout)
+        $invokeWebRequestParams = @{
+            Method = $Method
+            Headers = $Headers
+            Uri = $local:Url
+            Body = [System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)
+            TimeoutSec = $Timeout
+        }
+
+        if ($OutFile) {
+            $invokeWebRequestParams['OutFile'] = $OutFile
+        }
+
+        $local:Response = Invoke-WebRequest @invokeWebRequestParams
         Wait-LongRunningTask $local:Response $Headers $Timeout
     }
     else
     {
-        Invoke-RestMethod -Method $Method -Headers $Headers -Uri $local:Url `
-            -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)) `
-            -OutFile $OutFile -TimeoutSec $Timeout
+        $invokeRestMethodParams = @{
+            Method = $Method
+            Headers = $Headers
+            Uri = $local:Url
+            Body = [System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)
+            TimeoutSec = $Timeout
+        }
+
+        if ($OutFile) {
+            $invokeRestMethodParams['OutFile'] = $OutFile
+        }
+
+        Invoke-RestMethod @invokeRestMethodParams
     }
 }
 


### PR DESCRIPTION
Starting with PowerShell 7.4, there has been a change in the behavior of the -OutFile parameter, particularly in its handling of $null values. As a result, the existing implementation of the Request may trigger an exception, preventing any requests from being sent to the Safeguard REST API.

To address this, the proposed fix involves validating whether $OutFile is set prior to passing it to the Invoke-WebRequest or Invoke-RestMethod commands.

https://github.com/PowerShell/PowerShell/issues/20744