### PR TITLE
Auto copy access request ID to clipboard

### DIFF
--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -354,6 +354,10 @@ The number of hours requested for password access. The sum of Requested Days/Hou
 .PARAMETER RequestedDurationMinutes
 The number of minutes requested for password access. The sum of Requested Days/Hours/Minutes must not exceed 31 days.
 
+.PARAMETER NoClipboard
+Do not copy the access request ID to the clipboard. By default, when running interactively, the
+access request ID is copied to the clipboard automatically.
+
 .INPUTS
 None.
 
@@ -395,7 +399,9 @@ function New-SafeguardAccessRequest
         [Parameter(Mandatory=$false)]
         [int]$RequestedDurationHours,
         [Parameter(Mandatory=$false)]
-        [int]$RequestedDurationMinutes
+        [int]$RequestedDurationMinutes,
+        [Parameter(Mandatory=$false)]
+        [switch]$NoClipboard
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -469,7 +475,7 @@ function New-SafeguardAccessRequest
     $local:Result = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
          POST "AccessRequests" -Body $local:Body | Select-Object -Property $local:RequestFields)
 
-    if ($local:Result.Id)
+    if ($local:Result.Id -and -not $NoClipboard -and [Environment]::UserInteractive)
     {
         try
         {


### PR DESCRIPTION
While investigating #473 and manipulating access requests via PowerShell, it was nice if the Request ID was put on the clipboard for me automatically.  I added a parameter to opt out and some logic to avoid using the clipboard when not in an interactive session.  If the clipboard is inaccessible, it will silently continue.