### PR TITLE
Issue #556 Can't Update Tags for an Asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ never require Administrator permission:
 > Install-Module safeguard-ps -Scope CurrentUser
 ```
 
+Or you may need to use the new method:
+```Powershell
+> Install-PSResource -Name safeguard-ps
+```
+Note, `Install-PSResource` doesn't load the newly installed module into the current
+session. You must import the new version or start a new session to use the updated
+module.
+
 ## Upgrading
 
 If you want to upgrade from the

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -36,8 +36,9 @@ function Resolve-SafeguardGroupId
 
     if (-not ($Group -as [int]))
     {
+        $local:EscapedName = $Group -replace "'", "\'"
         $local:Groups = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
-                                                -Parameters @{ filter = "Name ieq '$Group'" })
+                                                -Parameters @{ filter = "Name ieq '$($local:EscapedName)'" })
         if (-not $local:Groups)
         {
             throw "Unable to find $($GroupType.ToLower()) group matching '$Group'"

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -294,7 +294,7 @@ FunctionsToExport = @(
     # auditlog.psm1
     'Get-SafeguardAuditLog',
     # tags.psm1
-    'Get-SafeguardTag', 'Get-SafeguardTagOccurence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag', 'Get-SafeguardAssetAccountTag',
+    'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag', 'Get-SafeguardAssetAccountTag',
     'Update-SafeguardAssetAccountTag', 'Find-SafeguardTag', 'New-SafeguardTag', 'Update-SafeguardTag', 'Remove-SafeguardTag',
     'Test-SafeguardAssetTaggingRule', 'Test-SafeguardAssetAccountTaggingRule'
 )


### PR DESCRIPTION
For Issue #556, some methods did not include the specified `AssetPartitionId` when trying to resolve the tag. So modified the code such that it can resolve a unique tag without relying on the `AssetPartitionId`. Only when there are multiple tags with the same name will the `AssetPartitionId` be required.

We'll use the already existing `Resolve-AssetPartitionIdFromSafeguardSession` method, and also have it default to the macrocosm partition if not specified.