### PR TITLE
bugfixes found during 8.0 regression

### DIFF
--- a/src/reports.psm1
+++ b/src/reports.psm1
@@ -845,9 +845,9 @@ function Get-SafeguardReportAssetGroupMembership
                 AssetId = $_.Id;
                 AssetPartitionName = $_.AssetPartitionName;
                 AssetPartitionId = $_.AssetPartitionId;
-                PlatformDisplayName = $_.PlatformDisplayName;
-                PlatformType = $_.PlatformType;
-                PlatformId = $_.PlatformId;
+                PlatformDisplayName = $_.Platform.DisplayName;
+                PlatformType = $_.Platform.Type;
+                PlatformId = $_.Platform.Id;
                 Disabled = $_.Disabled;
                 SupportsSessionManagement = $_.SupportsSessionManagement;
                 AllowSessionRequests = $_.AllowSessionRequests;
@@ -948,7 +948,7 @@ function Get-SafeguardReportAccountGroupMembership
                 GroupId = $local:GroupInfo.GroupId;
                 AccountName = $_.Name;
                 AccountDescription = $_.Description;
-                AccountId = $_.AccountId;
+                AccountId = $_.Id;
                 AssetName = $_.Asset.Name;
                 NetworkAddress = $_.Asset.NetworkAddress;
                 AssetId = $_.Asset.Id;
@@ -959,9 +959,9 @@ function Get-SafeguardReportAccountGroupMembership
                 DistinguishedName = $_.DistinguishedName;
                 NetBiosName = $_.NetBiosName;
                 AltLoginName = $_.AltLoginName;
-                PlatformDisplayName = $_.PlatformDisplayName;
-                PlatformType = $_.PlatformType;
-                PlatformId = $_.PlatformId;
+                PlatformDisplayName = $_.Platform.DisplayName;
+                PlatformType = $_.Platform.Type;
+                PlatformId = $_.Platform.Id;
                 Disabled = $_.Disabled;
                 AllowPasswordRequest = $_.AllowPasswordRequest;
                 AllowSessionRequest = $_.AllowSessionRequest;
@@ -1054,14 +1054,14 @@ function Get-SafeguardReportAssetManagementConfiguration
             -Insecure:$Insecure Core GET "AssetAccounts") | ForEach-Object {
         $local:Profile = $local:ProfileLookupTable["$($_.AssetParitionId)_$($_.EffectiveProfileId)"]
         $local:Configuration = New-Object PSObject -Property ([ordered]@{
-            AssetPartitionName = $_.AssetPartitionName;
-            AssetName = $_.AssetName;
+            AssetPartitionName = $_.Asset.AssetPartitionName;
+            AssetName = $_.Asset.Name;
             AccountName = $_.Name;
             AccountDescription = $_.Description;
             AccountDistinguishedName = $_.DistinguishedName;
-            PlatformDisplayName = $_.PlatformDisplayName;
-            AssetPartitionId = $_.AssetParitionId;
-            AssetId = $_.AssetId;
+            PlatformDisplayName = $_.Platform.DisplayName;
+            AssetPartitionId = $_.Asset.AssetPartitionId;
+            AssetId = $_.Asset.Id;
             AccountId = $_.Id;
             ProfileName = $_.EffectiveProfileName;
             SyncGroupName = $_.SyncGroupName;
@@ -1258,19 +1258,19 @@ function Get-SafeguardReportPasswordLastChanged
 
     $local:Changes = @()
     (Get-SafeguardAssetAccount -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
-        -Fields AssetId,Id,AssetName,Name,DomainName,Description,LastSuccessPasswordCheckDate,LastSuccessPasswordChangeDate) | ForEach-Object {
+        -Fields Asset.Id,Id,Asset.Name,Name,DomainName,Description,TaskProperties.LastSuccessPasswordCheckDate,TaskProperties.LastSuccessPasswordChangeDate) | ForEach-Object {
             $local:Change = New-Object PSObject -Property ([ordered]@{
-                AssetId = $_.AssetId;
+                AssetId = $_.Asset.Id;
                 AccountId = $_.Id;
-                AssetName = $_.AssetName;
+                AssetName = $_.Asset.Name;
                 AccountName = $_.Name;
                 DomainName = $_.DomainName;
                 Description = $_.Description;
                 LastPasswordChange = "";
                 LastPasswordCheck = "";
             })
-            if ($_.LastSuccessPasswordChangeDate) {$local:Change.LastPasswordChange = (Get-Date $_.LastSuccessPasswordChangeDate -Format "yyyy-MM-dd HH:mm:ss");}
-            if ($_.LastSuccessPasswordCheckDate) {$local:Change.LastPasswordCheck = (Get-Date $_.LastSuccessPasswordCheckDate -Format "yyyy-MM-dd HH:mm:ss");}
+            if ($_.TaskProperties.LastSuccessPasswordChangeDate) {$local:Change.LastPasswordChange = (Get-Date $_.TaskProperties.LastSuccessPasswordChangeDate -Format "yyyy-MM-dd HH:mm:ss");}
+            if ($_.TaskProperties.LastSuccessPasswordCheckDate) {$local:Change.LastPasswordCheck = (Get-Date $_.TaskProperties.LastSuccessPasswordCheckDate -Format "yyyy-MM-dd HH:mm:ss");}
             $local:Changes += $local:Change
         }
 
@@ -1386,7 +1386,7 @@ function Get-SafeguardReportAssetAccountPasswordHistory
                                 -AssetPartition $AssetPartition -AssetPartitionId $AssetPartitionId -AssetToGet $AssetToGet -AccountToGet $AccountToGet)
     $local:AccountId = $local:Account.Id
 
-    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-pwhistory-$Days-days-$($local:Account.AssetName)-$($local:Account.Name).csv" -StdOut:$StdOut)
+    $local:OutFile = (Get-OutFileForParam -OutputDirectory $OutputDirectory -FileName "sg-pwhistory-$Days-days-$($local:Account.Asset.Name)-$($local:Account.Name).csv" -StdOut:$StdOut)
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "AssetAccounts/$($local:AccountId)/Passwords" `
         -Accept "text/csv" -OutFile $local:OutFile `

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -1267,8 +1267,6 @@ the clipboard so it can be pasted.
 This parameter will cause the output of the API to be returned rather than
 writing the private key to a file or adding a command to your command history.
 
-.PARAMETER
-
 .INPUTS
 None.
 
@@ -1421,8 +1419,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER
-
 .INPUTS
 None.
 
@@ -1469,7 +1465,15 @@ function Get-SafeguardAccessRequestRdpFile
     {
         if (-not ([System.Management.Automation.PSTypeName]"RdpPasswordEncrypter").Type)
         {
-            Add-Type -TypeDefinition @"
+           if ($PSVersionTable.PSEdition -eq "Core")
+           {
+               $local:Assemblies = ("System.Security.Cryptography.ProtectedData")
+           }
+           else
+           {
+               $local:Assemblies = ("System.Security")
+           }
+           Add-Type -ReferencedAssemblies $local:Assemblies -TypeDefinition @"
 using System;
 using System.Text;
 using System.Security.Cryptography;
@@ -1488,7 +1492,7 @@ public class RdpPasswordEncrypter {
         catch (Exception) { return null; }
     }
 }
-"@ -ReferencedAssemblies System.Security
+"@
         }
         $local:Encrypter = New-Object RdpPasswordEncrypter
         $local:FakePassword = $local:Encrypter.GetEncryptedPassword("sg")
@@ -1517,8 +1521,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER RequestId
 A string containing the ID of the access request.
-
-.PARAMETER
 
 .INPUTS
 None.
@@ -1576,8 +1578,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 .PARAMETER RequestId
 A string containing the ID of the access request.
 
-.PARAMETER
-
 .INPUTS
 None.
 
@@ -1633,8 +1633,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER RequestId
 A string containing the ID of the access request.
-
-.PARAMETER
 
 .INPUTS
 None.
@@ -1712,8 +1710,6 @@ Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER RequestId
 A string containing the ID of the access request.
-
-.PARAMETER
 
 .INPUTS
 None.

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -375,7 +375,7 @@ function Set-SafeguardAuthenticationProviderAsDefault
     $local:Provider = (Get-SafeguardAuthenticationProvider -Appliance $Appliance -AccessToken $AccessToken -Insecure:$Insecure -ProviderToGet $ProviderToSet)
     if ($local:Provider)
     {
-        if ($local:Provider.Count -ne 1)
+        if ($local:Provider.Count -gt 1)
         {
             throw "More than one authentication provider matched '$ProviderToSet'"
         }


### PR DESCRIPTION
- Remove empty .PARAMETER doc - causes command help to go missing
- fix assembly reference for Get-SafeguardAccessRequestRdpFile
- some lingering APIv4 fallout (still!) accessing properties and sub-properties
- Set-SafeguardAuthenticationProviderAsDefault: PS 5.1 return empty value for .Count when only 1 value is returned. PS 7 returns 1. Go figure.