### PR TITLE
Issue 506 Problem with API Module

### DIFF
--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -77,7 +77,7 @@ function Get-RstsTokenFromBrowser
         {
             $local:Assemblies = ("System.Web.dll","System.Net.Primitives.dll","System.Net.Sockets.dll","System.Text.RegularExpressions.dll",
                                  "System.Diagnostics.Process.dll","System.ComponentModel.Primitives.dll",
-                                 "System.Runtime.InteropServices.RuntimeInformation.dll","System.Collections.Specialized","System.Security.Cryptography.dll")
+                                 "System.Runtime.InteropServices.RuntimeInformation.dll","System.Collections.Specialized")
         }
         Add-Type -ReferencedAssemblies $local:Assemblies -TypeDefinition @"
         using System;
@@ -103,7 +103,7 @@ function Get-RstsTokenFromBrowser
                 try {
                     CodeVerifier = OAuthCodeVerifier();
                     string redirectUri = "urn:InstalledApplicationTcpListener";
-                    string accessTokenUri = $"https://{_appliance}/RSTS/Login?response_type=code&code_challenge_method=S256&code_challenge={OAuthCodeChallenge(CodeVerifier)}&redirect_uri={redirectUri}&port={port}";
+                    string accessTokenUri = string.Format("https://{0}/RSTS/Login?response_type=code&code_challenge_method=S256&code_challenge={1}&redirect_uri={2}&port={3}", _appliance, OAuthCodeChallenge(CodeVerifier), redirectUri, port);
                     if (!string.IsNullOrEmpty(username)) redirectUri += string.Format("&login_hint={0}", Uri.EscapeDataString(username));
                     try {
                         var psi = new ProcessStartInfo { FileName = accessTokenUri, UseShellExecute = true };


### PR DESCRIPTION
When attempting to invoke the basic `Connect-Safeguard` command, one could get the following error, depending on your environment (Windows and PowerShell version):
> Metadata file 'System.Security.Cryptography.dll' could not be found.
safeguard-ps.psm1:82

I believe, when running under Windows with PowerShell 5.1, it's using just the regular .NET Framework, so no explicit reference to `System.Security.Cryptography.dll` is needed. Unlike with PowerShell Core.

After fixing that problem, we immediately ran into another error that may again be a difference between PowerShell and PowerShell Core.
> Unexpected character '$'
string accessTokenUri = $"https://{_appli...

It seems the C# string interpolation is not supported, at least in this version of PowerShell. So we'll just use the old `string.Format()` method.