### PR TITLE
Add real-time SignalR event listeners for user-mode and A2A scenarios

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ safeguard-ps/
 |-- test/                         # Integration test framework and suites (requires PS 7)
 |   |-- Invoke-SafeguardPsTests.ps1       # Test runner
 |   |-- SafeguardPsTestFramework.psm1     # Framework module
-|   `-- Suites/Suite-*.ps1                # 32 test suite files (~355 tests)
+|   `-- Suites/Suite-*.ps1                # 34 test suite files (~360 tests)
 |-- samples/                      # Example scripts
 |-- docker/                       # Dockerfiles (Ubuntu, Alpine, Mariner, Windows)
 |-- pipeline-templates/           # Azure Pipelines CI/CD templates
@@ -150,7 +150,7 @@ The test runner requires **PowerShell 7** (`pwsh`). It automatically:
 - Runs pre-cleanup to remove stale objects from prior failed runs
 - Reports pass/fail/skip with structured output
 
-A healthy baseline is **344 passed, 0 failed, 8 skipped** (SPS tests skip when no SPS
+A healthy baseline is **350 passed, 0 failed, 8 skipped** (SPS tests skip when no SPS
 appliance is provided).
 
 ### Fixing test failures
@@ -184,8 +184,8 @@ Map feature modules to suites:
 | `groups.psm1` | UserGroups, AssetGroups, AccountGroups |
 | `tags.psm1` | Tags |
 | `directories.psm1` | (no dedicated suite -- test manually) |
-| `events.psm1` | Events |
-| `a2acallers.psm1` | (no dedicated suite -- requires A2A registration on appliance) |
+| `events.psm1` | Events, EventListener |
+| `a2acallers.psm1` | A2ARegistrations, A2ACredentials, A2AEventListener |
 | `certificates.psm1` | Certificates |
 | `reports.psm1` | Reports |
 | `deleted.psm1` | DeletedObjects |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ safeguard-ps/
 |   |-- sslhandling.psm1         # SSL/TLS helper (not exported)
 |   |-- ps-utilities.psm1        # Shared PowerShell utilities (not exported)
 |   |-- sg-utilities.psm1        # Shared Safeguard utilities (not exported)
+|   |-- signalr-utilities.psm1   # SignalR SSE helpers for event listeners (not exported)
 |   `-- <feature>.psm1           # Feature modules (assets, users, a2a, policies, customplatforms, etc.)
 |-- test/                         # Integration test framework and suites (requires PS 7)
 |   |-- Invoke-SafeguardPsTests.ps1       # Test runner
@@ -184,6 +185,7 @@ Map feature modules to suites:
 | `tags.psm1` | Tags |
 | `directories.psm1` | (no dedicated suite -- test manually) |
 | `events.psm1` | Events |
+| `a2acallers.psm1` | (no dedicated suite -- requires A2A registration on appliance) |
 | `certificates.psm1` | Certificates |
 | `reports.psm1` | Reports |
 | `deleted.psm1` | DeletedObjects |
@@ -242,6 +244,34 @@ Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
 `$SafeguardSession` and `$SafeguardSpsSession` hold connection/token state. Most cmdlets
 read these implicitly. Do not refactor global state handling in small edits -- it is a
 deliberate architectural choice.
+
+### SignalR event listeners
+
+The module supports real-time event streaming via SignalR Server-Sent Events (SSE). Two
+separate SignalR endpoints exist on the appliance:
+
+- **User mode**: `/service/event/signalr/` -- authenticated with Bearer token.
+  Cmdlet: `Wait-SafeguardEvent` (in `events.psm1`).
+- **A2A mode**: `/service/a2a/signalr/` -- authenticated with client certificate + API key.
+  Cmdlets: `Wait-SafeguardA2aEvent`, `Invoke-SafeguardA2aPasswordHandler`,
+  `Invoke-SafeguardA2aSshKeyHandler` (in `a2acallers.psm1`).
+
+Shared SignalR helpers (`Get-SignalRConnectionToken`, `Send-SignalRHandshake`) live in
+`signalr-utilities.psm1` and accept a `$ServicePath` parameter (`"event"` or `"a2a"`) to
+target the correct endpoint.
+
+**SSE protocol flow**: negotiate (POST) -> open SSE GET stream -> send handshake POST ->
+read handshake response -> read event frames. A fresh negotiate is required on every
+reconnect because connectionTokens are ephemeral.
+
+**PS 5.1 vs PS 7 SSL note**: `ServicePointManager.ServerCertificateValidationCallback` does
+not apply to `HttpWebRequest` on .NET Core (PS 7). The SSE stream code uses per-request
+`ServerCertificateValidationCallback` on PS 7 when `-Insecure` is specified.
+
+**Handler cmdlets** (`Invoke-SafeguardA2aPasswordHandler`, `Invoke-SafeguardA2aSshKeyHandler`)
+fetch the initial credential, call the handler, then listen for change events. On each
+event they fetch the updated credential and call the handler again. The handler receives
+the event name and the credential value (password string or private key string).
 
 ### API versioning
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,63 @@ one guaranteed to work.  Please try to match the first and second version
 numbers between Safeguard and safeguard-ps as instructed above to avoid any
 compatibility issues.
 
+## Real-Time Event Listeners
+
+safeguard-ps can listen for real-time events from the Safeguard appliance using
+SignalR over Server-Sent Events (SSE).  This is useful for monitoring changes,
+triggering automated workflows, or building integrations that react to events
+as they happen.
+
+### Listening for Events
+
+After connecting with `Connect-Safeguard`, use `Wait-SafeguardEvent` to listen
+for events.  The cmdlet runs continuously until interrupted with **Ctrl+C**.
+
+When no `-Handler` or `-HandlerScript` is provided, events are emitted to the
+pipeline so you can filter and process them:
+
+```PowerShell
+> Connect-Safeguard -Insecure 192.168.123.123 local Admin -Pkce
+> Wait-SafeguardEvent -Insecure
+```
+
+You can filter to specific event types using the `-Event` parameter:
+
+```PowerShell
+> Wait-SafeguardEvent -Insecure -Event AssetAccountPasswordUpdated,AssetAccountSshKeyUpdated
+```
+
+### Using Handlers
+
+Use `-Handler` to provide a script block, or `-HandlerScript` to point at an
+external `.ps1` file.  These are mutually exclusive.  The handler receives the
+event name and event body as arguments:
+
+```PowerShell
+> Wait-SafeguardEvent -Insecure -Handler { param($EventName, $EventBody) Write-Host "$EventName occurred" }
+```
+
+### A2A Event Listeners
+
+For Application to Application (A2A) scenarios, use `Wait-SafeguardA2aEvent`
+which authenticates with a client certificate and API key rather than an
+interactive session.  It connects to the A2A-specific SignalR endpoint:
+
+```PowerShell
+> Wait-SafeguardA2aEvent -Appliance 192.168.123.123 -Insecure -CertificateFile C:\cert.pfx -Password $pwd -ApiKey $apiKey
+```
+
+The `Invoke-SafeguardA2aPasswordHandler` and `Invoke-SafeguardA2aSshKeyHandler`
+cmdlets are higher-level wrappers that fetch the current credential immediately,
+invoke your handler, then continue listening for changes.  Each time the
+credential is updated on the appliance, the new value is fetched and delivered
+to your handler:
+
+```PowerShell
+> Invoke-SafeguardA2aPasswordHandler 192.168.123.123 $apiKey -CertificateFile C:\cert.pfx -Password $pwd -Insecure `
+    -Handler { param($EventName, $Password) Write-Host "$EventName -- new password received" }
+```
+
 ## Getting Started With A2A
 
 Once you have configured your A2A registration in Safeguard, you can get
@@ -255,7 +312,7 @@ This will report the certificate thumbprint you need to use as well as the
 API key required to request a specific account password.
 
 The best practice is to install your user certificate in the Windows
-User Certificate Store (user the Personal folder).  Then, you can reference
+User Certificate Store (use the Personal folder).  Then, you can reference
 the certificate securely in safeguard-ps just using the thumbprint.
 
 You can see the thumbprints of certificates currently installed in your Windows
@@ -778,6 +835,7 @@ Aliases are shown in parentheses where available.
 - `New-SafeguardEventSubscription`
 - `Edit-SafeguardEventSubscription`
 - `Remove-SafeguardEventSubscription`
+- `Wait-SafeguardEvent`
 
 ### A2A
 
@@ -823,6 +881,11 @@ Aliases are shown in parentheses where available.
 
 **Access Request Broker (calling A2A):**
 - `New-SafeguardA2aAccessRequest`
+
+**Event Listeners (calling A2A):**
+- `Wait-SafeguardA2aEvent`
+- `Invoke-SafeguardA2aPasswordHandler`
+- `Invoke-SafeguardA2aSshKeyHandler`
 
 ### One Identity Starling
 

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -1123,7 +1123,6 @@ function Wait-SafeguardA2aEvent
     $local:SseDisposables = @()
     $local:Reader = $null
     $local:BackoffSeconds = 1
-    $local:RecordSep = [char]0x1E
 
     Write-Host "Listening for Safeguard A2A events on $Appliance... (Press Ctrl+C to stop)"
 
@@ -1178,198 +1177,18 @@ function Wait-SafeguardA2aEvent
 
                 Send-SignalRHandshake @local:HandshakeArgs
 
-                # Step 4: Read and verify handshake response from SSE stream
-                $local:HandshakeData = ""
-                $local:HandshakeComplete = $false
-                while (-not $local:HandshakeComplete)
-                {
-                    $local:Line = $local:Reader.ReadLine()
-                    if ($null -eq $local:Line)
-                    {
-                        throw "SSE stream closed before handshake completed"
-                    }
-                    if ($local:Line.StartsWith(":"))
-                    {
-                        continue
-                    }
-                    elseif ($local:Line.StartsWith("data:"))
-                    {
-                        $local:Value = $local:Line.Substring(5)
-                        if ($local:Value.StartsWith(" "))
-                        {
-                            $local:Value = $local:Value.Substring(1)
-                        }
-                        if ($local:HandshakeData.Length -gt 0)
-                        {
-                            $local:HandshakeData += "`n"
-                        }
-                        $local:HandshakeData += $local:Value
-                    }
-                    elseif ($local:Line -eq "" -and $local:HandshakeData.Length -gt 0)
-                    {
-                        $local:HandshakeComplete = $true
-                    }
-                }
+                # Step 4: Read and verify handshake response
+                Read-SignalRHandshakeResponse -Reader $local:Reader
 
-                # Parse handshake frames
-                $local:HsFrames = $local:HandshakeData.Split($local:RecordSep)
-                foreach ($local:HsFrame in $local:HsFrames)
-                {
-                    $local:HsFrame = $local:HsFrame.Trim()
-                    if ($local:HsFrame.Length -eq 0) { continue }
-                    $local:HsParsed = ConvertFrom-Json $local:HsFrame
-                    if ($local:HsParsed.error)
-                    {
-                        throw "SignalR handshake error: $($local:HsParsed.error)"
-                    }
-                }
-
-                Write-Verbose "SignalR handshake complete"
                 $local:BackoffSeconds = 1
 
-                # Step 5: Event reading loop
-                $local:DataBuffer = ""
-                $local:CloseReceived = $false
-
-                while (-not $local:CloseReceived)
-                {
-                    $local:Line = $local:Reader.ReadLine()
-                    if ($null -eq $local:Line)
-                    {
-                        Write-Verbose "SSE stream ended (server closed connection)"
-                        break
-                    }
-
-                    if ($local:Line.StartsWith(":"))
-                    {
-                        # SSE comment or heartbeat
-                        continue
-                    }
-                    elseif ($local:Line.StartsWith("data:"))
-                    {
-                        $local:Value = $local:Line.Substring(5)
-                        if ($local:Value.StartsWith(" "))
-                        {
-                            $local:Value = $local:Value.Substring(1)
-                        }
-                        if ($local:DataBuffer.Length -gt 0)
-                        {
-                            $local:DataBuffer += "`n"
-                        }
-                        $local:DataBuffer += $local:Value
-                    }
-                    elseif ($local:Line -eq "" -and $local:DataBuffer.Length -gt 0)
-                    {
-                        # SSE event boundary -- process accumulated data
-                        $local:Frames = $local:DataBuffer.Split($local:RecordSep)
-                        $local:DataBuffer = ""
-
-                        foreach ($local:Frame in $local:Frames)
-                        {
-                            $local:Frame = $local:Frame.Trim()
-                            if ($local:Frame.Length -eq 0) { continue }
-
-                            try
-                            {
-                                $local:Msg = ConvertFrom-Json $local:Frame
-                            }
-                            catch
-                            {
-                                Write-Verbose "Failed to parse SignalR frame: $local:Frame"
-                                continue
-                            }
-
-                            # SignalR message types: 1=Invocation, 6=Ping, 7=Close
-                            if ($local:Msg.type -eq 6)
-                            {
-                                Write-Verbose "Received SignalR ping"
-                                continue
-                            }
-                            elseif ($local:Msg.type -eq 7)
-                            {
-                                Write-Verbose "Received SignalR close frame"
-                                $local:CloseReceived = $true
-                                break
-                            }
-                            elseif ($local:Msg.type -eq 1 -and $local:Msg.target -eq "NotifyEventAsync")
-                            {
-                                $local:EventData = $local:Msg.arguments[0]
-                                $local:EvName = $local:EventData.Name
-                                $local:EvBody = $local:EventData
-
-                                # Apply event name filter
-                                if ($local:EventFilter -and -not $local:EventFilter.ContainsKey($local:EvName))
-                                {
-                                    Write-Verbose "Skipping filtered event: $local:EvName"
-                                    continue
-                                }
-
-                                Write-Verbose "A2A event received: $local:EvName"
-
-                                if ($Handler)
-                                {
-                                    try
-                                    {
-                                        & $Handler $local:EvName $local:EvBody
-                                    }
-                                    catch
-                                    {
-                                        Write-Warning "Event handler error for '$($local:EvName)': $_"
-                                    }
-                                }
-                                elseif ($HandlerScript)
-                                {
-                                    try
-                                    {
-                                        & $HandlerScript $local:EvName $local:EvBody
-                                    }
-                                    catch
-                                    {
-                                        Write-Warning "Handler script error for '$($local:EvName)': $_"
-                                    }
-                                }
-                                else
-                                {
-                                    New-Object PSObject -Property @{
-                                        EventName = $local:EvName
-                                        EventBody = $local:EvBody
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                # Step 5: Event reading loop (dispatches to handler/script/pipeline)
+                Read-SignalREvents -Reader $local:Reader -EventFilter $local:EventFilter `
+                    -Handler $Handler -HandlerScript $HandlerScript
             }
             catch
             {
-                # Determine if this is a fatal (4xx) or transient error
-                $local:IsFatal = $false
-                if ($_.Exception -is [System.Net.WebException])
-                {
-                    $local:WebEx = $_.Exception
-                    if ($local:WebEx.Response)
-                    {
-                        $local:StatusCode = [int]$local:WebEx.Response.StatusCode
-                        if ($local:StatusCode -ge 400 -and $local:StatusCode -lt 500)
-                        {
-                            $local:IsFatal = $true
-                        }
-                    }
-                }
-                # PS 7+: HttpClient throws HttpRequestException, not WebException
-                elseif ($_.Exception.GetType().FullName -eq "System.Net.Http.HttpRequestException")
-                {
-                    $local:HrStatusCode = $_.Exception.StatusCode
-                    if ($null -ne $local:HrStatusCode)
-                    {
-                        $local:StatusInt = [int]$local:HrStatusCode
-                        if ($local:StatusInt -ge 400 -and $local:StatusInt -lt 500)
-                        {
-                            $local:IsFatal = $true
-                        }
-                    }
-                }
-                if ($local:IsFatal)
+                if (Test-SignalRFatalError -ErrorRecord $_)
                 {
                     throw
                 }

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -1120,9 +1120,8 @@ function Wait-SafeguardA2aEvent
         if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
     }
 
+    $local:SseDisposables = @()
     $local:Reader = $null
-    $local:Stream = $null
-    $local:WebResponse = $null
     $local:BackoffSeconds = 1
     $local:RecordSep = [char]0x1E
 
@@ -1135,15 +1134,16 @@ function Wait-SafeguardA2aEvent
             try
             {
                 # Clean up previous connection if reconnecting
-                if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
-                if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
-                if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+                foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
+                $local:SseDisposables = @()
+                $local:Reader = $null
 
                 # Step 1: Negotiate -- get a fresh connectionToken
                 $local:NegotiateArgs = @{
                     Appliance = $Appliance
                     ServicePath = "a2a"
                     ApiKey = $ApiKey
+                    Insecure = $Insecure
                 }
                 if ($local:Cert) { $local:NegotiateArgs["Certificate"] = $local:Cert }
                 elseif ($Thumbprint) { $local:NegotiateArgs["Thumbprint"] = $Thumbprint }
@@ -1153,32 +1153,17 @@ function Wait-SafeguardA2aEvent
                 # Step 2: Open SSE GET stream
                 $local:EncodedToken = [System.Uri]::EscapeDataString($local:ConnectionToken)
                 $local:SseUrl = "https://$Appliance/service/a2a/signalr?id=$local:EncodedToken"
-                Write-Verbose "Opening SSE stream: $local:SseUrl"
 
-                $local:Request = [System.Net.HttpWebRequest]::Create($local:SseUrl)
-                $local:Request.Method = "GET"
-                $local:Request.Accept = "text/event-stream"
-                $local:Request.KeepAlive = $true
-                $local:Request.Timeout = [System.Threading.Timeout]::Infinite
-                $local:Request.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
-                $local:Request.Headers.Add("Authorization", "A2A $ApiKey")
-                if ($local:Cert)
-                {
-                    $local:Request.ClientCertificates.Add($local:Cert) | Out-Null
+                $local:SseArgs = @{
+                    Url = $local:SseUrl
+                    Headers = @{ "Authorization" = "A2A $ApiKey" }
+                    Insecure = $Insecure
                 }
+                if ($local:Cert) { $local:SseArgs["Certificate"] = $local:Cert }
 
-                # On PS 7 (.NET Core), ServicePointManager callback does not apply to
-                # HttpWebRequest. Use the per-request callback for SSL bypass.
-                if ($Insecure -and $PSVersionTable.PSEdition -eq "Core")
-                {
-                    $local:Request.ServerCertificateValidationCallback = {
-                        param($CbSender, $CbCert, $CbChain, $CbPolicy) $true
-                    }
-                }
-
-                $local:WebResponse = $local:Request.GetResponse()
-                $local:Stream = $local:WebResponse.GetResponseStream()
-                $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+                $local:Sse = Open-SignalRSseStream @local:SseArgs
+                $local:Reader = $local:Sse.Reader
+                $local:SseDisposables = $local:Sse.Disposables
 
                 # Step 3: Send handshake via POST (after SSE stream is open)
                 $local:HandshakeArgs = @{
@@ -1186,6 +1171,7 @@ function Wait-SafeguardA2aEvent
                     ConnectionToken = $local:ConnectionToken
                     ServicePath = "a2a"
                     ApiKey = $ApiKey
+                    Insecure = $Insecure
                 }
                 if ($local:Cert) { $local:HandshakeArgs["Certificate"] = $local:Cert }
                 elseif ($Thumbprint) { $local:HandshakeArgs["Thumbprint"] = $Thumbprint }
@@ -1379,9 +1365,9 @@ function Wait-SafeguardA2aEvent
             }
 
             # Clean up before reconnect
-            if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
-            if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
-            if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+            foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
+            $local:SseDisposables = @()
+            $local:Reader = $null
 
             Write-Verbose "Reconnecting in $local:BackoffSeconds seconds..."
             Start-Sleep -Seconds $local:BackoffSeconds
@@ -1390,9 +1376,7 @@ function Wait-SafeguardA2aEvent
     }
     finally
     {
-        if ($local:Reader) { try { $local:Reader.Dispose() } catch {} }
-        if ($local:Stream) { try { $local:Stream.Dispose() } catch {} }
-        if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} }
+        foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
         if ($Insecure)
         {
             Enable-SslVerification

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -973,3 +973,782 @@ function New-SafeguardA2aAccessRequest
             -CertificateFile $CertificateFile -Password $Password -Service a2a -Method POST -RelativeUrl AccessRequests -Body $local:Body
     }
 }
+
+<#
+.SYNOPSIS
+Listen for real-time Safeguard A2A events over SignalR using Server-Sent Events.
+
+.DESCRIPTION
+Wait-SafeguardA2aEvent opens a persistent SignalR connection to the Safeguard A2A
+event service (/service/a2a/signalr/) and streams live event notifications using
+certificate-based A2A authentication.
+
+The cmdlet blocks until interrupted with Ctrl+C. Events can be processed by a
+script block (-Handler), an external script (-HandlerScript), or emitted to the
+output pipeline as PSCustomObjects when no handler is specified.
+
+For user-mode event listening with Bearer token authentication, use
+Wait-SafeguardEvent instead.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER CertificateFile
+A string containing the path to a PFX certificate file for A2A authentication.
+
+.PARAMETER Password
+A secure string containing the password for decrypting the certificate file.
+
+.PARAMETER Thumbprint
+A string containing the thumbprint of a certificate in the user certificate store
+for A2A authentication.
+
+.PARAMETER ApiKey
+A string containing the A2A API key for authorization.
+
+.PARAMETER Event
+An array of event names to filter for. If omitted, all events are delivered.
+
+.PARAMETER Handler
+A script block to invoke for each event. Receives two arguments: $EventName (string)
+and $EventBody (PSObject).
+
+.PARAMETER HandlerScript
+Path to a .ps1 script to invoke for each event. The script receives two arguments:
+$EventName (string) and $EventBody (PSObject).
+
+.INPUTS
+None.
+
+.OUTPUTS
+When no Handler or HandlerScript is specified, outputs PSCustomObjects with
+EventName and EventBody properties.
+
+.EXAMPLE
+Wait-SafeguardA2aEvent 10.5.32.54 $apiKey -Thumbprint $tp -Insecure
+
+Listen for all A2A events using certificate store authentication.
+
+.EXAMPLE
+Wait-SafeguardA2aEvent 10.5.32.54 $apiKey -CertificateFile C:\cert.pfx -Password $pwd -Insecure -Event "AssetAccountPasswordUpdated"
+
+Listen for specific A2A events using certificate file authentication.
+
+.EXAMPLE
+Wait-SafeguardA2aEvent 10.5.32.54 $apiKey -Thumbprint $tp -Insecure -Handler { param($n,$b) Write-Host "Got $n" }
+
+Process A2A events with an inline script block.
+#>
+function Wait-SafeguardA2aEvent
+{
+    [CmdletBinding(DefaultParameterSetName="CertStore")]
+    Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="File",Mandatory=$true)]
+        [string]$CertificateFile,
+        [Parameter(ParameterSetName="File",Mandatory=$false)]
+        [SecureString]$Password,
+        [Parameter(ParameterSetName="CertStore",Mandatory=$true)]
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Event,
+        [Parameter(Mandatory=$false)]
+        [ScriptBlock]$Handler,
+        [Parameter(Mandatory=$false)]
+        [string]$HandlerScript
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Handler -and $HandlerScript)
+    {
+        throw "You may specify -Handler or -HandlerScript but not both"
+    }
+    if ($HandlerScript -and -not (Test-Path $HandlerScript))
+    {
+        throw "Handler script not found: $HandlerScript"
+    }
+
+    Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
+    Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
+    Import-Module -Name "$PSScriptRoot\signalr-utilities.psm1" -Scope Local
+
+    # Resolve certificate
+    $local:Cert = $null
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:Cert = (Use-CertificateFile $CertificateFile $Password)
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "CertStore")
+    {
+        $local:Store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My", "CurrentUser")
+        $local:Store.Open("ReadOnly")
+        $local:Certs = $local:Store.Certificates.Find(
+            [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint, $Thumbprint, $false)
+        $local:Store.Close()
+        if ($local:Certs.Count -eq 0)
+        {
+            throw "Certificate with thumbprint '$Thumbprint' not found in CurrentUser\My store"
+        }
+        $local:Cert = $local:Certs[0]
+    }
+
+    # Build event filter lookup for fast matching
+    $local:EventFilter = $null
+    if ($Event)
+    {
+        $local:EventFilter = @{}
+        foreach ($local:E in $Event)
+        {
+            $local:EventFilter[$local:E] = $true
+        }
+    }
+
+    Edit-SslVersionSupport
+    if ($Insecure)
+    {
+        Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+    }
+
+    $local:Reader = $null
+    $local:Stream = $null
+    $local:WebResponse = $null
+    $local:BackoffSeconds = 1
+    $local:RecordSep = [char]0x1E
+
+    Write-Host "Listening for Safeguard A2A events on $Appliance... (Press Ctrl+C to stop)"
+
+    try
+    {
+        while ($true)
+        {
+            try
+            {
+                # Clean up previous connection if reconnecting
+                if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
+                if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
+                if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+
+                # Step 1: Negotiate -- get a fresh connectionToken
+                $local:NegotiateArgs = @{
+                    Appliance = $Appliance
+                    ServicePath = "a2a"
+                    ApiKey = $ApiKey
+                }
+                if ($local:Cert) { $local:NegotiateArgs["Certificate"] = $local:Cert }
+                elseif ($Thumbprint) { $local:NegotiateArgs["Thumbprint"] = $Thumbprint }
+
+                $local:ConnectionToken = Get-SignalRConnectionToken @local:NegotiateArgs
+
+                # Step 2: Open SSE GET stream
+                $local:EncodedToken = [System.Uri]::EscapeDataString($local:ConnectionToken)
+                $local:SseUrl = "https://$Appliance/service/a2a/signalr?id=$local:EncodedToken"
+                Write-Verbose "Opening SSE stream: $local:SseUrl"
+
+                $local:Request = [System.Net.HttpWebRequest]::Create($local:SseUrl)
+                $local:Request.Method = "GET"
+                $local:Request.Accept = "text/event-stream"
+                $local:Request.KeepAlive = $true
+                $local:Request.Timeout = [System.Threading.Timeout]::Infinite
+                $local:Request.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
+                $local:Request.Headers.Add("Authorization", "A2A $ApiKey")
+                if ($local:Cert)
+                {
+                    $local:Request.ClientCertificates.Add($local:Cert) | Out-Null
+                }
+
+                # On PS 7 (.NET Core), ServicePointManager callback does not apply to
+                # HttpWebRequest. Use the per-request callback for SSL bypass.
+                if ($Insecure -and $PSVersionTable.PSEdition -eq "Core")
+                {
+                    $local:Request.ServerCertificateValidationCallback = {
+                        param($CbSender, $CbCert, $CbChain, $CbPolicy) $true
+                    }
+                }
+
+                $local:WebResponse = $local:Request.GetResponse()
+                $local:Stream = $local:WebResponse.GetResponseStream()
+                $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+
+                # Step 3: Send handshake via POST (after SSE stream is open)
+                $local:HandshakeArgs = @{
+                    Appliance = $Appliance
+                    ConnectionToken = $local:ConnectionToken
+                    ServicePath = "a2a"
+                    ApiKey = $ApiKey
+                }
+                if ($local:Cert) { $local:HandshakeArgs["Certificate"] = $local:Cert }
+                elseif ($Thumbprint) { $local:HandshakeArgs["Thumbprint"] = $Thumbprint }
+
+                Send-SignalRHandshake @local:HandshakeArgs
+
+                # Step 4: Read and verify handshake response from SSE stream
+                $local:HandshakeData = ""
+                $local:HandshakeComplete = $false
+                while (-not $local:HandshakeComplete)
+                {
+                    $local:Line = $local:Reader.ReadLine()
+                    if ($null -eq $local:Line)
+                    {
+                        throw "SSE stream closed before handshake completed"
+                    }
+                    if ($local:Line.StartsWith(":"))
+                    {
+                        continue
+                    }
+                    elseif ($local:Line.StartsWith("data:"))
+                    {
+                        $local:Value = $local:Line.Substring(5)
+                        if ($local:Value.StartsWith(" "))
+                        {
+                            $local:Value = $local:Value.Substring(1)
+                        }
+                        if ($local:HandshakeData.Length -gt 0)
+                        {
+                            $local:HandshakeData += "`n"
+                        }
+                        $local:HandshakeData += $local:Value
+                    }
+                    elseif ($local:Line -eq "" -and $local:HandshakeData.Length -gt 0)
+                    {
+                        $local:HandshakeComplete = $true
+                    }
+                }
+
+                # Parse handshake frames
+                $local:HsFrames = $local:HandshakeData.Split($local:RecordSep)
+                foreach ($local:HsFrame in $local:HsFrames)
+                {
+                    $local:HsFrame = $local:HsFrame.Trim()
+                    if ($local:HsFrame.Length -eq 0) { continue }
+                    $local:HsParsed = ConvertFrom-Json $local:HsFrame
+                    if ($local:HsParsed.error)
+                    {
+                        throw "SignalR handshake error: $($local:HsParsed.error)"
+                    }
+                }
+
+                Write-Verbose "SignalR handshake complete"
+                $local:BackoffSeconds = 1
+
+                # Step 5: Event reading loop
+                $local:DataBuffer = ""
+                $local:CloseReceived = $false
+
+                while (-not $local:CloseReceived)
+                {
+                    $local:Line = $local:Reader.ReadLine()
+                    if ($null -eq $local:Line)
+                    {
+                        Write-Verbose "SSE stream ended (server closed connection)"
+                        break
+                    }
+
+                    if ($local:Line.StartsWith(":"))
+                    {
+                        # SSE comment or heartbeat
+                        continue
+                    }
+                    elseif ($local:Line.StartsWith("data:"))
+                    {
+                        $local:Value = $local:Line.Substring(5)
+                        if ($local:Value.StartsWith(" "))
+                        {
+                            $local:Value = $local:Value.Substring(1)
+                        }
+                        if ($local:DataBuffer.Length -gt 0)
+                        {
+                            $local:DataBuffer += "`n"
+                        }
+                        $local:DataBuffer += $local:Value
+                    }
+                    elseif ($local:Line -eq "" -and $local:DataBuffer.Length -gt 0)
+                    {
+                        # SSE event boundary -- process accumulated data
+                        $local:Frames = $local:DataBuffer.Split($local:RecordSep)
+                        $local:DataBuffer = ""
+
+                        foreach ($local:Frame in $local:Frames)
+                        {
+                            $local:Frame = $local:Frame.Trim()
+                            if ($local:Frame.Length -eq 0) { continue }
+
+                            try
+                            {
+                                $local:Msg = ConvertFrom-Json $local:Frame
+                            }
+                            catch
+                            {
+                                Write-Verbose "Failed to parse SignalR frame: $local:Frame"
+                                continue
+                            }
+
+                            # SignalR message types: 1=Invocation, 6=Ping, 7=Close
+                            if ($local:Msg.type -eq 6)
+                            {
+                                Write-Verbose "Received SignalR ping"
+                                continue
+                            }
+                            elseif ($local:Msg.type -eq 7)
+                            {
+                                Write-Verbose "Received SignalR close frame"
+                                $local:CloseReceived = $true
+                                break
+                            }
+                            elseif ($local:Msg.type -eq 1 -and $local:Msg.target -eq "NotifyEventAsync")
+                            {
+                                $local:EventData = $local:Msg.arguments[0]
+                                $local:EvName = $local:EventData.Name
+                                $local:EvBody = $local:EventData
+
+                                # Apply event name filter
+                                if ($local:EventFilter -and -not $local:EventFilter.ContainsKey($local:EvName))
+                                {
+                                    Write-Verbose "Skipping filtered event: $local:EvName"
+                                    continue
+                                }
+
+                                Write-Verbose "A2A event received: $local:EvName"
+
+                                if ($Handler)
+                                {
+                                    try
+                                    {
+                                        & $Handler $local:EvName $local:EvBody
+                                    }
+                                    catch
+                                    {
+                                        Write-Warning "Event handler error for '$($local:EvName)': $_"
+                                    }
+                                }
+                                elseif ($HandlerScript)
+                                {
+                                    try
+                                    {
+                                        & $HandlerScript $local:EvName $local:EvBody
+                                    }
+                                    catch
+                                    {
+                                        Write-Warning "Handler script error for '$($local:EvName)': $_"
+                                    }
+                                }
+                                else
+                                {
+                                    New-Object PSObject -Property @{
+                                        EventName = $local:EvName
+                                        EventBody = $local:EvBody
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                # Determine if this is a fatal (4xx) or transient error
+                $local:IsFatal = $false
+                if ($_.Exception -is [System.Net.WebException])
+                {
+                    $local:WebEx = $_.Exception
+                    if ($local:WebEx.Response)
+                    {
+                        $local:StatusCode = [int]$local:WebEx.Response.StatusCode
+                        if ($local:StatusCode -ge 400 -and $local:StatusCode -lt 500)
+                        {
+                            $local:IsFatal = $true
+                        }
+                    }
+                }
+                if ($local:IsFatal)
+                {
+                    throw
+                }
+
+                Write-Warning "Connection error: $($_.Exception.Message)"
+            }
+
+            # Clean up before reconnect
+            if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
+            if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
+            if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+
+            Write-Verbose "Reconnecting in $local:BackoffSeconds seconds..."
+            Start-Sleep -Seconds $local:BackoffSeconds
+            $local:BackoffSeconds = [Math]::Min($local:BackoffSeconds * 2, 60)
+        }
+    }
+    finally
+    {
+        if ($local:Reader) { try { $local:Reader.Dispose() } catch {} }
+        if ($local:Stream) { try { $local:Stream.Dispose() } catch {} }
+        if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} }
+        if ($Insecure)
+        {
+            Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+        }
+        Write-Verbose "A2A event listener stopped."
+    }
+}
+
+<#
+.SYNOPSIS
+Listen for A2A password change events and call a handler with the new password.
+
+.DESCRIPTION
+Invoke-SafeguardA2aPasswordHandler retrieves the current password for an A2A credential
+via the API, passes it to the handler, then opens a persistent SignalR connection to listen
+for AssetAccountPasswordUpdated events. Each time the password changes, the new password
+is fetched and the handler is called again.
+
+This is the PowerShell equivalent of handle-a2a-password-event.sh from safeguard-bash.
+
+The handler receives the event name (string) and the password (string) as its two arguments.
+On initial invocation before any events, the event name is "InitialPassword".
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER CertificateFile
+A string containing the path to a PFX certificate file for A2A authentication.
+
+.PARAMETER Password
+A secure string containing the password for decrypting the certificate file.
+
+.PARAMETER Thumbprint
+A string containing the thumbprint of a certificate in the user certificate store
+for A2A authentication.
+
+.PARAMETER ApiKey
+A string containing the A2A API key that identifies the account being monitored.
+
+.PARAMETER Handler
+A script block to invoke with each password. Receives two arguments: $EventName (string)
+and $Password (string).
+
+.PARAMETER HandlerScript
+Path to a .ps1 script to invoke with each password. Receives two arguments: $EventName
+(string) and $Password (string).
+
+.PARAMETER Version
+Version of the Web API you are using (default: 4).
+
+.INPUTS
+None.
+
+.OUTPUTS
+None.
+
+.EXAMPLE
+Invoke-SafeguardA2aPasswordHandler 10.5.32.54 $apiKey -Thumbprint $tp -Insecure -Handler { param($ev,$pw) Write-Host "Password: $pw" }
+
+Listen for password changes and handle with a script block.
+
+.EXAMPLE
+Invoke-SafeguardA2aPasswordHandler 10.5.32.54 $apiKey -CertificateFile C:\cert.pfx -Password $pwd -Insecure -HandlerScript C:\scripts\rotate.ps1
+
+Listen for password changes and invoke an external script.
+#>
+function Invoke-SafeguardA2aPasswordHandler
+{
+    [CmdletBinding(DefaultParameterSetName="CertStore")]
+    Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="File",Mandatory=$true)]
+        [string]$CertificateFile,
+        [Parameter(ParameterSetName="File",Mandatory=$false)]
+        [SecureString]$Password,
+        [Parameter(ParameterSetName="CertStore",Mandatory=$true)]
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$false)]
+        [ScriptBlock]$Handler,
+        [Parameter(Mandatory=$false)]
+        [string]$HandlerScript,
+        [Parameter(Mandatory=$false)]
+        [int]$Version = 4
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $Handler -and -not $HandlerScript)
+    {
+        throw "You must specify -Handler or -HandlerScript"
+    }
+    if ($Handler -and $HandlerScript)
+    {
+        throw "You may specify -Handler or -HandlerScript but not both"
+    }
+    if ($HandlerScript -and -not (Test-Path $HandlerScript))
+    {
+        throw "Handler script not found: $HandlerScript"
+    }
+
+    # Build common credential args for Get-SafeguardA2aPassword calls
+    $local:CredArgs = @{
+        Appliance = $Appliance
+        ApiKey = $ApiKey
+        Version = $Version
+    }
+    if ($Insecure) { $local:CredArgs["Insecure"] = $true }
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:CredArgs["CertificateFile"] = $CertificateFile
+        if ($Password) { $local:CredArgs["Password"] = $Password }
+    }
+    else
+    {
+        $local:CredArgs["Thumbprint"] = $Thumbprint
+    }
+
+    # Step 1: Fetch and deliver initial password
+    Write-Verbose "Fetching initial password via A2A..."
+    $local:InitialPassword = Get-SafeguardA2aPassword @local:CredArgs
+
+    Write-Verbose "Calling handler with initial password"
+    $local:HandlerTarget = $Handler
+    if (-not $local:HandlerTarget) { $local:HandlerTarget = $HandlerScript }
+    try
+    {
+        & $local:HandlerTarget "InitialPassword" $local:InitialPassword
+    }
+    catch
+    {
+        Write-Warning "Handler error for initial password: $_"
+    }
+
+    # Step 2: Listen for password change events and fetch new password on each change
+    Write-Host "Listening for A2A password changes on $Appliance... (Press Ctrl+C to stop)"
+
+    $local:ListenerArgs = @{
+        Appliance = $Appliance
+        ApiKey = $ApiKey
+        Event = @("AssetAccountPasswordUpdated")
+    }
+    if ($Insecure) { $local:ListenerArgs["Insecure"] = $true }
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:ListenerArgs["CertificateFile"] = $CertificateFile
+        if ($Password) { $local:ListenerArgs["Password"] = $Password }
+    }
+    else
+    {
+        $local:ListenerArgs["Thumbprint"] = $Thumbprint
+    }
+
+    # Use a handler that fetches the new password and forwards to the user's handler
+    $local:ListenerArgs["Handler"] = {
+        param($EvName, $EvBody)
+        Write-Verbose "Password change event received, fetching new password..."
+        try
+        {
+            $local:NewPassword = Get-SafeguardA2aPassword @local:CredArgs
+            & $local:HandlerTarget $EvName $local:NewPassword
+        }
+        catch
+        {
+            Write-Warning "Error handling password change event: $_"
+        }
+    }.GetNewClosure()
+
+    Wait-SafeguardA2aEvent @local:ListenerArgs
+}
+
+<#
+.SYNOPSIS
+Listen for A2A SSH key change events and call a handler with the new private key.
+
+.DESCRIPTION
+Invoke-SafeguardA2aSshKeyHandler retrieves the current SSH private key for an A2A
+credential via the API, passes it to the handler, then opens a persistent SignalR
+connection to listen for AssetAccountSshKeyUpdated events. Each time the SSH key
+changes, the new private key is fetched and the handler is called again.
+
+The handler receives the event name (string) and the private key (string) as its
+two arguments. On initial invocation before any events, the event name is
+"InitialSshKey".
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER CertificateFile
+A string containing the path to a PFX certificate file for A2A authentication.
+
+.PARAMETER Password
+A secure string containing the password for decrypting the certificate file.
+
+.PARAMETER Thumbprint
+A string containing the thumbprint of a certificate in the user certificate store
+for A2A authentication.
+
+.PARAMETER ApiKey
+A string containing the A2A API key that identifies the account being monitored.
+
+.PARAMETER KeyFormat
+A string containing which format to use for the private key. The options are:
+  - OpenSsh: OpenSSH legacy PEM format (default)
+  - Ssh2: Tectia format for use with tools from SSH.com
+  - Putty: Putty format for use with PuTTY tools
+
+.PARAMETER Handler
+A script block to invoke with each SSH key. Receives two arguments: $EventName
+(string) and $PrivateKey (string).
+
+.PARAMETER HandlerScript
+Path to a .ps1 script to invoke with each SSH key. Receives two arguments:
+$EventName (string) and $PrivateKey (string).
+
+.PARAMETER Version
+Version of the Web API you are using (default: 4).
+
+.INPUTS
+None.
+
+.OUTPUTS
+None.
+
+.EXAMPLE
+Invoke-SafeguardA2aSshKeyHandler 10.5.32.54 $apiKey -Thumbprint $tp -Insecure -Handler { param($ev,$key) Set-Content -Path ~/.ssh/id_rsa -Value $key }
+
+Listen for SSH key changes and update a local key file.
+
+.EXAMPLE
+Invoke-SafeguardA2aSshKeyHandler 10.5.32.54 $apiKey -CertificateFile C:\cert.pfx -Password $pwd -Insecure -KeyFormat Putty -HandlerScript C:\scripts\deploy-key.ps1
+
+Listen for SSH key changes in Putty format and invoke an external script.
+#>
+function Invoke-SafeguardA2aSshKeyHandler
+{
+    [CmdletBinding(DefaultParameterSetName="CertStore")]
+    Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="File",Mandatory=$true)]
+        [string]$CertificateFile,
+        [Parameter(ParameterSetName="File",Mandatory=$false)]
+        [SecureString]$Password,
+        [Parameter(ParameterSetName="CertStore",Mandatory=$true)]
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("OpenSsh","Ssh2","Putty",IgnoreCase=$true)]
+        [string]$KeyFormat = $null,
+        [Parameter(Mandatory=$false)]
+        [ScriptBlock]$Handler,
+        [Parameter(Mandatory=$false)]
+        [string]$HandlerScript,
+        [Parameter(Mandatory=$false)]
+        [int]$Version = 4
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $Handler -and -not $HandlerScript)
+    {
+        throw "You must specify -Handler or -HandlerScript"
+    }
+    if ($Handler -and $HandlerScript)
+    {
+        throw "You may specify -Handler or -HandlerScript but not both"
+    }
+    if ($HandlerScript -and -not (Test-Path $HandlerScript))
+    {
+        throw "Handler script not found: $HandlerScript"
+    }
+
+    # Build common credential args for Get-SafeguardA2aPrivateKey calls
+    $local:CredArgs = @{
+        Appliance = $Appliance
+        ApiKey = $ApiKey
+        Version = $Version
+    }
+    if ($Insecure) { $local:CredArgs["Insecure"] = $true }
+    if ($KeyFormat) { $local:CredArgs["KeyFormat"] = $KeyFormat }
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:CredArgs["CertificateFile"] = $CertificateFile
+        if ($Password) { $local:CredArgs["Password"] = $Password }
+    }
+    else
+    {
+        $local:CredArgs["Thumbprint"] = $Thumbprint
+    }
+
+    # Step 1: Fetch and deliver initial SSH key
+    Write-Verbose "Fetching initial SSH private key via A2A..."
+    $local:InitialKey = Get-SafeguardA2aPrivateKey @local:CredArgs
+
+    Write-Verbose "Calling handler with initial SSH key"
+    $local:HandlerTarget = $Handler
+    if (-not $local:HandlerTarget) { $local:HandlerTarget = $HandlerScript }
+    try
+    {
+        & $local:HandlerTarget "InitialSshKey" $local:InitialKey
+    }
+    catch
+    {
+        Write-Warning "Handler error for initial SSH key: $_"
+    }
+
+    # Step 2: Listen for SSH key change events and fetch new key on each change
+    Write-Host "Listening for A2A SSH key changes on $Appliance... (Press Ctrl+C to stop)"
+
+    $local:ListenerArgs = @{
+        Appliance = $Appliance
+        ApiKey = $ApiKey
+        Event = @("AssetAccountSshKeyUpdated")
+    }
+    if ($Insecure) { $local:ListenerArgs["Insecure"] = $true }
+    if ($PSCmdlet.ParameterSetName -eq "File")
+    {
+        $local:ListenerArgs["CertificateFile"] = $CertificateFile
+        if ($Password) { $local:ListenerArgs["Password"] = $Password }
+    }
+    else
+    {
+        $local:ListenerArgs["Thumbprint"] = $Thumbprint
+    }
+
+    # Use a handler that fetches the new SSH key and forwards to the user's handler
+    $local:ListenerArgs["Handler"] = {
+        param($EvName, $EvBody)
+        Write-Verbose "SSH key change event received, fetching new key..."
+        try
+        {
+            $local:NewKey = Get-SafeguardA2aPrivateKey @local:CredArgs
+            & $local:HandlerTarget $EvName $local:NewKey
+        }
+        catch
+        {
+            Write-Warning "Error handling SSH key change event: $_"
+        }
+    }.GetNewClosure()
+
+    Wait-SafeguardA2aEvent @local:ListenerArgs
+}

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -1356,6 +1356,19 @@ function Wait-SafeguardA2aEvent
                         }
                     }
                 }
+                # PS 7+: HttpClient throws HttpRequestException, not WebException
+                elseif ($_.Exception.GetType().FullName -eq "System.Net.Http.HttpRequestException")
+                {
+                    $local:HrStatusCode = $_.Exception.StatusCode
+                    if ($null -ne $local:HrStatusCode)
+                    {
+                        $local:StatusInt = [int]$local:HrStatusCode
+                        if ($local:StatusInt -ge 400 -and $local:StatusInt -lt 500)
+                        {
+                            $local:IsFatal = $true
+                        }
+                    }
+                }
                 if ($local:IsFatal)
                 {
                     throw
@@ -1540,13 +1553,16 @@ function Invoke-SafeguardA2aPasswordHandler
     }
 
     # Use a handler that fetches the new password and forwards to the user's handler
+    # NOTE: Do not use $local: for captured variables inside .GetNewClosure() --
+    # the closure stores them in a dynamic module scope, and $local: only searches
+    # the scriptblock's own (empty) local scope.
     $local:ListenerArgs["Handler"] = {
         param($EvName, $EvBody)
         Write-Verbose "Password change event received, fetching new password..."
         try
         {
-            $local:NewPassword = Get-SafeguardA2aPassword @local:CredArgs
-            & $local:HandlerTarget $EvName $local:NewPassword
+            $NewPassword = Get-SafeguardA2aPassword @CredArgs
+            & $HandlerTarget $EvName $NewPassword
         }
         catch
         {
@@ -1720,13 +1736,16 @@ function Invoke-SafeguardA2aSshKeyHandler
     }
 
     # Use a handler that fetches the new SSH key and forwards to the user's handler
+    # NOTE: Do not use $local: for captured variables inside .GetNewClosure() --
+    # the closure stores them in a dynamic module scope, and $local: only searches
+    # the scriptblock's own (empty) local scope.
     $local:ListenerArgs["Handler"] = {
         param($EvName, $EvBody)
         Write-Verbose "SSH key change event received, fetching new key..."
         try
         {
-            $local:NewKey = Get-SafeguardA2aPrivateKey @local:CredArgs
-            & $local:HandlerTarget $EvName $local:NewKey
+            $NewKey = Get-SafeguardA2aPrivateKey @CredArgs
+            & $HandlerTarget $EvName $NewKey
         }
         catch
         {

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1333,7 +1333,6 @@ function Wait-SafeguardEvent
     $local:SseDisposables = @()
     $local:Reader = $null
     $local:BackoffSeconds = 1
-    $local:RecordSep = [char]0x1E
 
     Write-Host "Listening for Safeguard events on $Appliance... (Press Ctrl+C to stop)"
 
@@ -1367,198 +1366,18 @@ function Wait-SafeguardEvent
                     -ConnectionToken $local:ConnectionToken -AccessToken $AccessToken `
                     -Insecure:$Insecure
 
-                # Step 4: Read and verify handshake response from SSE stream
-                $local:HandshakeData = ""
-                $local:HandshakeComplete = $false
-                while (-not $local:HandshakeComplete)
-                {
-                    $local:Line = $local:Reader.ReadLine()
-                    if ($null -eq $local:Line)
-                    {
-                        throw "SSE stream closed before handshake completed"
-                    }
-                    if ($local:Line.StartsWith(":"))
-                    {
-                        continue
-                    }
-                    elseif ($local:Line.StartsWith("data:"))
-                    {
-                        $local:Value = $local:Line.Substring(5)
-                        if ($local:Value.StartsWith(" "))
-                        {
-                            $local:Value = $local:Value.Substring(1)
-                        }
-                        if ($local:HandshakeData.Length -gt 0)
-                        {
-                            $local:HandshakeData += "`n"
-                        }
-                        $local:HandshakeData += $local:Value
-                    }
-                    elseif ($local:Line -eq "" -and $local:HandshakeData.Length -gt 0)
-                    {
-                        $local:HandshakeComplete = $true
-                    }
-                }
+                # Step 4: Read and verify handshake response
+                Read-SignalRHandshakeResponse -Reader $local:Reader
 
-                # Parse handshake frames
-                $local:HsFrames = $local:HandshakeData.Split($local:RecordSep)
-                foreach ($local:HsFrame in $local:HsFrames)
-                {
-                    $local:HsFrame = $local:HsFrame.Trim()
-                    if ($local:HsFrame.Length -eq 0) { continue }
-                    $local:HsParsed = ConvertFrom-Json $local:HsFrame
-                    if ($local:HsParsed.error)
-                    {
-                        throw "SignalR handshake error: $($local:HsParsed.error)"
-                    }
-                }
-
-                Write-Verbose "SignalR handshake complete"
                 $local:BackoffSeconds = 1
 
-                # Step 5: Event reading loop
-                $local:DataBuffer = ""
-                $local:CloseReceived = $false
-
-                while (-not $local:CloseReceived)
-                {
-                    $local:Line = $local:Reader.ReadLine()
-                    if ($null -eq $local:Line)
-                    {
-                        Write-Verbose "SSE stream ended (server closed connection)"
-                        break
-                    }
-
-                    if ($local:Line.StartsWith(":"))
-                    {
-                        # SSE comment or heartbeat
-                        continue
-                    }
-                    elseif ($local:Line.StartsWith("data:"))
-                    {
-                        $local:Value = $local:Line.Substring(5)
-                        if ($local:Value.StartsWith(" "))
-                        {
-                            $local:Value = $local:Value.Substring(1)
-                        }
-                        if ($local:DataBuffer.Length -gt 0)
-                        {
-                            $local:DataBuffer += "`n"
-                        }
-                        $local:DataBuffer += $local:Value
-                    }
-                    elseif ($local:Line -eq "" -and $local:DataBuffer.Length -gt 0)
-                    {
-                        # SSE event boundary -- process accumulated data
-                        $local:Frames = $local:DataBuffer.Split($local:RecordSep)
-                        $local:DataBuffer = ""
-
-                        foreach ($local:Frame in $local:Frames)
-                        {
-                            $local:Frame = $local:Frame.Trim()
-                            if ($local:Frame.Length -eq 0) { continue }
-
-                            try
-                            {
-                                $local:Msg = ConvertFrom-Json $local:Frame
-                            }
-                            catch
-                            {
-                                Write-Verbose "Failed to parse SignalR frame: $local:Frame"
-                                continue
-                            }
-
-                            # SignalR message types: 1=Invocation, 6=Ping, 7=Close
-                            if ($local:Msg.type -eq 6)
-                            {
-                                Write-Verbose "Received SignalR ping"
-                                continue
-                            }
-                            elseif ($local:Msg.type -eq 7)
-                            {
-                                Write-Verbose "Received SignalR close frame"
-                                $local:CloseReceived = $true
-                                break
-                            }
-                            elseif ($local:Msg.type -eq 1 -and $local:Msg.target -eq "NotifyEventAsync")
-                            {
-                                $local:EventData = $local:Msg.arguments[0]
-                                $local:EvName = $local:EventData.Name
-                                $local:EvBody = $local:EventData
-
-                                # Apply event name filter
-                                if ($local:EventFilter -and -not $local:EventFilter.ContainsKey($local:EvName))
-                                {
-                                    Write-Verbose "Skipping filtered event: $local:EvName"
-                                    continue
-                                }
-
-                                Write-Verbose "Event received: $local:EvName"
-
-                                if ($Handler)
-                                {
-                                    try
-                                    {
-                                        & $Handler $local:EvName $local:EvBody
-                                    }
-                                    catch
-                                    {
-                                        Write-Warning "Event handler error for '$($local:EvName)': $_"
-                                    }
-                                }
-                                elseif ($HandlerScript)
-                                {
-                                    try
-                                    {
-                                        & $HandlerScript $local:EvName $local:EvBody
-                                    }
-                                    catch
-                                    {
-                                        Write-Warning "Handler script error for '$($local:EvName)': $_"
-                                    }
-                                }
-                                else
-                                {
-                                    New-Object PSObject -Property @{
-                                        EventName = $local:EvName
-                                        EventBody = $local:EvBody
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                # Step 5: Event reading loop (dispatches to handler/script/pipeline)
+                Read-SignalREvents -Reader $local:Reader -EventFilter $local:EventFilter `
+                    -Handler $Handler -HandlerScript $HandlerScript
             }
             catch
             {
-                # Determine if this is a fatal (4xx) or transient error
-                $local:IsFatal = $false
-                if ($_.Exception -is [System.Net.WebException])
-                {
-                    $local:WebEx = $_.Exception
-                    if ($local:WebEx.Response)
-                    {
-                        $local:StatusCode = [int]$local:WebEx.Response.StatusCode
-                        if ($local:StatusCode -ge 400 -and $local:StatusCode -lt 500)
-                        {
-                            $local:IsFatal = $true
-                        }
-                    }
-                }
-                # PS 7+: HttpClient throws HttpRequestException, not WebException
-                elseif ($_.Exception.GetType().FullName -eq "System.Net.Http.HttpRequestException")
-                {
-                    $local:HrStatusCode = $_.Exception.StatusCode
-                    if ($null -ne $local:HrStatusCode)
-                    {
-                        $local:StatusInt = [int]$local:HrStatusCode
-                        if ($local:StatusInt -ge 400 -and $local:StatusInt -lt 500)
-                        {
-                            $local:IsFatal = $true
-                        }
-                    }
-                }
-                if ($local:IsFatal)
+                if (Test-SignalRFatalError -ErrorRecord $_)
                 {
                     throw
                 }

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1330,9 +1330,8 @@ function Wait-SafeguardEvent
         if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
     }
 
+    $local:SseDisposables = @()
     $local:Reader = $null
-    $local:Stream = $null
-    $local:WebResponse = $null
     $local:BackoffSeconds = 1
     $local:RecordSep = [char]0x1E
 
@@ -1345,43 +1344,28 @@ function Wait-SafeguardEvent
             try
             {
                 # Clean up previous connection if reconnecting
-                if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
-                if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
-                if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+                foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
+                $local:SseDisposables = @()
+                $local:Reader = $null
 
                 # Step 1: Negotiate -- get a fresh connectionToken
                 $local:ConnectionToken = Get-SignalRConnectionToken -Appliance $Appliance `
-                    -AccessToken $AccessToken
+                    -AccessToken $AccessToken -Insecure:$Insecure
 
                 # Step 2: Open SSE GET stream
                 $local:EncodedToken = [System.Uri]::EscapeDataString($local:ConnectionToken)
                 $local:SseUrl = "https://$Appliance/service/event/signalr?id=$local:EncodedToken"
-                Write-Verbose "Opening SSE stream: $local:SseUrl"
 
-                $local:Request = [System.Net.HttpWebRequest]::Create($local:SseUrl)
-                $local:Request.Method = "GET"
-                $local:Request.Accept = "text/event-stream"
-                $local:Request.KeepAlive = $true
-                $local:Request.Timeout = [System.Threading.Timeout]::Infinite
-                $local:Request.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
-                $local:Request.Headers.Add("Authorization", "Bearer $AccessToken")
-
-                # On PS 7 (.NET Core), ServicePointManager callback does not apply to
-                # HttpWebRequest. Use the per-request callback for SSL bypass.
-                if ($Insecure -and $PSVersionTable.PSEdition -eq "Core")
-                {
-                    $local:Request.ServerCertificateValidationCallback = {
-                        param($CbSender, $CbCert, $CbChain, $CbPolicy) $true
-                    }
-                }
-
-                $local:WebResponse = $local:Request.GetResponse()
-                $local:Stream = $local:WebResponse.GetResponseStream()
-                $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+                $local:Sse = Open-SignalRSseStream -Url $local:SseUrl `
+                    -Headers @{ "Authorization" = "Bearer $AccessToken" } `
+                    -Insecure:$Insecure
+                $local:Reader = $local:Sse.Reader
+                $local:SseDisposables = $local:Sse.Disposables
 
                 # Step 3: Send handshake via POST (after SSE stream is open)
                 Send-SignalRHandshake -Appliance $Appliance `
-                    -ConnectionToken $local:ConnectionToken -AccessToken $AccessToken
+                    -ConnectionToken $local:ConnectionToken -AccessToken $AccessToken `
+                    -Insecure:$Insecure
 
                 # Step 4: Read and verify handshake response from SSE stream
                 $local:HandshakeData = ""
@@ -1570,9 +1554,9 @@ function Wait-SafeguardEvent
             }
 
             # Clean up before reconnect
-            if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
-            if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
-            if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+            foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
+            $local:SseDisposables = @()
+            $local:Reader = $null
 
             Write-Verbose "Reconnecting in $local:BackoffSeconds seconds..."
             Start-Sleep -Seconds $local:BackoffSeconds
@@ -1596,9 +1580,7 @@ function Wait-SafeguardEvent
     }
     finally
     {
-        if ($local:Reader) { try { $local:Reader.Dispose() } catch {} }
-        if ($local:Stream) { try { $local:Stream.Dispose() } catch {} }
-        if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} }
+        foreach ($local:D in $local:SseDisposables) { try { $local:D.Dispose() } catch {} }
         if ($Insecure)
         {
             Enable-SslVerification

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1197,3 +1197,513 @@ function Remove-SafeguardEventSubscription
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "EventSubscribers/$SubscriptionId"
 
 }
+
+# SignalR SSE event listener cmdlet
+
+<#
+.SYNOPSIS
+Listen for real-time Safeguard events over SignalR using Server-Sent Events.
+
+.DESCRIPTION
+Wait-SafeguardEvent opens a persistent SignalR connection to the Safeguard event
+service and streams live event notifications. This is the PowerShell equivalent of
+the event listener in safeguard-bash and SafeguardDotNet.
+
+The cmdlet blocks until interrupted with Ctrl+C. Events can be processed by a
+script block (-Handler), an external script (-HandlerScript), or emitted to the
+output pipeline as PSCustomObjects when no handler is specified.
+
+Supports both user mode (Bearer token) and A2A mode (certificate + API key).
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ApiKey
+A string containing the A2A API key for authorization.
+
+.PARAMETER CertificateFile
+Path to a PFX certificate file for A2A authentication.
+
+.PARAMETER Password
+A SecureString containing the password for the PFX certificate file.
+
+.PARAMETER Thumbprint
+A string containing the thumbprint of a certificate in the user certificate store
+for A2A authentication.
+
+.PARAMETER Event
+An array of event names to filter for. If omitted, all events are delivered.
+
+.PARAMETER Handler
+A script block to invoke for each event. Receives two arguments: $EventName (string)
+and $EventBody (PSObject).
+
+.PARAMETER HandlerScript
+Path to a .ps1 script to invoke for each event. The script receives two arguments:
+$EventName (string) and $EventBody (PSObject).
+
+.INPUTS
+None.
+
+.OUTPUTS
+When no Handler or HandlerScript is specified, outputs PSCustomObjects with
+EventName and EventBody properties.
+
+.EXAMPLE
+Wait-SafeguardEvent -Insecure
+
+Listen for all events using the current session, emitting objects to the pipeline.
+
+.EXAMPLE
+Wait-SafeguardEvent -Insecure -Event "AssetCreated","AssetRemoved"
+
+Listen for specific events only.
+
+.EXAMPLE
+Wait-SafeguardEvent -Insecure -Handler { param($EventName, $EventBody) Write-Host "Got $EventName" }
+
+Process events with an inline script block.
+
+.EXAMPLE
+Wait-SafeguardEvent -Appliance 10.5.32.54 -ApiKey $key -CertificateFile C:\cert.pfx -Password $pwd -Insecure
+
+Listen for A2A events using certificate file authentication.
+
+.EXAMPLE
+Wait-SafeguardEvent -Appliance 10.5.32.54 -ApiKey $key -Thumbprint $tp -Insecure
+
+Listen for A2A events using certificate thumbprint.
+#>
+function Wait-SafeguardEvent
+{
+    [CmdletBinding(DefaultParameterSetName="UserMode")]
+    Param(
+        [Parameter(Mandatory=$false,ParameterSetName="UserMode")]
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false,ParameterSetName="UserMode")]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
+        [string]$CertificateFile,
+        [Parameter(Mandatory=$false,ParameterSetName="A2AWithFile")]
+        [SecureString]$Password,
+        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Event,
+        [Parameter(Mandatory=$false)]
+        [ScriptBlock]$Handler,
+        [Parameter(Mandatory=$false)]
+        [string]$HandlerScript
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($Handler -and $HandlerScript)
+    {
+        throw "You may specify -Handler or -HandlerScript but not both"
+    }
+    if ($HandlerScript -and -not (Test-Path $HandlerScript))
+    {
+        throw "Handler script not found: $HandlerScript"
+    }
+
+    Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
+    Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
+    Import-Module -Name "$PSScriptRoot\signalr-utilities.psm1" -Scope Local
+
+    # Determine if this is A2A mode
+    $local:IsA2a = ($PSCmdlet.ParameterSetName -eq "A2AWithFile" -or `
+                    $PSCmdlet.ParameterSetName -eq "A2AWithThumbprint")
+
+    # Resolve session state for user mode
+    if (-not $local:IsA2a)
+    {
+        if (-not $Appliance -and $SafeguardSession)
+        {
+            $Appliance = $SafeguardSession["Appliance"]
+        }
+        if (-not $AccessToken -and $SafeguardSession)
+        {
+            $AccessToken = $SafeguardSession["AccessToken"]
+        }
+        if (-not $PSBoundParameters.ContainsKey("Insecure") -and $SafeguardSession)
+        {
+            $Insecure = $SafeguardSession["Insecure"]
+        }
+        if (-not $Appliance)
+        {
+            $Appliance = (Read-Host "Appliance")
+        }
+        if (-not $AccessToken)
+        {
+            throw "AccessToken required. Use Connect-Safeguard first or pass -AccessToken."
+        }
+    }
+
+    # Resolve certificate for A2A mode
+    $local:Cert = $null
+    if ($PSCmdlet.ParameterSetName -eq "A2AWithFile")
+    {
+        $local:Cert = (Use-CertificateFile $CertificateFile $Password)
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "A2AWithThumbprint")
+    {
+        $local:Store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My", "CurrentUser")
+        $local:Store.Open("ReadOnly")
+        $local:Certs = $local:Store.Certificates.Find(
+            [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint, $Thumbprint, $false)
+        $local:Store.Close()
+        if ($local:Certs.Count -eq 0)
+        {
+            throw "Certificate with thumbprint '$Thumbprint' not found in CurrentUser\My store"
+        }
+        $local:Cert = $local:Certs[0]
+    }
+
+    # Build event filter lookup for fast matching
+    $local:EventFilter = $null
+    if ($Event)
+    {
+        $local:EventFilter = @{}
+        foreach ($local:E in $Event)
+        {
+            $local:EventFilter[$local:E] = $true
+        }
+    }
+
+    Edit-SslVersionSupport
+    if ($Insecure)
+    {
+        Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+    }
+
+    $local:Reader = $null
+    $local:Stream = $null
+    $local:WebResponse = $null
+    $local:BackoffSeconds = 1
+    $local:RecordSep = [char]0x1E
+
+    Write-Host "Listening for Safeguard events on $Appliance... (Press Ctrl+C to stop)"
+
+    try
+    {
+        while ($true)
+        {
+            try
+            {
+                # Clean up previous connection if reconnecting
+                if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
+                if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
+                if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+
+                # Step 1: Negotiate -- get a fresh connectionToken
+                $local:NegotiateArgs = @{ Appliance = $Appliance }
+                if ($local:IsA2a)
+                {
+                    $local:NegotiateArgs["ApiKey"] = $ApiKey
+                    if ($local:Cert) { $local:NegotiateArgs["Certificate"] = $local:Cert }
+                    elseif ($Thumbprint) { $local:NegotiateArgs["Thumbprint"] = $Thumbprint }
+                }
+                else
+                {
+                    $local:NegotiateArgs["AccessToken"] = $AccessToken
+                }
+
+                $local:ConnectionToken = Get-SignalRConnectionToken @local:NegotiateArgs
+
+                # Step 2: Open SSE GET stream
+                $local:EncodedToken = [System.Uri]::EscapeDataString($local:ConnectionToken)
+                $local:SseUrl = "https://$Appliance/service/event/signalr?id=$local:EncodedToken"
+                Write-Verbose "Opening SSE stream: $local:SseUrl"
+
+                $local:Request = [System.Net.HttpWebRequest]::Create($local:SseUrl)
+                $local:Request.Method = "GET"
+                $local:Request.Accept = "text/event-stream"
+                $local:Request.KeepAlive = $true
+                $local:Request.Timeout = [System.Threading.Timeout]::Infinite
+                $local:Request.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
+
+                if ($local:IsA2a)
+                {
+                    $local:Request.Headers.Add("Authorization", "A2A $ApiKey")
+                    if ($local:Cert)
+                    {
+                        $local:Request.ClientCertificates.Add($local:Cert) | Out-Null
+                    }
+                }
+                else
+                {
+                    $local:Request.Headers.Add("Authorization", "Bearer $AccessToken")
+                }
+
+                # On PS 7 (.NET Core), ServicePointManager callback does not apply to
+                # HttpWebRequest. Use the per-request callback for SSL bypass.
+                if ($Insecure -and $PSVersionTable.PSEdition -eq "Core")
+                {
+                    $local:Request.ServerCertificateValidationCallback = {
+                        param($CbSender, $CbCert, $CbChain, $CbPolicy) $true
+                    }
+                }
+
+                $local:WebResponse = $local:Request.GetResponse()
+                $local:Stream = $local:WebResponse.GetResponseStream()
+                $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+
+                # Step 3: Send handshake via POST (after SSE stream is open)
+                $local:HandshakeArgs = @{
+                    Appliance = $Appliance
+                    ConnectionToken = $local:ConnectionToken
+                }
+                if ($local:IsA2a)
+                {
+                    $local:HandshakeArgs["ApiKey"] = $ApiKey
+                    if ($local:Cert) { $local:HandshakeArgs["Certificate"] = $local:Cert }
+                    elseif ($Thumbprint) { $local:HandshakeArgs["Thumbprint"] = $Thumbprint }
+                }
+                else
+                {
+                    $local:HandshakeArgs["AccessToken"] = $AccessToken
+                }
+
+                Send-SignalRHandshake @local:HandshakeArgs
+
+                # Step 4: Read and verify handshake response from SSE stream
+                $local:HandshakeData = ""
+                $local:HandshakeComplete = $false
+                while (-not $local:HandshakeComplete)
+                {
+                    $local:Line = $local:Reader.ReadLine()
+                    if ($null -eq $local:Line)
+                    {
+                        throw "SSE stream closed before handshake completed"
+                    }
+                    if ($local:Line.StartsWith(":"))
+                    {
+                        continue
+                    }
+                    elseif ($local:Line.StartsWith("data:"))
+                    {
+                        $local:Value = $local:Line.Substring(5)
+                        if ($local:Value.StartsWith(" "))
+                        {
+                            $local:Value = $local:Value.Substring(1)
+                        }
+                        if ($local:HandshakeData.Length -gt 0)
+                        {
+                            $local:HandshakeData += "`n"
+                        }
+                        $local:HandshakeData += $local:Value
+                    }
+                    elseif ($local:Line -eq "" -and $local:HandshakeData.Length -gt 0)
+                    {
+                        $local:HandshakeComplete = $true
+                    }
+                }
+
+                # Parse handshake frames
+                $local:HsFrames = $local:HandshakeData.Split($local:RecordSep)
+                foreach ($local:HsFrame in $local:HsFrames)
+                {
+                    $local:HsFrame = $local:HsFrame.Trim()
+                    if ($local:HsFrame.Length -eq 0) { continue }
+                    $local:HsParsed = ConvertFrom-Json $local:HsFrame
+                    if ($local:HsParsed.error)
+                    {
+                        throw "SignalR handshake error: $($local:HsParsed.error)"
+                    }
+                }
+
+                Write-Verbose "SignalR handshake complete"
+                $local:BackoffSeconds = 1
+
+                # Step 5: Event reading loop
+                $local:DataBuffer = ""
+                $local:CloseReceived = $false
+
+                while (-not $local:CloseReceived)
+                {
+                    $local:Line = $local:Reader.ReadLine()
+                    if ($null -eq $local:Line)
+                    {
+                        Write-Verbose "SSE stream ended (server closed connection)"
+                        break
+                    }
+
+                    if ($local:Line.StartsWith(":"))
+                    {
+                        # SSE comment or heartbeat
+                        continue
+                    }
+                    elseif ($local:Line.StartsWith("data:"))
+                    {
+                        $local:Value = $local:Line.Substring(5)
+                        if ($local:Value.StartsWith(" "))
+                        {
+                            $local:Value = $local:Value.Substring(1)
+                        }
+                        if ($local:DataBuffer.Length -gt 0)
+                        {
+                            $local:DataBuffer += "`n"
+                        }
+                        $local:DataBuffer += $local:Value
+                    }
+                    elseif ($local:Line -eq "" -and $local:DataBuffer.Length -gt 0)
+                    {
+                        # SSE event boundary -- process accumulated data
+                        $local:Frames = $local:DataBuffer.Split($local:RecordSep)
+                        $local:DataBuffer = ""
+
+                        foreach ($local:Frame in $local:Frames)
+                        {
+                            $local:Frame = $local:Frame.Trim()
+                            if ($local:Frame.Length -eq 0) { continue }
+
+                            try
+                            {
+                                $local:Msg = ConvertFrom-Json $local:Frame
+                            }
+                            catch
+                            {
+                                Write-Verbose "Failed to parse SignalR frame: $local:Frame"
+                                continue
+                            }
+
+                            # SignalR message types: 1=Invocation, 6=Ping, 7=Close
+                            if ($local:Msg.type -eq 6)
+                            {
+                                Write-Verbose "Received SignalR ping"
+                                continue
+                            }
+                            elseif ($local:Msg.type -eq 7)
+                            {
+                                Write-Verbose "Received SignalR close frame"
+                                $local:CloseReceived = $true
+                                break
+                            }
+                            elseif ($local:Msg.type -eq 1 -and $local:Msg.target -eq "NotifyEventAsync")
+                            {
+                                $local:EventData = $local:Msg.arguments[0]
+                                $local:EvName = $local:EventData.Name
+                                $local:EvBody = $local:EventData
+
+                                # Apply event name filter
+                                if ($local:EventFilter -and -not $local:EventFilter.ContainsKey($local:EvName))
+                                {
+                                    Write-Verbose "Skipping filtered event: $local:EvName"
+                                    continue
+                                }
+
+                                Write-Verbose "Event received: $local:EvName"
+
+                                if ($Handler)
+                                {
+                                    try
+                                    {
+                                        & $Handler $local:EvName $local:EvBody
+                                    }
+                                    catch
+                                    {
+                                        Write-Warning "Event handler error for '$($local:EvName)': $_"
+                                    }
+                                }
+                                elseif ($HandlerScript)
+                                {
+                                    try
+                                    {
+                                        & $HandlerScript $local:EvName $local:EvBody
+                                    }
+                                    catch
+                                    {
+                                        Write-Warning "Handler script error for '$($local:EvName)': $_"
+                                    }
+                                }
+                                else
+                                {
+                                    New-Object PSObject -Property @{
+                                        EventName = $local:EvName
+                                        EventBody = $local:EvBody
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                # Determine if this is a fatal (4xx) or transient error
+                $local:IsFatal = $false
+                if ($_.Exception -is [System.Net.WebException])
+                {
+                    $local:WebEx = $_.Exception
+                    if ($local:WebEx.Response)
+                    {
+                        $local:StatusCode = [int]$local:WebEx.Response.StatusCode
+                        if ($local:StatusCode -ge 400 -and $local:StatusCode -lt 500)
+                        {
+                            $local:IsFatal = $true
+                        }
+                    }
+                }
+                if ($local:IsFatal)
+                {
+                    throw
+                }
+
+                Write-Warning "Connection error: $($_.Exception.Message)"
+            }
+
+            # Clean up before reconnect
+            if ($local:Reader) { try { $local:Reader.Dispose() } catch {} $local:Reader = $null }
+            if ($local:Stream) { try { $local:Stream.Dispose() } catch {} $local:Stream = $null }
+            if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
+
+            Write-Verbose "Reconnecting in $local:BackoffSeconds seconds..."
+            Start-Sleep -Seconds $local:BackoffSeconds
+            $local:BackoffSeconds = [Math]::Min($local:BackoffSeconds * 2, 60)
+
+            # Try to refresh token for session-based user mode connections
+            if (-not $local:IsA2a -and $SafeguardSession -and `
+                -not $PSBoundParameters.ContainsKey("AccessToken"))
+            {
+                try
+                {
+                    Write-Verbose "Attempting token refresh before reconnect..."
+                    Update-SafeguardAccessToken
+                    $AccessToken = $SafeguardSession["AccessToken"]
+                }
+                catch
+                {
+                    Write-Warning "Token refresh failed: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+    finally
+    {
+        if ($local:Reader) { try { $local:Reader.Dispose() } catch {} }
+        if ($local:Stream) { try { $local:Stream.Dispose() } catch {} }
+        if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} }
+        if ($Insecure)
+        {
+            Enable-SslVerification
+            if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+        }
+        Write-Verbose "Event listener stopped."
+    }
+}

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1545,6 +1545,19 @@ function Wait-SafeguardEvent
                         }
                     }
                 }
+                # PS 7+: HttpClient throws HttpRequestException, not WebException
+                elseif ($_.Exception.GetType().FullName -eq "System.Net.Http.HttpRequestException")
+                {
+                    $local:HrStatusCode = $_.Exception.StatusCode
+                    if ($null -ne $local:HrStatusCode)
+                    {
+                        $local:StatusInt = [int]$local:HrStatusCode
+                        if ($local:StatusInt -ge 400 -and $local:StatusInt -lt 500)
+                        {
+                            $local:IsFatal = $true
+                        }
+                    }
+                }
                 if ($local:IsFatal)
                 {
                     throw

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -1213,7 +1213,7 @@ The cmdlet blocks until interrupted with Ctrl+C. Events can be processed by a
 script block (-Handler), an external script (-HandlerScript), or emitted to the
 output pipeline as PSCustomObjects when no handler is specified.
 
-Supports both user mode (Bearer token) and A2A mode (certificate + API key).
+For A2A event listening, use Wait-SafeguardA2aEvent instead.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -1223,19 +1223,6 @@ A string containing the bearer token to be used with Safeguard Web API.
 
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate.
-
-.PARAMETER ApiKey
-A string containing the A2A API key for authorization.
-
-.PARAMETER CertificateFile
-Path to a PFX certificate file for A2A authentication.
-
-.PARAMETER Password
-A SecureString containing the password for the PFX certificate file.
-
-.PARAMETER Thumbprint
-A string containing the thumbprint of a certificate in the user certificate store
-for A2A authentication.
 
 .PARAMETER Event
 An array of event names to filter for. If omitted, all events are delivered.
@@ -1269,38 +1256,17 @@ Listen for specific events only.
 Wait-SafeguardEvent -Insecure -Handler { param($EventName, $EventBody) Write-Host "Got $EventName" }
 
 Process events with an inline script block.
-
-.EXAMPLE
-Wait-SafeguardEvent -Appliance 10.5.32.54 -ApiKey $key -CertificateFile C:\cert.pfx -Password $pwd -Insecure
-
-Listen for A2A events using certificate file authentication.
-
-.EXAMPLE
-Wait-SafeguardEvent -Appliance 10.5.32.54 -ApiKey $key -Thumbprint $tp -Insecure
-
-Listen for A2A events using certificate thumbprint.
 #>
 function Wait-SafeguardEvent
 {
-    [CmdletBinding(DefaultParameterSetName="UserMode")]
+    [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$false,ParameterSetName="UserMode")]
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
+        [Parameter(Mandatory=$false)]
         [string]$Appliance,
-        [Parameter(Mandatory=$false,ParameterSetName="UserMode")]
+        [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
-        [string]$ApiKey,
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithFile")]
-        [string]$CertificateFile,
-        [Parameter(Mandatory=$false,ParameterSetName="A2AWithFile")]
-        [SecureString]$Password,
-        [Parameter(Mandatory=$true,ParameterSetName="A2AWithThumbprint")]
-        [string]$Thumbprint,
         [Parameter(Mandatory=$false)]
         [string[]]$Event,
         [Parameter(Mandatory=$false)]
@@ -1322,56 +1288,28 @@ function Wait-SafeguardEvent
     }
 
     Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
-    Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
     Import-Module -Name "$PSScriptRoot\signalr-utilities.psm1" -Scope Local
 
-    # Determine if this is A2A mode
-    $local:IsA2a = ($PSCmdlet.ParameterSetName -eq "A2AWithFile" -or `
-                    $PSCmdlet.ParameterSetName -eq "A2AWithThumbprint")
-
-    # Resolve session state for user mode
-    if (-not $local:IsA2a)
+    # Resolve session state
+    if (-not $Appliance -and $SafeguardSession)
     {
-        if (-not $Appliance -and $SafeguardSession)
-        {
-            $Appliance = $SafeguardSession["Appliance"]
-        }
-        if (-not $AccessToken -and $SafeguardSession)
-        {
-            $AccessToken = $SafeguardSession["AccessToken"]
-        }
-        if (-not $PSBoundParameters.ContainsKey("Insecure") -and $SafeguardSession)
-        {
-            $Insecure = $SafeguardSession["Insecure"]
-        }
-        if (-not $Appliance)
-        {
-            $Appliance = (Read-Host "Appliance")
-        }
-        if (-not $AccessToken)
-        {
-            throw "AccessToken required. Use Connect-Safeguard first or pass -AccessToken."
-        }
+        $Appliance = $SafeguardSession["Appliance"]
     }
-
-    # Resolve certificate for A2A mode
-    $local:Cert = $null
-    if ($PSCmdlet.ParameterSetName -eq "A2AWithFile")
+    if (-not $AccessToken -and $SafeguardSession)
     {
-        $local:Cert = (Use-CertificateFile $CertificateFile $Password)
+        $AccessToken = $SafeguardSession["AccessToken"]
     }
-    elseif ($PSCmdlet.ParameterSetName -eq "A2AWithThumbprint")
+    if (-not $PSBoundParameters.ContainsKey("Insecure") -and $SafeguardSession)
     {
-        $local:Store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My", "CurrentUser")
-        $local:Store.Open("ReadOnly")
-        $local:Certs = $local:Store.Certificates.Find(
-            [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint, $Thumbprint, $false)
-        $local:Store.Close()
-        if ($local:Certs.Count -eq 0)
-        {
-            throw "Certificate with thumbprint '$Thumbprint' not found in CurrentUser\My store"
-        }
-        $local:Cert = $local:Certs[0]
+        $Insecure = $SafeguardSession["Insecure"]
+    }
+    if (-not $Appliance)
+    {
+        $Appliance = (Read-Host "Appliance")
+    }
+    if (-not $AccessToken)
+    {
+        throw "AccessToken required. Use Connect-Safeguard first or pass -AccessToken."
     }
 
     # Build event filter lookup for fast matching
@@ -1412,19 +1350,8 @@ function Wait-SafeguardEvent
                 if ($local:WebResponse) { try { $local:WebResponse.Close() } catch {} $local:WebResponse = $null }
 
                 # Step 1: Negotiate -- get a fresh connectionToken
-                $local:NegotiateArgs = @{ Appliance = $Appliance }
-                if ($local:IsA2a)
-                {
-                    $local:NegotiateArgs["ApiKey"] = $ApiKey
-                    if ($local:Cert) { $local:NegotiateArgs["Certificate"] = $local:Cert }
-                    elseif ($Thumbprint) { $local:NegotiateArgs["Thumbprint"] = $Thumbprint }
-                }
-                else
-                {
-                    $local:NegotiateArgs["AccessToken"] = $AccessToken
-                }
-
-                $local:ConnectionToken = Get-SignalRConnectionToken @local:NegotiateArgs
+                $local:ConnectionToken = Get-SignalRConnectionToken -Appliance $Appliance `
+                    -AccessToken $AccessToken
 
                 # Step 2: Open SSE GET stream
                 $local:EncodedToken = [System.Uri]::EscapeDataString($local:ConnectionToken)
@@ -1437,19 +1364,7 @@ function Wait-SafeguardEvent
                 $local:Request.KeepAlive = $true
                 $local:Request.Timeout = [System.Threading.Timeout]::Infinite
                 $local:Request.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
-
-                if ($local:IsA2a)
-                {
-                    $local:Request.Headers.Add("Authorization", "A2A $ApiKey")
-                    if ($local:Cert)
-                    {
-                        $local:Request.ClientCertificates.Add($local:Cert) | Out-Null
-                    }
-                }
-                else
-                {
-                    $local:Request.Headers.Add("Authorization", "Bearer $AccessToken")
-                }
+                $local:Request.Headers.Add("Authorization", "Bearer $AccessToken")
 
                 # On PS 7 (.NET Core), ServicePointManager callback does not apply to
                 # HttpWebRequest. Use the per-request callback for SSL bypass.
@@ -1465,22 +1380,8 @@ function Wait-SafeguardEvent
                 $local:Reader = New-Object System.IO.StreamReader($local:Stream)
 
                 # Step 3: Send handshake via POST (after SSE stream is open)
-                $local:HandshakeArgs = @{
-                    Appliance = $Appliance
-                    ConnectionToken = $local:ConnectionToken
-                }
-                if ($local:IsA2a)
-                {
-                    $local:HandshakeArgs["ApiKey"] = $ApiKey
-                    if ($local:Cert) { $local:HandshakeArgs["Certificate"] = $local:Cert }
-                    elseif ($Thumbprint) { $local:HandshakeArgs["Thumbprint"] = $Thumbprint }
-                }
-                else
-                {
-                    $local:HandshakeArgs["AccessToken"] = $AccessToken
-                }
-
-                Send-SignalRHandshake @local:HandshakeArgs
+                Send-SignalRHandshake -Appliance $Appliance `
+                    -ConnectionToken $local:ConnectionToken -AccessToken $AccessToken
 
                 # Step 4: Read and verify handshake response from SSE stream
                 $local:HandshakeData = ""
@@ -1677,9 +1578,8 @@ function Wait-SafeguardEvent
             Start-Sleep -Seconds $local:BackoffSeconds
             $local:BackoffSeconds = [Math]::Min($local:BackoffSeconds * 2, 60)
 
-            # Try to refresh token for session-based user mode connections
-            if (-not $local:IsA2a -and $SafeguardSession -and `
-                -not $PSBoundParameters.ContainsKey("AccessToken"))
+            # Try to refresh token for session-based connections
+            if ($SafeguardSession -and -not $PSBoundParameters.ContainsKey("AccessToken"))
             {
                 try
                 {

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -247,6 +247,7 @@ FunctionsToExport = @(
     'Get-SafeguardEvent','Get-SafeguardEventCategory','Get-SafeguardEventName','Get-SafeguardEventProperty','Find-SafeguardEvent',
     'Get-SafeguardEventSubscription', 'Find-SafeguardEventSubscription',
     'New-SafeguardEventSubscription', 'Remove-SafeguardEventSubscription', 'Edit-SafeguardEventSubscription',
+    'Wait-SafeguardEvent',
     # clustering.psm1
     'Get-SafeguardClusterMember','Get-SafeguardClusterHealth','Get-SafeguardClusterOperationStatus',
     'Add-SafeguardClusterMember','Remove-SafeguardClusterMember','Get-SafeguardClusterPrimary','Set-SafeguardClusterPrimary',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -270,6 +270,7 @@ FunctionsToExport = @(
     # a2acallers.psm1
     'Get-SafeguardA2aRetrievableAccount','Get-SafeguardA2aPassword','Get-SafeguardA2aPrivateKey','Get-SafeguardA2aApiKeySecret',
     'New-SafeguardA2aAccessRequest','Set-SafeguardA2aPassword','Set-SafeguardA2aPrivateKey',
+    'Wait-SafeguardA2aEvent','Invoke-SafeguardA2aPasswordHandler','Invoke-SafeguardA2aSshKeyHandler',
     # starling.psm1
     'Get-SafeguardStarlingSubscription','New-SafeguardStarlingSubscription','Remove-SafeguardStarlingSubscription',
     'Get-SafeguardStarlingJoinUrl','Invoke-SafeguardStarlingJoin','Invoke-SafeguardStarlingJoinBrowser',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -69,6 +69,7 @@ NestedModules = @(
     'sslhandling.psm1',
     'ps-utilities.psm1',
     'sg-utilities.psm1',
+    'signalr-utilities.psm1',
     'datatypes.psm1',
     'licensing.psm1',
     'certificates.psm1',

--- a/src/signalr-utilities.psm1
+++ b/src/signalr-utilities.psm1
@@ -9,6 +9,8 @@ function Get-SignalRConnectionToken
         [Parameter(Mandatory=$true)]
         [string]$Appliance,
         [Parameter(Mandatory=$false)]
+        [string]$ServicePath = "event",
+        [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [string]$ApiKey,
@@ -21,7 +23,7 @@ function Get-SignalRConnectionToken
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Url = "https://$Appliance/service/event/signalr/negotiate?negotiateVersion=1"
+    $local:Url = "https://$Appliance/service/$ServicePath/signalr/negotiate?negotiateVersion=1"
     $local:Headers = @{
         "Accept" = "application/json";
         "Content-type" = "application/json"
@@ -100,6 +102,8 @@ function Send-SignalRHandshake
         [Parameter(Mandatory=$true)]
         [string]$ConnectionToken,
         [Parameter(Mandatory=$false)]
+        [string]$ServicePath = "event",
+        [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
         [string]$ApiKey,
@@ -113,7 +117,7 @@ function Send-SignalRHandshake
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
     $local:EncodedToken = [System.Uri]::EscapeDataString($ConnectionToken)
-    $local:Url = "https://$Appliance/service/event/signalr?id=$local:EncodedToken"
+    $local:Url = "https://$Appliance/service/$ServicePath/signalr?id=$local:EncodedToken"
     $local:HandshakePayload = '{"protocol":"json","version":1}' + [char]0x1E
     $local:BodyBytes = [System.Text.Encoding]::UTF8.GetBytes($local:HandshakePayload)
 

--- a/src/signalr-utilities.psm1
+++ b/src/signalr-utilities.psm1
@@ -1,0 +1,161 @@
+<# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
+# SignalR SSE helpers for event listening
+# Nothing is exported from here -- imported with -Scope Local by consumers
+
+function Get-SignalRConnectionToken
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$false)]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [Parameter(Mandatory=$false)]
+        [string]$Thumbprint
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Url = "https://$Appliance/service/event/signalr/negotiate?negotiateVersion=1"
+    $local:Headers = @{
+        "Accept" = "application/json";
+        "Content-type" = "application/json"
+    }
+
+    if ($AccessToken)
+    {
+        $local:Headers["Authorization"] = "Bearer $AccessToken"
+    }
+    elseif ($ApiKey)
+    {
+        $local:Headers["Authorization"] = "A2A $ApiKey"
+    }
+
+    Write-Verbose "Negotiating SignalR connection at $local:Url"
+
+    try
+    {
+        if ($Certificate)
+        {
+            $local:Response = Invoke-RestMethod -Certificate $Certificate -Method POST `
+                -Headers $local:Headers -Uri $local:Url
+        }
+        elseif ($Thumbprint)
+        {
+            $local:Response = Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method POST `
+                -Headers $local:Headers -Uri $local:Url
+        }
+        else
+        {
+            $local:Response = Invoke-RestMethod -Method POST -Headers $local:Headers -Uri $local:Url
+        }
+    }
+    catch
+    {
+        Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+        Out-SafeguardExceptionIfPossible $_
+    }
+
+    if (-not $local:Response.connectionToken)
+    {
+        throw "SignalR negotiate failed -- no connectionToken in response"
+    }
+
+    # Verify SSE transport is available
+    $local:HasSse = $false
+    foreach ($local:Transport in $local:Response.availableTransports)
+    {
+        if ($local:Transport.transport -eq "ServerSentEvents")
+        {
+            $local:HasSse = $true
+            break
+        }
+    }
+    if (-not $local:HasSse)
+    {
+        throw "SignalR server does not support ServerSentEvents transport"
+    }
+
+    $local:TokenPreview = $local:Response.connectionToken
+    if ($local:TokenPreview.Length -gt 8)
+    {
+        $local:TokenPreview = $local:TokenPreview.Substring(0, 8) + "..."
+    }
+    Write-Verbose "Obtained connectionToken: $local:TokenPreview"
+
+    $local:Response.connectionToken
+}
+
+function Send-SignalRHandshake
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$true)]
+        [string]$ConnectionToken,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [string]$ApiKey,
+        [Parameter(Mandatory=$false)]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
+        [Parameter(Mandatory=$false)]
+        [string]$Thumbprint
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:EncodedToken = [System.Uri]::EscapeDataString($ConnectionToken)
+    $local:Url = "https://$Appliance/service/event/signalr?id=$local:EncodedToken"
+    $local:HandshakePayload = '{"protocol":"json","version":1}' + [char]0x1E
+    $local:BodyBytes = [System.Text.Encoding]::UTF8.GetBytes($local:HandshakePayload)
+
+    $local:Headers = @{
+        "Accept" = "application/json";
+        "Content-type" = "application/json"
+    }
+
+    if ($AccessToken)
+    {
+        $local:Headers["Authorization"] = "Bearer $AccessToken"
+    }
+    elseif ($ApiKey)
+    {
+        $local:Headers["Authorization"] = "A2A $ApiKey"
+    }
+
+    Write-Verbose "Sending SignalR handshake to $local:Url"
+
+    try
+    {
+        if ($Certificate)
+        {
+            Invoke-RestMethod -Certificate $Certificate -Method POST `
+                -Headers $local:Headers -Uri $local:Url -Body $local:BodyBytes | Out-Null
+        }
+        elseif ($Thumbprint)
+        {
+            Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method POST `
+                -Headers $local:Headers -Uri $local:Url -Body $local:BodyBytes | Out-Null
+        }
+        else
+        {
+            Invoke-RestMethod -Method POST -Headers $local:Headers -Uri $local:Url `
+                -Body $local:BodyBytes | Out-Null
+        }
+    }
+    catch
+    {
+        Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+        Out-SafeguardExceptionIfPossible $_
+    }
+
+    Write-Verbose "SignalR handshake sent successfully"
+}

--- a/src/signalr-utilities.psm1
+++ b/src/signalr-utilities.psm1
@@ -1,6 +1,6 @@
 <# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
 # SignalR SSE helpers for event listening
-# Nothing is exported from here -- imported with -Scope Local by consumers
+# Not exported -- loaded via NestedModules and imported with -Scope Local by consumers
 
 function Get-SignalRConnectionToken
 {
@@ -276,4 +276,236 @@ function Open-SignalRSseStream
             Disposables = @($local:Reader, $local:Stream, $local:WebResponse)
         }
     }
+}
+
+function Read-SignalRSseDataBlock
+{
+    # Reads one SSE data block from a StreamReader. Accumulates "data:" lines until
+    # a blank line boundary. Skips SSE comments (lines starting with ":").
+    # Returns the accumulated data string, or $null if the stream ended.
+    [CmdletBinding()]
+    [OutputType([string])]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [System.IO.StreamReader]$Reader
+    )
+
+    $local:Buffer = ""
+    while ($true)
+    {
+        $local:Line = $Reader.ReadLine()
+        if ($null -eq $local:Line)
+        {
+            if ($local:Buffer.Length -gt 0)
+            {
+                return $local:Buffer
+            }
+            return $null
+        }
+        if ($local:Line.StartsWith(":"))
+        {
+            continue
+        }
+        elseif ($local:Line.StartsWith("data:"))
+        {
+            $local:Value = $local:Line.Substring(5)
+            if ($local:Value.StartsWith(" "))
+            {
+                $local:Value = $local:Value.Substring(1)
+            }
+            if ($local:Buffer.Length -gt 0)
+            {
+                $local:Buffer += "`n"
+            }
+            $local:Buffer += $local:Value
+        }
+        elseif ($local:Line -eq "" -and $local:Buffer.Length -gt 0)
+        {
+            return $local:Buffer
+        }
+    }
+}
+
+function Read-SignalRHandshakeResponse
+{
+    # Reads and validates the SignalR handshake response from an SSE stream.
+    # Throws on handshake error or if the stream closes before handshake completes.
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [System.IO.StreamReader]$Reader
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:RecordSep = [char]0x1E
+    $local:HandshakeData = Read-SignalRSseDataBlock -Reader $Reader
+
+    if ($null -eq $local:HandshakeData)
+    {
+        throw "SSE stream closed before handshake completed"
+    }
+
+    $local:HsFrames = $local:HandshakeData.Split($local:RecordSep)
+    foreach ($local:HsFrame in $local:HsFrames)
+    {
+        $local:HsFrame = $local:HsFrame.Trim()
+        if ($local:HsFrame.Length -eq 0) { continue }
+        $local:HsParsed = ConvertFrom-Json $local:HsFrame
+        if ($local:HsParsed.error)
+        {
+            throw "SignalR handshake error: $($local:HsParsed.error)"
+        }
+    }
+
+    Write-Verbose "SignalR handshake complete"
+}
+
+function Read-SignalREvents
+{
+    # Reads SignalR event frames from an SSE stream and dispatches them.
+    # When no Handler or HandlerScript is specified, emits PSCustomObjects to the pipeline.
+    # Returns when the stream ends or a SignalR close frame is received.
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [System.IO.StreamReader]$Reader,
+        [Parameter(Mandatory=$false)]
+        [hashtable]$EventFilter,
+        [Parameter(Mandatory=$false)]
+        [ScriptBlock]$Handler,
+        [Parameter(Mandatory=$false)]
+        [string]$HandlerScript
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:RecordSep = [char]0x1E
+
+    while ($true)
+    {
+        $local:DataBlock = Read-SignalRSseDataBlock -Reader $Reader
+        if ($null -eq $local:DataBlock)
+        {
+            Write-Verbose "SSE stream ended (server closed connection)"
+            return
+        }
+
+        $local:Frames = $local:DataBlock.Split($local:RecordSep)
+
+        foreach ($local:Frame in $local:Frames)
+        {
+            $local:Frame = $local:Frame.Trim()
+            if ($local:Frame.Length -eq 0) { continue }
+
+            try
+            {
+                $local:Msg = ConvertFrom-Json $local:Frame
+            }
+            catch
+            {
+                Write-Verbose "Failed to parse SignalR frame: $local:Frame"
+                continue
+            }
+
+            # SignalR message types: 1=Invocation, 6=Ping, 7=Close
+            if ($local:Msg.type -eq 6)
+            {
+                Write-Verbose "Received SignalR ping"
+                continue
+            }
+            elseif ($local:Msg.type -eq 7)
+            {
+                Write-Verbose "Received SignalR close frame"
+                return
+            }
+            elseif ($local:Msg.type -eq 1 -and $local:Msg.target -eq "NotifyEventAsync")
+            {
+                $local:EventData = $local:Msg.arguments[0]
+                $local:EvName = $local:EventData.Name
+                $local:EvBody = $local:EventData
+
+                # Apply event name filter
+                if ($EventFilter -and -not $EventFilter.ContainsKey($local:EvName))
+                {
+                    Write-Verbose "Skipping filtered event: $local:EvName"
+                    continue
+                }
+
+                Write-Verbose "Event received: $local:EvName"
+
+                if ($Handler)
+                {
+                    try
+                    {
+                        & $Handler $local:EvName $local:EvBody
+                    }
+                    catch
+                    {
+                        Write-Warning "Event handler error for '$($local:EvName)': $_"
+                    }
+                }
+                elseif ($HandlerScript)
+                {
+                    try
+                    {
+                        & $HandlerScript $local:EvName $local:EvBody
+                    }
+                    catch
+                    {
+                        Write-Warning "Handler script error for '$($local:EvName)': $_"
+                    }
+                }
+                else
+                {
+                    New-Object PSObject -Property @{
+                        EventName = $local:EvName
+                        EventBody = $local:EvBody
+                    }
+                }
+            }
+        }
+    }
+}
+
+function Test-SignalRFatalError
+{
+    # Returns $true if the exception represents a fatal (4xx) HTTP error that
+    # should not be retried. Handles both WebException (PS 5.1) and
+    # HttpRequestException (PS 7+).
+    [CmdletBinding()]
+    [OutputType([bool])]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [System.Management.Automation.ErrorRecord]$ErrorRecord
+    )
+
+    if ($ErrorRecord.Exception -is [System.Net.WebException])
+    {
+        $local:WebEx = $ErrorRecord.Exception
+        if ($local:WebEx.Response)
+        {
+            $local:StatusCode = [int]$local:WebEx.Response.StatusCode
+            if ($local:StatusCode -ge 400 -and $local:StatusCode -lt 500)
+            {
+                return $true
+            }
+        }
+    }
+    elseif ($ErrorRecord.Exception.GetType().FullName -eq "System.Net.Http.HttpRequestException")
+    {
+        $local:HrStatusCode = $ErrorRecord.Exception.StatusCode
+        if ($null -ne $local:HrStatusCode)
+        {
+            $local:StatusInt = [int]$local:HrStatusCode
+            if ($local:StatusInt -ge 400 -and $local:StatusInt -lt 500)
+            {
+                return $true
+            }
+        }
+    }
+
+    return $false
 }

--- a/src/signalr-utilities.psm1
+++ b/src/signalr-utilities.psm1
@@ -17,11 +17,23 @@ function Get-SignalRConnectionToken
         [Parameter(Mandatory=$false)]
         [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
         [Parameter(Mandatory=$false)]
-        [string]$Thumbprint
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    # $PSDefaultParameterValues is module-scoped on PS 7 -- the caller's SSL bypass
+    # does not propagate into this module. Clone the global values so that
+    # Invoke-RestMethod sees -SkipCertificateCheck when -Insecure is set.
+    if ($Insecure)
+    {
+        Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
+        Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+    }
 
     $local:Url = "https://$Appliance/service/$ServicePath/signalr/negotiate?negotiateVersion=1"
     $local:Headers = @{
@@ -110,11 +122,21 @@ function Send-SignalRHandshake
         [Parameter(Mandatory=$false)]
         [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate,
         [Parameter(Mandatory=$false)]
-        [string]$Thumbprint
+        [string]$Thumbprint,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    # $PSDefaultParameterValues is module-scoped on PS 7 -- clone from global
+    if ($Insecure)
+    {
+        Import-Module -Name "$PSScriptRoot\sslhandling.psm1" -Scope Local
+        Disable-SslVerification
+        if ($global:PSDefaultParameterValues) { $PSDefaultParameterValues = $global:PSDefaultParameterValues.Clone() }
+    }
 
     $local:EncodedToken = [System.Uri]::EscapeDataString($ConnectionToken)
     $local:Url = "https://$Appliance/service/$ServicePath/signalr?id=$local:EncodedToken"
@@ -162,4 +184,96 @@ function Send-SignalRHandshake
     }
 
     Write-Verbose "SignalR handshake sent successfully"
+}
+
+function Open-SignalRSseStream
+{
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [string]$Url,
+        [Parameter(Mandatory=$false)]
+        [hashtable]$Headers,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Write-Verbose "Opening SSE stream: $Url"
+
+    if ($PSVersionTable.PSEdition -eq "Core")
+    {
+        # PS 7+: HttpWebRequest SSL callback is broken on .NET 10+.
+        # Use HttpClient with DangerousAcceptAnyServerCertificateValidator.
+        $local:Handler = New-Object System.Net.Http.HttpClientHandler
+        if ($Insecure)
+        {
+            $local:Handler.ServerCertificateCustomValidationCallback = `
+                [System.Net.Http.HttpClientHandler]::DangerousAcceptAnyServerCertificateValidator
+        }
+        if ($Certificate)
+        {
+            $local:Handler.ClientCertificates.Add($Certificate) | Out-Null
+        }
+
+        $local:Client = New-Object System.Net.Http.HttpClient($local:Handler)
+        $local:Client.Timeout = [System.Threading.Timeout]::InfiniteTimeSpan
+
+        $local:Request = New-Object System.Net.Http.HttpRequestMessage(
+            [System.Net.Http.HttpMethod]::Get, $Url)
+        $local:Request.Headers.TryAddWithoutValidation("Accept", "text/event-stream") | Out-Null
+        if ($Headers)
+        {
+            foreach ($local:Key in $Headers.Keys)
+            {
+                $local:Request.Headers.TryAddWithoutValidation($local:Key, $Headers[$local:Key]) | Out-Null
+            }
+        }
+
+        $local:Response = $local:Client.SendAsync($local:Request,
+            [System.Net.Http.HttpCompletionOption]::ResponseHeadersRead).GetAwaiter().GetResult()
+        $local:Response.EnsureSuccessStatusCode() | Out-Null
+        $local:Stream = $local:Response.Content.ReadAsStreamAsync().GetAwaiter().GetResult()
+        $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+
+        @{
+            Reader = $local:Reader
+            Disposables = @($local:Reader, $local:Stream, $local:Response, $local:Request, $local:Client, $local:Handler)
+        }
+    }
+    else
+    {
+        # PS 5.1: HttpWebRequest with ServicePointManager callback (set by Disable-SslVerification)
+        $local:WR = [System.Net.HttpWebRequest]::Create($Url)
+        $local:WR.Method = "GET"
+        $local:WR.Accept = "text/event-stream"
+        $local:WR.KeepAlive = $true
+        $local:WR.Timeout = [System.Threading.Timeout]::Infinite
+        $local:WR.ReadWriteTimeout = [System.Threading.Timeout]::Infinite
+        if ($Headers)
+        {
+            foreach ($local:Key in $Headers.Keys)
+            {
+                $local:WR.Headers.Add($local:Key, $Headers[$local:Key])
+            }
+        }
+        if ($Certificate)
+        {
+            $local:WR.ClientCertificates.Add($Certificate) | Out-Null
+        }
+
+        $local:WebResponse = $local:WR.GetResponse()
+        $local:Stream = $local:WebResponse.GetResponseStream()
+        $local:Reader = New-Object System.IO.StreamReader($local:Stream)
+
+        @{
+            Reader = $local:Reader
+            Disposables = @($local:Reader, $local:Stream, $local:WebResponse)
+        }
+    }
 }

--- a/test/Suites/Suite-A2AEventListener.ps1
+++ b/test/Suites/Suite-A2AEventListener.ps1
@@ -1,0 +1,404 @@
+@{
+    Name        = "A2A Event Listener"
+    Description = "Tests Wait-SafeguardA2aEvent, Invoke-SafeguardA2aPasswordHandler, and Invoke-SafeguardA2aSshKeyHandler"
+    Tags        = @("a2a", "signalr", "listener", "certificate")
+
+    Setup = {
+        param($Context)
+
+        $prefix = $Context.TestPrefix
+        $certUser = "${prefix}_A2aEvtCertUser"
+        $testAsset = "${prefix}_A2aEvtAsset"
+        $testAccount = "${prefix}_A2aEvtAcct"
+        $testA2a = "${prefix}_A2aEvtReg"
+        $initialPassword = "A2aEvtInitPwd_3xRz!"
+
+        # Locate test certificate files
+        $certDir = Join-Path $Context.TestRoot "TestData\CERTS"
+        if (-not (Test-Path $certDir)) {
+            throw "Test certificate directory not found: $certDir"
+        }
+        $Context.SuiteData["UserPfx"] = Join-Path $certDir "UserCert.pfx"
+        $Context.SuiteData["RootCaPem"] = Join-Path $certDir "RootCA.pem"
+        $Context.SuiteData["IntCaPem"] = Join-Path $certDir "IntermediateCA.pem"
+        $Context.SuiteData["PfxPasswordPlain"] = "a"
+
+        # Compute thumbprints for cleanup
+        $rootCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+            $Context.SuiteData["RootCaPem"])
+        $Context.SuiteData["RootThumbprint"] = $rootCert.Thumbprint
+
+        $intCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+            $Context.SuiteData["IntCaPem"])
+        $Context.SuiteData["IntThumbprint"] = $intCert.Thumbprint
+
+        $userCert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
+            $Context.SuiteData["UserPfx"],
+            $Context.SuiteData["PfxPasswordPlain"])
+        $Context.SuiteData["UserThumbprint"] = $userCert.Thumbprint
+
+        # Pre-cleanup: remove stale objects (reverse dependency order)
+        Remove-SgPsStaleTestObject -Collection "A2ARegistrations" -Name $testA2a
+        Remove-SgPsStaleTestObject -Collection "AssetAccounts" -Name $testAccount
+        Remove-SgPsStaleTestObject -Collection "Assets" -Name $testAsset
+        Remove-SgPsStaleTestObject -Collection "Users" -Name $certUser
+        try { Uninstall-SafeguardTrustedCertificate -Insecure $Context.SuiteData["IntThumbprint"] } catch {}
+        try { Uninstall-SafeguardTrustedCertificate -Insecure $Context.SuiteData["RootThumbprint"] } catch {}
+
+        # 1. Install trusted cert chain
+        $null = Install-SafeguardTrustedCertificate -Insecure $Context.SuiteData["RootCaPem"]
+        Register-SgPsTestCleanup -Description "Uninstall RootCA" -Action {
+            param($Ctx)
+            try { Uninstall-SafeguardTrustedCertificate -Insecure $Ctx.SuiteData['RootThumbprint'] } catch {}
+        }
+
+        $null = Install-SafeguardTrustedCertificate -Insecure $Context.SuiteData["IntCaPem"]
+        Register-SgPsTestCleanup -Description "Uninstall IntermediateCA" -Action {
+            param($Ctx)
+            try { Uninstall-SafeguardTrustedCertificate -Insecure $Ctx.SuiteData['IntThumbprint'] } catch {}
+        }
+
+        # 2. Create certificate user
+        $cUser = Invoke-SafeguardMethod -Insecure Core POST "Users" -Body @{
+            PrimaryAuthenticationProvider = @{
+                Id = -2
+                Identity = $Context.SuiteData["UserThumbprint"]
+            }
+            Name = $certUser
+        }
+        $Context.SuiteData["CertUserId"] = $cUser.Id
+        Register-SgPsTestCleanup -Description "Delete certificate user" -Action {
+            param($Ctx)
+            try { Remove-SafeguardUser -Insecure $Ctx.SuiteData['CertUserId'] } catch {}
+        }
+
+        # 3. Create asset and account
+        $asset = New-SafeguardAsset -Insecure -DisplayName $testAsset `
+            -Platform 521 -NetworkAddress "10.0.9.100" `
+            -ServiceAccountCredentialType "None" -NoSshHostKeyDiscovery
+        $Context.SuiteData["AssetId"] = $asset.Id
+        $Context.SuiteData["TestAsset"] = $testAsset
+        Register-SgPsTestCleanup -Description "Delete A2A event asset" -Action {
+            param($Ctx)
+            try { Remove-SafeguardAsset -Insecure $Ctx.SuiteData['AssetId'] } catch {}
+        }
+
+        $account = New-SafeguardAssetAccount -Insecure -ParentAsset $asset.Id -NewAccountName $testAccount
+        $Context.SuiteData["AccountId"] = $account.Id
+        $Context.SuiteData["TestAccount"] = $testAccount
+        Register-SgPsTestCleanup -Description "Delete A2A event account" -Action {
+            param($Ctx)
+            try { Remove-SafeguardAssetAccount -Insecure $Ctx.SuiteData['AssetId'] $Ctx.SuiteData['AccountId'] } catch {}
+        }
+
+        # Set initial password
+        Set-SafeguardAssetAccountPassword -Insecure $testAsset $testAccount `
+            -NewPassword (ConvertTo-SecureString $initialPassword -AsPlainText -Force)
+        $Context.SuiteData["InitialPassword"] = $initialPassword
+
+        # Generate two RSA private keys for SSH key handler test
+        $rsa1 = [System.Security.Cryptography.RSA]::Create(2048)
+        $Context.SuiteData["SshKey1"] = $rsa1.ExportRSAPrivateKeyPem()
+        $rsa1.Dispose()
+        $rsa2 = [System.Security.Cryptography.RSA]::Create(2048)
+        $Context.SuiteData["SshKey2"] = $rsa2.ExportRSAPrivateKeyPem()
+        $rsa2.Dispose()
+
+        # Set initial SSH key on the account
+        Invoke-SafeguardMethod -Insecure Core PUT "AssetAccounts/$($account.Id)/SshKey" `
+            -Parameters @{ keyFormat = "OpenSsh" } `
+            -Body @{ Passphrase = ""; PrivateKey = $Context.SuiteData["SshKey1"] }
+
+        # 4. Create A2A registration with credential retrieval
+        $a2aReg = Invoke-SafeguardMethod -Insecure Core POST "A2ARegistrations" -Body @{
+            AppName = $testA2a
+            CertificateUserId = $cUser.Id
+            Description = "A2A event listener test"
+            VisibleToCertificateUsers = $true
+            BidirectionalEnabled = $true
+        }
+        $Context.SuiteData["A2aId"] = $a2aReg.Id
+        Register-SgPsTestCleanup -Description "Delete A2A registration" -Action {
+            param($Ctx)
+            try { Remove-SafeguardA2a -Insecure $Ctx.SuiteData['A2aId'] } catch {}
+        }
+
+        # 5. Add credential retrieval for the account
+        Add-SafeguardA2aCredentialRetrieval -Insecure $Context.SuiteData["A2aId"] `
+            -Asset $testAsset -Account $testAccount
+
+        # 6. Get the API key
+        $apiKey = Get-SafeguardA2aCredentialRetrievalApiKey -Insecure $Context.SuiteData["A2aId"] `
+            -Asset $testAsset -Account $testAccount
+        $Context.SuiteData["ApiKey"] = $apiKey
+
+        # 7. Enable A2A service
+        try {
+            Invoke-SafeguardMethod -Insecure Appliance POST "A2AService/Enable"
+        } catch {
+            # May already be enabled
+        }
+
+        # Store values for background jobs
+        $Context.SuiteData["ManifestPath"] = Join-Path $Context.ModuleRoot "safeguard-ps.psd1"
+        $Context.SuiteData["Appliance"] = $Context.Appliance
+
+        # Temp file paths
+        $tempDir = [System.IO.Path]::GetTempPath()
+        $Context.SuiteData["OutputFile"] = Join-Path $tempDir "${prefix}_a2aevt_output.txt"
+        $Context.SuiteData["SshKeyOutputFile"] = Join-Path $tempDir "${prefix}_a2aevt_sshkey_output.txt"
+
+        # Clean leftover temp files
+        if (Test-Path $Context.SuiteData["OutputFile"]) {
+            Remove-Item $Context.SuiteData["OutputFile"] -Force
+        }
+        if (Test-Path $Context.SuiteData["SshKeyOutputFile"]) {
+            Remove-Item $Context.SuiteData["SshKeyOutputFile"] -Force
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        $manifestPath = $Context.SuiteData["ManifestPath"]
+        $appliance = $Context.SuiteData["Appliance"]
+        $pfxPath = $Context.SuiteData["UserPfx"]
+        $pfxPasswordPlain = $Context.SuiteData["PfxPasswordPlain"]
+        $apiKey = $Context.SuiteData["ApiKey"]
+        $testAsset = $Context.SuiteData["TestAsset"]
+        $testAccount = $Context.SuiteData["TestAccount"]
+        $accountId = $Context.SuiteData["AccountId"]
+
+        # ----------------------------------------------------------------
+        # Helper: poll a job's verbose stream for a pattern
+        # ----------------------------------------------------------------
+        $waitForVerbose = {
+            param([System.Management.Automation.Job]$Job, [string]$Pattern, [int]$TimeoutSeconds = 45)
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+                if ($Job.State -eq 'Failed' -or $Job.State -eq 'Completed') {
+                    $jobErr = Receive-Job $Job -ErrorAction SilentlyContinue 2>&1
+                    throw "Listener job ended unexpectedly ($($Job.State)): $jobErr"
+                }
+                if ($Job.ChildJobs.Count -gt 0) {
+                    foreach ($msg in $Job.ChildJobs[0].Verbose) {
+                        if ($msg.Message -match $Pattern) {
+                            return $true
+                        }
+                    }
+                }
+                Start-Sleep -Milliseconds 500
+            }
+            return $false
+        }
+
+        # ================================================================
+        # Test 1: Wait-SafeguardA2aEvent captures events in pipeline mode
+        # ================================================================
+        Test-SgPsAssert "Wait-SafeguardA2aEvent captures password change event" {
+            $job = $null
+            try {
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    $secPwd = ConvertTo-SecureString $using:pfxPasswordPlain -AsPlainText -Force
+                    Wait-SafeguardA2aEvent -Appliance $using:appliance -Insecure `
+                        -CertificateFile $using:pfxPath -Password $secPwd `
+                        -ApiKey $using:apiKey
+                }
+
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "A2A listener did not connect within 45 seconds" }
+
+                # Trigger password change from main process
+                $newPwd = "A2aEvtChanged1_8kWp!"
+                Set-SafeguardAssetAccountPassword -Insecure $testAsset $testAccount `
+                    -NewPassword (ConvertTo-SecureString $newPwd -AsPlainText -Force)
+
+                # Poll for the correlated event
+                $found = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 20) {
+                    $output = @(Receive-Job $job -Keep -ErrorAction SilentlyContinue)
+                    foreach ($evt in $output) {
+                        if ($evt -is [PSCustomObject] -and
+                            $evt.EventName -eq "AssetAccountPasswordUpdated" -and
+                            ($evt.EventBody | ConvertTo-Json -Compress -Depth 10) -match [regex]::Escape("$accountId"))
+                        {
+                            $found = $true
+                            break
+                        }
+                    }
+                    if ($found) { break }
+                    Start-Sleep -Milliseconds 500
+                }
+                $found
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        # ================================================================
+        # Test 2: Invoke-SafeguardA2aPasswordHandler delivers passwords
+        # ================================================================
+        Test-SgPsAssert "Invoke-SafeguardA2aPasswordHandler delivers initial and changed password" {
+            $outputFile = $Context.SuiteData["OutputFile"]
+            $job = $null
+            try {
+                # Clean output file
+                if (Test-Path $outputFile) { Remove-Item $outputFile -Force }
+
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    $secPwd = ConvertTo-SecureString $using:pfxPasswordPlain -AsPlainText -Force
+                    $outPath = $using:outputFile
+                    $handler = {
+                        param($EventName, $Password)
+                        "$EventName=$Password" | Add-Content -Path $outPath -Encoding UTF8
+                    }.GetNewClosure()
+                    Invoke-SafeguardA2aPasswordHandler -Appliance $using:appliance -Insecure `
+                        -CertificateFile $using:pfxPath -Password $secPwd `
+                        -ApiKey $using:apiKey -Handler $handler
+                }
+
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "Password handler did not connect within 45 seconds" }
+
+                # Verify initial password was delivered
+                $initialFound = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 10) {
+                    if (Test-Path $outputFile) {
+                        $content = Get-Content $outputFile -Raw -ErrorAction SilentlyContinue
+                        if ($content -match "InitialPassword=") {
+                            $initialFound = $true
+                            break
+                        }
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+                if (-not $initialFound) { throw "Initial password not delivered to handler" }
+
+                # Trigger password change
+                $newPwd = "A2aEvtChanged2_5mNq!"
+                Set-SafeguardAssetAccountPassword -Insecure $testAsset $testAccount `
+                    -NewPassword (ConvertTo-SecureString $newPwd -AsPlainText -Force)
+
+                # Poll for the changed password
+                $changeFound = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 20) {
+                    if (Test-Path $outputFile) {
+                        $content = Get-Content $outputFile -Raw -ErrorAction SilentlyContinue
+                        if ($content -match "AssetAccountPasswordUpdated=$newPwd") {
+                            $changeFound = $true
+                            break
+                        }
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+                $changeFound
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        # ================================================================
+        # Test 3: Invoke-SafeguardA2aSshKeyHandler delivers SSH keys
+        # ================================================================
+        Test-SgPsAssert "Invoke-SafeguardA2aSshKeyHandler delivers initial and changed SSH key" {
+            $sshKeyOutputFile = $Context.SuiteData["SshKeyOutputFile"]
+            $sshKey2 = $Context.SuiteData["SshKey2"]
+            $job = $null
+            try {
+                # Clean output file
+                if (Test-Path $sshKeyOutputFile) { Remove-Item $sshKeyOutputFile -Force }
+
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    $secPwd = ConvertTo-SecureString $using:pfxPasswordPlain -AsPlainText -Force
+                    $outPath = $using:sshKeyOutputFile
+                    $handler = {
+                        param($EventName, $PrivateKey)
+                        $marker = "NOKEY"
+                        if ($PrivateKey -and $PrivateKey.Length -gt 100) {
+                            $marker = "HASKEY"
+                        }
+                        "$EventName=$marker" | Add-Content -Path $outPath -Encoding UTF8
+                    }.GetNewClosure()
+                    Invoke-SafeguardA2aSshKeyHandler -Appliance $using:appliance -Insecure `
+                        -CertificateFile $using:pfxPath -Password $secPwd `
+                        -ApiKey $using:apiKey -Handler $handler
+                }
+
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "SSH key handler did not connect within 45 seconds" }
+
+                # Verify initial SSH key was delivered
+                $initialFound = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 10) {
+                    if (Test-Path $sshKeyOutputFile) {
+                        $content = Get-Content $sshKeyOutputFile -Raw -ErrorAction SilentlyContinue
+                        if ($content -match "InitialSshKey=HASKEY") {
+                            $initialFound = $true
+                            break
+                        }
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+                if (-not $initialFound) { throw "Initial SSH key not delivered to handler" }
+
+                # Trigger SSH key change by setting a different key
+                Invoke-SafeguardMethod -Insecure Core PUT "AssetAccounts/$accountId/SshKey" `
+                    -Parameters @{ keyFormat = "OpenSsh" } `
+                    -Body @{ Passphrase = ""; PrivateKey = $sshKey2 }
+
+                # Poll for the changed SSH key delivery
+                $changeFound = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 20) {
+                    if (Test-Path $sshKeyOutputFile) {
+                        $content = Get-Content $sshKeyOutputFile -Raw -ErrorAction SilentlyContinue
+                        if ($content -match "AssetAccountSshKeyUpdated=HASKEY") {
+                            $changeFound = $true
+                            break
+                        }
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+                $changeFound
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+
+        # Remove temp files
+        $path = $Context.SuiteData["OutputFile"]
+        if ($path -and (Test-Path $path)) {
+            try { Remove-Item $path -Force } catch {}
+        }
+        $sshPath = $Context.SuiteData["SshKeyOutputFile"]
+        if ($sshPath -and (Test-Path $sshPath)) {
+            try { Remove-Item $sshPath -Force } catch {}
+        }
+    }
+}

--- a/test/Suites/Suite-EventListener.ps1
+++ b/test/Suites/Suite-EventListener.ps1
@@ -1,0 +1,249 @@
+@{
+    Name        = "Event Listener"
+    Description = "Tests Wait-SafeguardEvent SignalR SSE real-time event listening"
+    Tags        = @("events", "signalr", "listener")
+
+    Setup = {
+        param($Context)
+
+        $prefix = $Context.TestPrefix
+
+        # Pre-cleanup: stale test objects from prior failed runs
+        Remove-SgPsStaleTestObject -Collection "Assets" -Name "${prefix}_EvtLstn1"
+        Remove-SgPsStaleTestObject -Collection "Assets" -Name "${prefix}_EvtLstn2"
+        Remove-SgPsStaleTestObject -Collection "Assets" -Name "${prefix}_EvtLstn3"
+
+        # Store values needed by background jobs (cannot access $SafeguardSession from job)
+        $Context.SuiteData["ManifestPath"] = Join-Path $Context.ModuleRoot "safeguard-ps.psd1"
+        $Context.SuiteData["Appliance"] = $Context.Appliance
+        $Context.SuiteData["AccessToken"] = $SafeguardSession["AccessToken"]
+
+        # Temp file paths for handler tests
+        $tempDir = [System.IO.Path]::GetTempPath()
+        $Context.SuiteData["OutputFile"] = Join-Path $tempDir "${prefix}_evtlstn_output.txt"
+        $Context.SuiteData["HandlerScriptPath"] = Join-Path $tempDir "${prefix}_evtlstn_handler.ps1"
+
+        # Clean up leftover temp files
+        foreach ($f in @($Context.SuiteData["OutputFile"], $Context.SuiteData["HandlerScriptPath"])) {
+            if (Test-Path $f) { Remove-Item $f -Force }
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        $prefix = $Context.TestPrefix
+        $manifestPath = $Context.SuiteData["ManifestPath"]
+        $appliance = $Context.SuiteData["Appliance"]
+        $token = $Context.SuiteData["AccessToken"]
+
+        # ----------------------------------------------------------------
+        # Helper: poll a job's verbose stream for a pattern
+        # ----------------------------------------------------------------
+        $waitForVerbose = {
+            param([System.Management.Automation.Job]$Job, [string]$Pattern, [int]$TimeoutSeconds = 30)
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+                if ($Job.State -eq 'Failed' -or $Job.State -eq 'Completed') {
+                    $jobErr = Receive-Job $Job -ErrorAction SilentlyContinue 2>&1
+                    throw "Listener job ended unexpectedly ($($Job.State)): $jobErr"
+                }
+                if ($Job.ChildJobs.Count -gt 0) {
+                    foreach ($msg in $Job.ChildJobs[0].Verbose) {
+                        if ($msg.Message -match $Pattern) {
+                            return $true
+                        }
+                    }
+                }
+                Start-Sleep -Milliseconds 500
+            }
+            return $false
+        }
+
+        # ----------------------------------------------------------------
+        # Helper: poll Receive-Job output for a matching event
+        # ----------------------------------------------------------------
+        $waitForEvent = {
+            param(
+                [System.Management.Automation.Job]$Job,
+                [string]$EventName,
+                [string]$BodyPattern,
+                [int]$TimeoutSeconds = 15
+            )
+            $sw = [System.Diagnostics.Stopwatch]::StartNew()
+            while ($sw.Elapsed.TotalSeconds -lt $TimeoutSeconds) {
+                $output = @(Receive-Job $Job -Keep -ErrorAction SilentlyContinue)
+                foreach ($evt in $output) {
+                    if ($evt -is [PSCustomObject] -and $evt.EventName -eq $EventName) {
+                        if (-not $BodyPattern) { return $true }
+                        $bodyJson = $evt.EventBody | ConvertTo-Json -Compress -Depth 10
+                        if ($bodyJson -match $BodyPattern) { return $true }
+                    }
+                }
+                Start-Sleep -Milliseconds 500
+            }
+            return $false
+        }
+
+        # ================================================================
+        # Test 1: Pipeline mode captures correlated events
+        # ================================================================
+        Test-SgPsAssert "Wait-SafeguardEvent captures events in pipeline mode" {
+            $assetName = "${prefix}_EvtLstn1"
+            $job = $null
+            try {
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    Wait-SafeguardEvent -Appliance $using:appliance -AccessToken $using:token -Insecure
+                }
+
+                # Wait for SSE handshake to complete
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "Listener did not connect within 30 seconds" }
+
+                # Trigger an event
+                $asset = New-SafeguardAsset -Insecure -DisplayName $assetName `
+                    -Platform 521 -NetworkAddress "10.99.0.1" `
+                    -ServiceAccountCredentialType "None" -NoSshHostKeyDiscovery
+                $Context.SuiteData["Asset1Id"] = $asset.Id
+                Register-SgPsTestCleanup -Description "Delete $assetName" -Action {
+                    param($Ctx)
+                    try { Remove-SafeguardAsset -Insecure $Ctx.SuiteData['Asset1Id'] } catch {}
+                }
+
+                # Poll for the correlated event
+                $found = & $waitForEvent $job 'AssetCreated' $assetName 15
+                $found
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        # ================================================================
+        # Test 2: Event filter limits delivered events
+        # ================================================================
+        Test-SgPsAssert "Wait-SafeguardEvent -Event filter works" {
+            $assetName = "${prefix}_EvtLstn2"
+            $job = $null
+            try {
+                # Listen ONLY for AssetCreated events
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    Wait-SafeguardEvent -Appliance $using:appliance -AccessToken $using:token -Insecure `
+                        -Event @("AssetCreated")
+                }
+
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "Listener did not connect within 30 seconds" }
+
+                # Trigger AssetCreated (should pass filter)
+                $asset = New-SafeguardAsset -Insecure -DisplayName $assetName `
+                    -Platform 521 -NetworkAddress "10.99.0.2" `
+                    -ServiceAccountCredentialType "None" -NoSshHostKeyDiscovery
+                $Context.SuiteData["Asset2Id"] = $asset.Id
+                Register-SgPsTestCleanup -Description "Delete $assetName" -Action {
+                    param($Ctx)
+                    try { Remove-SafeguardAsset -Insecure $Ctx.SuiteData['Asset2Id'] } catch {}
+                }
+
+                # Poll for our AssetCreated event
+                $found = & $waitForEvent $job 'AssetCreated' $assetName 15
+                if (-not $found) { throw "Filtered AssetCreated event not received" }
+
+                # Collect all events and verify ONLY AssetCreated events present
+                $allOutput = @(Receive-Job $job -Keep -ErrorAction SilentlyContinue)
+                $events = @($allOutput | Where-Object {
+                    $_ -is [PSCustomObject] -and $null -ne $_.EventName
+                })
+                $nonAssetCreated = @($events | Where-Object { $_.EventName -ne 'AssetCreated' })
+                $nonAssetCreated.Count -eq 0
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+
+        # ================================================================
+        # Test 3: HandlerScript receives events
+        # ================================================================
+        Test-SgPsAssert "Wait-SafeguardEvent -HandlerScript receives events" {
+            $assetName = "${prefix}_EvtLstn3"
+            $outputFile = $Context.SuiteData["OutputFile"]
+            $handlerPath = $Context.SuiteData["HandlerScriptPath"]
+            $job = $null
+            try {
+                # Clean output file
+                if (Test-Path $outputFile) { Remove-Item $outputFile -Force }
+
+                # Create handler script that appends events to temp file
+                @"
+param(`$EventName, `$EventBody)
+`$line = "`$EventName|`$(`$EventBody | ConvertTo-Json -Compress -Depth 10)"
+`$line | Add-Content -Path "$outputFile" -Encoding UTF8
+"@ | Set-Content -Path $handlerPath -Encoding UTF8
+
+                $job = Start-Job -ScriptBlock {
+                    Import-Module $using:manifestPath -Force
+                    $VerbosePreference = 'Continue'
+                    Wait-SafeguardEvent -Appliance $using:appliance -AccessToken $using:token -Insecure `
+                        -HandlerScript $using:handlerPath
+                }
+
+                $ready = & $waitForVerbose $job 'SignalR handshake complete' 45
+                if (-not $ready) { throw "Listener did not connect within 30 seconds" }
+
+                # Trigger event
+                $asset = New-SafeguardAsset -Insecure -DisplayName $assetName `
+                    -Platform 521 -NetworkAddress "10.99.0.3" `
+                    -ServiceAccountCredentialType "None" -NoSshHostKeyDiscovery
+                $Context.SuiteData["Asset3Id"] = $asset.Id
+                Register-SgPsTestCleanup -Description "Delete $assetName" -Action {
+                    param($Ctx)
+                    try { Remove-SafeguardAsset -Insecure $Ctx.SuiteData['Asset3Id'] } catch {}
+                }
+
+                # Poll output file for our event
+                $found = $false
+                $sw = [System.Diagnostics.Stopwatch]::StartNew()
+                while ($sw.Elapsed.TotalSeconds -lt 15) {
+                    if (Test-Path $outputFile) {
+                        $content = Get-Content $outputFile -Raw -ErrorAction SilentlyContinue
+                        if ($content -match $assetName) {
+                            $found = $true
+                            break
+                        }
+                    }
+                    Start-Sleep -Milliseconds 500
+                }
+                $found
+            }
+            finally {
+                if ($job) {
+                    Stop-Job $job -ErrorAction SilentlyContinue
+                    Remove-Job $job -Force -ErrorAction SilentlyContinue
+                }
+            }
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+
+        # Remove temp files
+        foreach ($key in @("OutputFile", "HandlerScriptPath")) {
+            $path = $Context.SuiteData[$key]
+            if ($path -and (Test-Path $path)) {
+                try { Remove-Item $path -Force } catch {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add real-time event streaming from Safeguard appliances using SignalR over Server-Sent Events (SSE). This enables monitoring changes, triggering automated workflows, and building integrations that react to events as they happen
directly from PowerShell.

New cmdlets:

 - Wait-SafeguardEvent -- listens for events using the authenticated user session with pipeline output, handler scriptblock, or handler script file support. Includes event filtering, automatic reconnection with backoff, and token 
refresh.
 - Wait-SafeguardA2aEvent -- listens for A2A events using client certificate and API key authentication against the A2A-specific SignalR endpoint.
 - Invoke-SafeguardA2aPasswordHandler -- fetches the current password via A2A, invokes the handler, then listens for password change events and delivers updated passwords.
 - Invoke-SafeguardA2aSshKeyHandler -- same pattern for SSH private keys with KeyFormat support (OpenSsh, Ssh2, Putty).

Shared SignalR helpers live in src/signalr-utilities.psm1, parameterized to target either the user-mode (/service/event/signalr/) or A2A (/service/a2a/signalr/) endpoint. The SSE stream uses HttpClient on PS 7+ and HttpWebRequest on
PS 5.1 to work around HttpWebRequest.ServerCertificateValidationCallback being silently broken on .NET 10.

Also fixes $PSDefaultParameterValues not propagating across module boundaries on PS 7 -- each helper now independently handles SSL bypass.

Includes two new integration test suites (6 tests) covering pipeline mode, event filtering, handler scripts, and both A2A password and SSH key handler flows. All tests pass against a live appliance.

README updated with a new "Real-Time Event Listeners" getting-started section and all new cmdlets added to the cmdlet reference. Also fixes a small typo.