### PR TITLE
Fix code signing to use x86 Windows SDK signtool per SSL.com docs

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -91,21 +91,40 @@ jobs:
         $(Build.SourcesDirectory)\eSignerCKA\eSignerCKATool.exe load
       displayName: "Unload and load certificate into Windows Certificate Store"
 
-    # We should now be able to access the certificate using the standard Windows signtool.exe from the Windows SDK,
-    # which should be installed on the build agent images being used.
-    #
-    # Typically, you often see examples of signtool.exe and other things accessing the certificate by the thumbprint.
-    # And in fact, the sample SSL.com code includes a bunch of extra PowerShell script to get the thumbprint. The
-    # signtool.exe can sign catalog files, but we'll stick with the Set-AuthenticodeSignature cmdlet for now.
-    # "signtool.exe" sign /fd sha256 /tr http://ts.ssl.com /td sha256 /n "One Identity LLC" "C:\path\to\program.exe"
+    # Sign the catalog file using the x86 Windows SDK signtool with thumbprint matching,
+    # per SSL.com's eSignerCKA documentation for Azure DevOps pipelines.
 
     - powershell: |
-        $cert = Get-ChildItem -Path Cert:\CurrentUser\My -CodeSigningCert
-        Write-Verbose -Verbose "Subject: $($cert.Subject)"
-        Write-Verbose -Verbose "Issuer: $($cert.Issuer)"
+        $ErrorActionPreference = "Stop"
+        $CodeSigningCert = Get-ChildItem Cert:\CurrentUser\My -CodeSigningCert | Select-Object -First 1
+        if (-not $CodeSigningCert) {
+            throw "No code signing certificate found in CurrentUser\My store"
+        }
+        Write-Verbose -Verbose "Thumbprint: $($CodeSigningCert.Thumbprint)"
         $catalogfile = (Get-Module safeguard-ps -ListAvailable)[0].Path -replace "psd1","cat"
-        Write-Verbose -Verbose $catalogfile
-        Set-AuthenticodeSignature -Certificate $cert -FilePath $catalogfile -HashAlgorithm SHA256 -TimestampServer "http://ts.ssl.com"
+        if (-not (Test-Path $catalogfile)) {
+            throw "Catalog file not found: $catalogfile"
+        }
+        Write-Verbose -Verbose "Signing catalog file: $catalogfile"
+        $signtool = Get-ChildItem -Path "C:\Program Files (x86)\Windows Kits" -Recurse -Filter "signtool.exe" |
+            Where-Object { $_.FullName -match "\\x86\\" } |
+            Sort-Object -Property FullName -Descending |
+            Select-Object -First 1
+        if (-not $signtool) {
+            throw "x86 signtool.exe not found in Windows SDK"
+        }
+        Write-Verbose -Verbose "Using signtool: $($signtool.FullName)"
+        & $signtool.FullName sign /debug /fd sha256 /tr http://ts.ssl.com /td sha256 /sha1 $CodeSigningCert.Thumbprint $catalogfile
+        if ($LASTEXITCODE -ne 0) {
+            throw "signtool.exe failed with exit code $LASTEXITCODE"
+        }
+        # Verify the signature independently
+        $verify = Get-AuthenticodeSignature -FilePath $catalogfile
+        Write-Verbose -Verbose "Verification status: $($verify.Status)"
+        if ($verify.Status -ne "Valid") {
+            throw "Signature verification failed with status '$($verify.Status)': $($verify.StatusMessage)"
+        }
+        Write-Host "Catalog file signed and verified successfully"
       displayName: 'Signing PowerShell module catalog file'
 
     - task: PowerShell@2


### PR DESCRIPTION
Set-AuthenticodeSignature cannot access the private key through eSignerCKA's PKCS#11 cloud HSM bridge. Switch to using the x86 Windows SDK signtool.exe with /sha1 thumbprint matching, which is the exact approach recommended by SSL.com's eSignerCKA Azure DevOps documentation.

Also add proper error handling: exit code check, independent signature verification via Get-AuthenticodeSignature, and /debug flag for diagnostics.

Fixes #581