### PR TITLE
Close API coverage gaps: AuditLog expansion, ReasonCodes, RunningTasks, Messages, UserPasswordRule

### DIFF
--- a/pipeline-templates/build-windows-steps.yml
+++ b/pipeline-templates/build-windows-steps.yml
@@ -48,6 +48,40 @@ steps:
 - task: PowerShell@2
   inputs:
     targetType: inline
+    pwsh: false
+    failOnStderr: true
+    script: |
+      $ErrorActionPreference = "Stop"
+      Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
+      Write-Host "Verifying src/ parses correctly under Windows PowerShell 5.1..."
+      $srcDir = Join-Path "$(System.DefaultWorkingDirectory)" "src"
+      $files = Get-ChildItem -Path $srcDir -Include "*.psm1","*.ps1","*.psd1" -Recurse
+      $failures = @()
+      foreach ($file in $files)
+      {
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.PSParser]::Tokenize((Get-Content $file.FullName -Raw), [ref]$errors)
+          if ($errors.Count -gt 0)
+          {
+              $failures += "$($file.Name): $($errors[0].Message) (line $($errors[0].Token.StartLine))"
+          }
+      }
+      if ($failures.Count -gt 0)
+      {
+          Write-Host "##[error]PS 5.1 parse failures detected:"
+          $failures | ForEach-Object { Write-Host "##[error]  $_" }
+          throw "$($failures.Count) file(s) failed to parse under Windows PowerShell 5.1"
+      }
+      Write-Host "All $($files.Count) src/ files parse successfully under PS 5.1"
+      Write-Host "Attempting module import under Windows PowerShell 5.1..."
+      Import-Module -Name safeguard-ps -Verbose
+      Write-Host "Module imported successfully under PS 5.1"
+  displayName: 'Verify PS 5.1 compatibility (parse and import)'
+
+- task: PowerShell@2
+  inputs:
+    targetType: inline
     failOnStderr: true
     script: |
       $env:VERSION_STRING = "$(VersionString)"

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.2"
+    value: "8.3"
   - name: isPrerelease
     value: ${{ true }}
   - name: shouldPublishDocker

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -10,9 +10,12 @@ objects, JSON, or CSV.  This is a generic cmdlet that is meant for search.
 More specific audit log cmdlets may be provided in the future for the more
 efficiently retrieving data from the individual log endpoints.
 
-This cmdlet only supports querying data in discreet units of time: days,
+When querying by time range, this cmdlet supports discreet units of time: days,
 hours, or minutes.  You can query for 10 days of data or 2 hours of data, but
 you can't mix and match to query for 2 days and 5 hours of data.
+
+When looking up a specific audit log entry by ID, use the -Id parameter to
+retrieve a single record without time range filtering.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -25,6 +28,12 @@ Ignore verification of Safeguard appliance SSL certificate.
 
 .PARAMETER Log
 The name of the Log to search.
+
+.PARAMETER Id
+The unique identifier of a specific audit log entry to retrieve.  Supported
+for: AccessRequests, Appliance, Archives, DiscoveryAccounts, DiscoveryAssets,
+DiscoveryServices, DiscoverySshKeys, Logins, Patches.  For log types with
+hierarchical drill-down paths use Invoke-SafeguardMethod directly.
 
 .PARAMETER StartDate
 An optional start date for the query.
@@ -57,13 +66,16 @@ None.
 JSON, CSV, or Objects
 
 .EXAMPLE
-Get-SafeguardAuditLog ObjectChanges -Fields "-UserProperties,-Changes,SessionSpsNodeIpAddress" -Hours 12 -Csv
+Get-SafeguardAuditLog ObjectChanges -Fields "-UserProperties,-Changes,SessionSpsNodeIpAddress" -Hours 12 -CsvOutput
 
 .EXAMPLE
 Get-SafeguardAuditLog AllActivity -Fields "Id,LogTime,UserId,UserProperties,EventName" -Days 2
 
 .EXAMPLE
 Get-SafeguardAuditLog CredentialManagement -Fields "-UserProperties,-ConnectionProperties,-RequestStatus" -StartDate "2021-12-14" -Days 2 -JsonOutput -QueryFilter "EventName eq 'SshKeyChangeFailed'"
+
+.EXAMPLE
+Get-SafeguardAuditLog Logins -Id "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 #>
 function Get-SafeguardAuditLog
 {
@@ -78,9 +90,14 @@ function Get-SafeguardAuditLog
         [Parameter(Mandatory=$true,Position=0)]
         [ValidateSet("AccessRequests","AccessRequestActivities","AccessRequestSessions","Appliance","Archives","CredentialManagement",
                      "DirectorySync","DiscoveryAccounts","DiscoveryAssets","DiscoveryServices","DiscoverySshKeys","Licenses",
-                     "Logins","Maintenance","ObjectChanges","Patches","AllActivity")]
+                     "Logins","Maintenance","ObjectChanges","Patches","PlatformScripts","AllActivity")]
         [string]$Log,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$true,ParameterSetName="Id",Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Id,
+        [Parameter(Mandatory=$false,ParameterSetName="Days")]
+        [Parameter(Mandatory=$false,ParameterSetName="Hours")]
+        [Parameter(Mandatory=$false,ParameterSetName="Minutes")]
         [DateTime]$StartDate,
         [Parameter(Mandatory=$false,ParameterSetName="Days")]
         [int]$Days = 1,
@@ -88,13 +105,17 @@ function Get-SafeguardAuditLog
         [int]$Hours,
         [Parameter(Mandatory=$false,ParameterSetName="Minutes")]
         [int]$Minutes,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$false,ParameterSetName="Days")]
+        [Parameter(Mandatory=$false,ParameterSetName="Hours")]
+        [Parameter(Mandatory=$false,ParameterSetName="Minutes")]
         [string]$QueryFilter,
         [Parameter(Mandatory=$false)]
         [string[]]$Fields,
         [Parameter(Mandatory=$false)]
         [switch]$JsonOutput,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$false,ParameterSetName="Days")]
+        [Parameter(Mandatory=$false,ParameterSetName="Hours")]
+        [Parameter(Mandatory=$false,ParameterSetName="Minutes")]
         [switch]$CsvOutput
     )
 
@@ -112,71 +133,96 @@ function Get-SafeguardAuditLog
         "DirectorySync" { $local:RelUrl = "AuditLog/DirectorySync"; break }
         "DiscoveryAccounts" { $local:RelUrl = "AuditLog/Discovery/Accounts"; break }
         "DiscoveryAssets" { $local:RelUrl = "AuditLog/Discovery/Assets"; break }
-        "DiscoveryServices" { $local:RelUrl = "AuditLog/Services"; break }
-        "DiscoverySshKeys" { $local:RelUrl = "AuditLog/SshKeys"; break }
+        "DiscoveryServices" { $local:RelUrl = "AuditLog/Discovery/Services"; break }
+        "DiscoverySshKeys" { $local:RelUrl = "AuditLog/Discovery/SshKeys"; break }
         "Licenses" { $local:RelUrl = "AuditLog/Licenses"; break }
         "Logins" { $local:RelUrl = "AuditLog/Logins"; break }
         "Maintenance" { $local:RelUrl = "AuditLog/Maintenance"; break }
         "ObjectChanges" { $local:RelUrl = "AuditLog/ObjectChanges"; break }
         "Patches" { $local:RelUrl = "AuditLog/Patches"; break }
+        "PlatformScripts" { $local:RelUrl = "AuditLog/PlatformScripts"; break }
         "AllActivity"  { $local:RelUrl = "AuditLog/Search"; break }
     }
 
-    if ($StartDate)
+    if ($PSCmdlet.ParameterSetName -eq "Id")
     {
-        $local:UtcStartDate = $StartDate.ToUniversalTime()
-        if ($PSBoundParameters.ContainsKey("Minutes"))
+        # Detail lookup -- validate that this log type supports simple /{id} paths
+        $local:DetailTypes = @("AccessRequests","Appliance","Archives","DiscoveryAccounts","DiscoveryAssets",
+                               "DiscoveryServices","DiscoverySshKeys","Logins","Patches")
+        if ($local:DetailTypes -notcontains $Log)
         {
-            $local:UtcEndDate = ($local:UtcStartDate.AddMinutes($Minutes))
+            throw ("The $Log log type uses hierarchical drill-down paths and does not support -Id. " +
+                   "Use Invoke-SafeguardMethod for detail access, e.g. " +
+                   "Invoke-SafeguardMethod Core GET '$($local:RelUrl)/<subtype>/<id>'")
         }
-        elseif ($PSBoundParameters.ContainsKey("Hours"))
+
+        $local:Parameters = @{}
+        if ($Fields)
         {
-            $local:UtcEndDate = ($local:UtcStartDate.AddHours($Hours))
+            $local:Parameters["fields"] = ($Fields -join ",")
         }
-        else
-        {
-            $local:UtcEndDate = ($local:UtcStartDate.AddDays($Days))
-        }
+
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET "$($local:RelUrl)/$Id" -Parameters $local:Parameters -JsonOutput:$JsonOutput
     }
     else
     {
-        if ($PSBoundParameters.ContainsKey("Minutes"))
+        if ($StartDate)
         {
-            $local:UtcStartDate = ([DateTime]::UtcNow.AddMinutes(0 - $Minutes))
-        }
-        elseif ($PSBoundParameters.ContainsKey("Hours"))
-        {
-            $local:UtcStartDate = ([DateTime]::UtcNow.AddHours(0 - $Hours))
+            $local:UtcStartDate = $StartDate.ToUniversalTime()
+            if ($PSBoundParameters.ContainsKey("Minutes"))
+            {
+                $local:UtcEndDate = ($local:UtcStartDate.AddMinutes($Minutes))
+            }
+            elseif ($PSBoundParameters.ContainsKey("Hours"))
+            {
+                $local:UtcEndDate = ($local:UtcStartDate.AddHours($Hours))
+            }
+            else
+            {
+                $local:UtcEndDate = ($local:UtcStartDate.AddDays($Days))
+            }
         }
         else
         {
-            $local:UtcStartDate = ([DateTime]::UtcNow.AddDays(0 - $Days))
+            if ($PSBoundParameters.ContainsKey("Minutes"))
+            {
+                $local:UtcStartDate = ([DateTime]::UtcNow.AddMinutes(0 - $Minutes))
+            }
+            elseif ($PSBoundParameters.ContainsKey("Hours"))
+            {
+                $local:UtcStartDate = ([DateTime]::UtcNow.AddHours(0 - $Hours))
+            }
+            else
+            {
+                $local:UtcStartDate = ([DateTime]::UtcNow.AddDays(0 - $Days))
+            }
         }
-    }
-    Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
-    $local:Parameters = @{ startDate = (Format-UtcDateTimeAsString $local:UtcStartDate) }
-    if ($local:UtcEndDate)
-    {
-        $local:Parameters["endDate"] = (Format-UtcDateTimeAsString $local:UtcEndDate)
-    }
-    if ($QueryFilter)
-    {
-        $local:Parameters["filter"] = $QueryFilter
-    }
-    if ($Fields)
-    {
-        $local:Parameters["fields"] = ($Fields -join ",")
-    }
+        Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+        $local:Parameters = @{ startDate = (Format-UtcDateTimeAsString $local:UtcStartDate) }
+        if ($local:UtcEndDate)
+        {
+            $local:Parameters["endDate"] = (Format-UtcDateTimeAsString $local:UtcEndDate)
+        }
+        if ($QueryFilter)
+        {
+            $local:Parameters["filter"] = $QueryFilter
+        }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
 
-    if ($CsvOutput)
-    {
-        $local:Accept = "text/csv"
-    }
-    else
-    {
-        $local:Accept = "application/json"
-    }
+        if ($CsvOutput)
+        {
+            $local:Accept = "text/csv"
+        }
+        else
+        {
+            $local:Accept = "application/json"
+        }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Accept $local:Accept `
-                           Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -Accept $local:Accept `
+                               Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+    }
 }

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -857,3 +857,132 @@ function Get-SafeguardAuditLogDiscoveredItem
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                            Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
 }
+<#
+.SYNOPSIS
+Get platform script change audit log data from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet drills into the platform script audit log, allowing you to list all
+script changes, filter by platform, retrieve a specific script version, or download
+the raw script content as it existed at that point in time.
+
+The list endpoints return metadata (Id, PlatformId, PlatformDisplayName, LogTime).
+The detail endpoint (-PlatformId -LogId) returns the actual script content at that
+version.  The -Raw switch returns the script as raw bytes.
+
+This endpoint requires AssetAdmin or Auditor roles.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER PlatformId
+The ID of the platform to filter script changes for.  Required for detail and
+raw lookups.
+
+.PARAMETER LogId
+The unique ID of a specific script change log entry.  Requires -PlatformId.
+Use the Id field from the list output.
+
+.PARAMETER Raw
+Switch to retrieve the raw script content at the time of this change entry.
+Requires both -PlatformId and -LogId.
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER JsonOutput
+A switch to return data as pretty JSON string.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON, Objects, or String (for -Raw)
+
+.EXAMPLE
+Get-SafeguardAuditLogPlatformScript -Insecure
+
+.EXAMPLE
+Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId 12345
+
+.EXAMPLE
+Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId 12345 -LogId "abc-123"
+
+.EXAMPLE
+Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId 12345 -LogId "abc-123" -Raw
+#>
+function Get-SafeguardAuditLogPlatformScript
+{
+    [CmdletBinding(DefaultParameterSetName="List")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="ByPlatform",Mandatory=$true,Position=0)]
+        [Parameter(ParameterSetName="Detail",Mandatory=$true,Position=0)]
+        [Parameter(ParameterSetName="Raw",Mandatory=$true,Position=0)]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$PlatformId,
+        [Parameter(ParameterSetName="Detail",Mandatory=$true,Position=1)]
+        [Parameter(ParameterSetName="Raw",Mandatory=$true,Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$LogId,
+        [Parameter(ParameterSetName="Raw",Mandatory=$true)]
+        [switch]$Raw,
+        [Parameter(ParameterSetName="List",Mandatory=$false)]
+        [Parameter(ParameterSetName="ByPlatform",Mandatory=$false)]
+        [string]$QueryFilter,
+        [Parameter(ParameterSetName="List",Mandatory=$false)]
+        [Parameter(ParameterSetName="ByPlatform",Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [switch]$JsonOutput
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSCmdlet.ParameterSetName -eq "Raw")
+    {
+        $local:RelUrl = "AuditLog/PlatformScripts/$PlatformId/$LogId/Raw"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET $local:RelUrl
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "Detail")
+    {
+        $local:RelUrl = "AuditLog/PlatformScripts/$PlatformId/$LogId"
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET $local:RelUrl -JsonOutput:$JsonOutput
+    }
+    else
+    {
+        $local:RelUrl = "AuditLog/PlatformScripts"
+        if ($PSCmdlet.ParameterSetName -eq "ByPlatform")
+        {
+            $local:RelUrl += "/$PlatformId"
+        }
+        $local:Parameters = @{}
+        if ($QueryFilter)
+        {
+            $local:Parameters["filter"] = $QueryFilter
+        }
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+    }
+}

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -626,3 +626,234 @@ function Get-SafeguardAuditLogAccessRequestSession
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                            Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
 }
+
+<#
+.SYNOPSIS
+Get object change audit log data from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet drills into the object change audit log, allowing you to list changes
+by object type, filter to a specific object, or retrieve the detail of a single
+change entry.
+
+At minimum, -ObjectType is required.  Provide -ObjectId to narrow to a single
+object, and -LogId to retrieve a specific change entry.
+
+The API accepts many object types including User, Asset, AssetAccount, Policy,
+Role, Directory, IdentityProvider, UserGroup, AssetGroup, AccountGroup, and more.
+Use the Swagger documentation for a complete list.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ObjectType
+The type of object to retrieve changes for (e.g., User, Asset, AssetAccount,
+Policy, Role).  Required for all modes.
+
+.PARAMETER ObjectId
+The ID of the specific object to retrieve changes for.  Requires -ObjectType.
+
+.PARAMETER LogId
+The unique ID of a specific change log entry.  Requires -ObjectType and -ObjectId.
+Use the Id field from the list output.
+
+.PARAMETER StartDate
+Get changes that occurred after this date.  Only used for list queries (not with -LogId).
+
+.PARAMETER EndDate
+Get changes that occurred before this date.  Only used for list queries (not with -LogId).
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER JsonOutput
+A switch to return data as pretty JSON string.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON or Objects
+
+.EXAMPLE
+Get-SafeguardAuditLogObjectChange -Insecure User
+
+.EXAMPLE
+Get-SafeguardAuditLogObjectChange -Insecure User -ObjectId 123
+
+.EXAMPLE
+Get-SafeguardAuditLogObjectChange -Insecure User -ObjectId 123 -LogId "abc-def-123"
+
+.EXAMPLE
+Get-SafeguardAuditLogObjectChange -Insecure Asset -StartDate (Get-Date).AddDays(-7) -QueryFilter "EventName eq 'AssetCreated'"
+#>
+function Get-SafeguardAuditLogObjectChange
+{
+    [CmdletBinding(DefaultParameterSetName="ByType")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ObjectType,
+        [Parameter(ParameterSetName="ByObject",Mandatory=$true,Position=1)]
+        [Parameter(ParameterSetName="Detail",Mandatory=$true,Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ObjectId,
+        [Parameter(ParameterSetName="Detail",Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$LogId,
+        [Parameter(ParameterSetName="ByType",Mandatory=$false)]
+        [Parameter(ParameterSetName="ByObject",Mandatory=$false)]
+        [DateTime]$StartDate,
+        [Parameter(ParameterSetName="ByType",Mandatory=$false)]
+        [Parameter(ParameterSetName="ByObject",Mandatory=$false)]
+        [DateTime]$EndDate,
+        [Parameter(ParameterSetName="ByType",Mandatory=$false)]
+        [Parameter(ParameterSetName="ByObject",Mandatory=$false)]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [switch]$JsonOutput
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSBoundParameters.ContainsKey("StartDate") -and $PSBoundParameters.ContainsKey("EndDate"))
+    {
+        if ($StartDate -gt $EndDate)
+        {
+            throw "-StartDate must not be later than -EndDate."
+        }
+    }
+
+    if ($PSCmdlet.ParameterSetName -eq "Detail")
+    {
+        $local:RelUrl = "AuditLog/ObjectChanges/$ObjectType/$ObjectId/$LogId"
+        $local:Parameters = @{}
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+    }
+    else
+    {
+        $local:RelUrl = "AuditLog/ObjectChanges/$ObjectType"
+        if ($PSCmdlet.ParameterSetName -eq "ByObject")
+        {
+            $local:RelUrl += "/$ObjectId"
+        }
+        $local:Parameters = (Get-AuditLogListParameters -StartDate $StartDate -EndDate $EndDate `
+                                -QueryFilter $QueryFilter -Fields $Fields)
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+}
+
+<#
+.SYNOPSIS
+Get items discovered during a specific discovery job from the Safeguard audit log.
+
+.DESCRIPTION
+This cmdlet retrieves the actual accounts, assets, or services that were discovered
+during a specific discovery job run.  The discovery job is identified by its audit
+log entry ID, which can be obtained from Get-SafeguardAuditLog (e.g.,
+Get-SafeguardAuditLog DiscoveryAccounts -Id <logEntryId>).
+
+This endpoint requires AssetAdmin or Auditor roles.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER DiscoveryType
+The type of discovery results to retrieve: Accounts, Assets, or Services.
+
+.PARAMETER DiscoveryLogId
+The ID of the discovery audit log entry.  Obtain this from the Id field of
+Get-SafeguardAuditLog DiscoveryAccounts (or DiscoveryAssets, DiscoveryServices).
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER JsonOutput
+A switch to return data as pretty JSON string.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON or Objects
+
+.EXAMPLE
+Get-SafeguardAuditLogDiscoveredItem -Insecure Accounts -DiscoveryLogId "abc-123"
+
+.EXAMPLE
+Get-SafeguardAuditLogDiscoveredItem -Insecure Assets -DiscoveryLogId "abc-123" -Fields "Name","IpAddress"
+#>
+function Get-SafeguardAuditLogDiscoveredItem
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidateSet("Accounts","Assets","Services")]
+        [string]$DiscoveryType,
+        [Parameter(Mandatory=$true,Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$DiscoveryLogId,
+        [Parameter(Mandatory=$false)]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [switch]$JsonOutput
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:RelUrl = "AuditLog/Discovery/$DiscoveryType/$DiscoveryLogId/Discovered$DiscoveryType"
+
+    $local:Parameters = @{}
+    if ($QueryFilter)
+    {
+        $local:Parameters["filter"] = $QueryFilter
+    }
+    if ($Fields)
+    {
+        $local:Parameters["fields"] = ($Fields -join ",")
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+}

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -1165,3 +1165,304 @@ function Get-SafeguardAuditLogSigningCertificateHistory
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                            Core GET "AuditLog/Retention/SigningCertificate/History"
 }
+
+<#
+.SYNOPSIS
+Get scheduled audit log reports for the current user from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet retrieves scheduled audit log reports belonging to the currently
+authenticated user. When called without parameters it returns all reports.
+When called with -ReportId it returns a specific report.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReportId
+The ID of a specific scheduled audit log report to retrieve.
+
+.EXAMPLE
+Get-SafeguardScheduledAuditLogReport -Insecure
+
+.EXAMPLE
+Get-SafeguardScheduledAuditLogReport -Insecure -ReportId 42
+#>
+function Get-SafeguardScheduledAuditLogReport
+{
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,Position=0)]
+        [int]$ReportId
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSBoundParameters.ContainsKey("ReportId"))
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET "Me/ScheduledAuditLogReports/$ReportId"
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core GET "Me/ScheduledAuditLogReports"
+    }
+}
+
+<#
+.SYNOPSIS
+Create a new scheduled audit log report for the current user in Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet creates a new scheduled audit log report. At minimum, a Name is required.
+You can optionally specify the category, schedule, format, and filtering options.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Name
+The name of the scheduled report (required).
+
+.PARAMETER Description
+An optional description for the report.
+
+.PARAMETER CategoryOption
+The audit log category to report on. Valid values include: AccessRequestActivity,
+AccessRequestSession, Password, ObjectChange, Appliance, Archive, Login, Patch,
+License, DirectorySync.
+
+.PARAMETER SerializationFormat
+The output format for the report: Json or Csv.
+
+.PARAMETER Body
+A hashtable or PSObject containing the full report configuration. Use this for
+advanced configuration instead of individual parameters.
+
+.EXAMPLE
+New-SafeguardScheduledAuditLogReport -Insecure -Name "Weekly Logins" -CategoryOption Login -SerializationFormat Csv
+
+.EXAMPLE
+New-SafeguardScheduledAuditLogReport -Insecure -Body @{ Name = "My Report"; CategoryOption = "Password"; ScheduleType = "Weekly" }
+#>
+function New-SafeguardScheduledAuditLogReport
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$true,Position=0)]
+        [string]$Name,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$Description,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [ValidateSet("AccessRequestActivity","AccessRequestSession","Password","ObjectChange",
+                     "Appliance","Archive","Login","Patch","License","DirectorySync",IgnoreCase=$true)]
+        [string]$CategoryOption,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [ValidateSet("Json","Csv",IgnoreCase=$true)]
+        [string]$SerializationFormat,
+        [Parameter(ParameterSetName="Body",Mandatory=$true)]
+        [object]$Body
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSCmdlet.ParameterSetName -eq "Body")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core POST "Me/ScheduledAuditLogReports" -Body $Body
+    }
+    else
+    {
+        $local:ReportBody = @{ Name = $Name }
+        if ($Description) { $local:ReportBody.Description = $Description }
+        if ($CategoryOption) { $local:ReportBody.CategoryOption = $CategoryOption }
+        if ($SerializationFormat) { $local:ReportBody.SerializationFormat = $SerializationFormat }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core POST "Me/ScheduledAuditLogReports" -Body $local:ReportBody
+    }
+}
+
+<#
+.SYNOPSIS
+Update an existing scheduled audit log report in Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet updates an existing scheduled audit log report. Pass the full report
+object (from Get-SafeguardScheduledAuditLogReport) with modifications applied.
+Supports pipeline input for the report object.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReportId
+The ID of the scheduled report to update.
+
+.PARAMETER ReportObject
+A PSObject containing the full report configuration to set. Supports pipeline input.
+
+.EXAMPLE
+$report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId 42
+$report.Description = "Updated description"
+Edit-SafeguardScheduledAuditLogReport -Insecure -ReportId 42 -ReportObject $report
+
+.EXAMPLE
+Get-SafeguardScheduledAuditLogReport -Insecure -ReportId 42 | Edit-SafeguardScheduledAuditLogReport -Insecure
+#>
+function Edit-SafeguardScheduledAuditLogReport
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,Position=0)]
+        [int]$ReportId,
+        [Parameter(Mandatory=$false,ValueFromPipeline=$true)]
+        [object]$ReportObject
+    )
+
+    begin
+    {
+        if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+        if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+    }
+
+    process
+    {
+        if (-not $ReportObject)
+        {
+            if (-not $PSBoundParameters.ContainsKey("ReportId"))
+            {
+                throw "You must specify a ReportId or pipe a report object"
+            }
+            $ReportObject = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                                                   Core GET "Me/ScheduledAuditLogReports/$ReportId"
+        }
+        $local:Id = if ($PSBoundParameters.ContainsKey("ReportId")) { $ReportId } else { $ReportObject.Id }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                               Core PUT "Me/ScheduledAuditLogReports/$($local:Id)" -Body $ReportObject
+    }
+}
+
+<#
+.SYNOPSIS
+Remove a scheduled audit log report from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet deletes a scheduled audit log report belonging to the current user.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReportId
+The ID of the scheduled report to delete.
+
+.EXAMPLE
+Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId 42
+#>
+function Remove-SafeguardScheduledAuditLogReport
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [int]$ReportId
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core DELETE "Me/ScheduledAuditLogReports/$ReportId"
+}
+
+<#
+.SYNOPSIS
+Execute a scheduled audit log report immediately in Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet triggers immediate execution of a scheduled audit log report and
+returns the report results. The report runs synchronously and returns the data
+in the configured format (JSON or CSV).
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReportId
+The ID of the scheduled report to execute.
+
+.EXAMPLE
+Invoke-SafeguardScheduledAuditLogReport -Insecure -ReportId 42
+#>
+function Invoke-SafeguardScheduledAuditLogReport
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [int]$ReportId
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core POST "Me/ScheduledAuditLogReports/$ReportId/Execute"
+}

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -226,3 +226,403 @@ function Get-SafeguardAuditLog
                                Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
     }
 }
+
+# Helper to build common query parameters for audit log list endpoints
+function Get-AuditLogListParameters
+{
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [object]$StartDate,
+        [Parameter(Mandatory=$false)]
+        [object]$EndDate,
+        [Parameter(Mandatory=$false)]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
+    )
+
+    Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
+    $local:Parameters = @{}
+    if ($null -ne $StartDate)
+    {
+        $local:Parameters["startDate"] = (Format-UtcDateTimeAsString ([DateTime]$StartDate).ToUniversalTime())
+    }
+    if ($null -ne $EndDate)
+    {
+        $local:Parameters["endDate"] = (Format-UtcDateTimeAsString ([DateTime]$EndDate).ToUniversalTime())
+    }
+    if ($QueryFilter)
+    {
+        $local:Parameters["filter"] = $QueryFilter
+    }
+    if ($Fields)
+    {
+        $local:Parameters["fields"] = ($Fields -join ",")
+    }
+    $local:Parameters
+}
+
+<#
+.SYNOPSIS
+Get access request activity audit log data from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet drills into the access request activity audit log, allowing you to list
+activities, filter by request, retrieve individual log entries, or get session log
+data for a specific activity.
+
+Without parameters, returns all access request activity entries from the last 24 hours
+(API default).  Use -StartDate and -EndDate to control the time range.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+The unique ID of the access request to filter by.  When provided alone, returns
+all activity entries for that request.
+
+.PARAMETER LogId
+The database ID of a specific activity log entry.  Requires -RequestId.
+
+.PARAMETER SessionLog
+Switch to retrieve session log entries for a specific activity.  Requires both
+-RequestId and -LogId.
+
+.PARAMETER StartDate
+Get activity that occurred after this date.  Defaults to 1 day before EndDate.
+
+.PARAMETER EndDate
+Get activity that occurred before this date.  Defaults to now.
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER UserId
+Get activity for a specific user (top-level list only).
+
+.PARAMETER AssetId
+Get activity for a specific asset (top-level list only).
+
+.PARAMETER AccountId
+Get activity for a specific account (top-level list only).
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER JsonOutput
+A switch to return data as pretty JSON string.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON or Objects
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestActivity -Insecure
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestActivity -Insecure -RequestId "abc-123" -LogId "def-456"
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestActivity -Insecure -RequestId "abc-123" -LogId "def-456" -SessionLog
+#>
+function Get-SafeguardAuditLogAccessRequestActivity
+{
+    [CmdletBinding(DefaultParameterSetName="List")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,ParameterSetName="List",Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="Detail",Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="SessionLog",Position=0)]
+        [string]$RequestId,
+        [Parameter(Mandatory=$true,ParameterSetName="Detail",Position=1)]
+        [Parameter(Mandatory=$true,ParameterSetName="SessionLog",Position=1)]
+        [ValidateNotNullOrEmpty()]
+        [string]$LogId,
+        [Parameter(Mandatory=$true,ParameterSetName="SessionLog")]
+        [switch]$SessionLog,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [Parameter(Mandatory=$false,ParameterSetName="SessionLog")]
+        [DateTime]$StartDate,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [Parameter(Mandatory=$false,ParameterSetName="SessionLog")]
+        [DateTime]$EndDate,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [Parameter(Mandatory=$false,ParameterSetName="SessionLog")]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$UserId,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$AssetId,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$AccountId,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [switch]$JsonOutput
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSCmdlet.ParameterSetName -eq "Detail")
+    {
+        $local:RelUrl = "AuditLog/AccessRequests/Activities/$RequestId/$LogId"
+        $local:Parameters = @{}
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "SessionLog")
+    {
+        $local:RelUrl = "AuditLog/AccessRequests/Activities/$RequestId/$LogId/SessionLog"
+        $local:Parameters = (Get-AuditLogListParameters -StartDate $StartDate -EndDate $EndDate `
+                                -QueryFilter $QueryFilter -Fields $Fields)
+    }
+    else
+    {
+        # List mode -- top-level or filtered by RequestId
+        if ($RequestId)
+        {
+            # UserId/AssetId/AccountId are only valid on the top-level list endpoint
+            if ($PSBoundParameters.ContainsKey("UserId") -or $PSBoundParameters.ContainsKey("AssetId") -or `
+                $PSBoundParameters.ContainsKey("AccountId"))
+            {
+                throw "-UserId, -AssetId, and -AccountId filters are only supported on the top-level list " +
+                      "(without -RequestId). Use -QueryFilter for request-level filtering."
+            }
+            $local:RelUrl = "AuditLog/AccessRequests/Activities/$RequestId"
+        }
+        else
+        {
+            $local:RelUrl = "AuditLog/AccessRequests/Activities"
+        }
+        $local:Parameters = (Get-AuditLogListParameters -StartDate $StartDate -EndDate $EndDate `
+                                -QueryFilter $QueryFilter -Fields $Fields)
+        if ($PSBoundParameters.ContainsKey("UserId"))
+        {
+            $local:Parameters["userId"] = $UserId
+        }
+        if ($PSBoundParameters.ContainsKey("AssetId"))
+        {
+            $local:Parameters["assetId"] = $AssetId
+        }
+        if ($PSBoundParameters.ContainsKey("AccountId"))
+        {
+            $local:Parameters["accountId"] = $AccountId
+        }
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+}
+
+<#
+.SYNOPSIS
+Get access request session audit log data from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet drills into the access request session audit log, allowing you to list
+session activities, filter by request and session, retrieve individual log entries,
+get session playback data, or get the SPS audit portal link for a session.
+
+Without parameters, returns all access request session entries from the last 24 hours
+(API default).  Use -StartDate and -EndDate to control the time range.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RequestId
+The unique ID of the access request to filter by.
+
+.PARAMETER SessionId
+The unique session ID within an access request.  Requires -RequestId.
+
+.PARAMETER LogId
+The database ID of a specific session log entry.  Requires -RequestId and -SessionId.
+
+.PARAMETER Playback
+Switch to retrieve session playback data.  Requires -RequestId and -SessionId.
+
+.PARAMETER AuditPortalLink
+Switch to retrieve the SPS audit portal permalink.  Requires -RequestId and -SessionId.
+
+.PARAMETER StartDate
+Get activity that occurred after this date.  Defaults to 1 day before EndDate.
+
+.PARAMETER EndDate
+Get activity that occurred before this date.  Defaults to now.
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER UserId
+Get activity for a specific user (top-level list only).
+
+.PARAMETER AssetId
+Get activity for a specific asset (top-level list only).
+
+.PARAMETER AccountId
+Get activity for a specific account (top-level list only).
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER JsonOutput
+A switch to return data as pretty JSON string.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON, Objects, or String (for AuditPortalLink)
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestSession -Insecure
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestSession -Insecure -RequestId "abc-123" -SessionId 1
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestSession -Insecure -RequestId "abc-123" -SessionId 1 -Playback
+
+.EXAMPLE
+Get-SafeguardAuditLogAccessRequestSession -Insecure -RequestId "abc-123" -SessionId 1 -AuditPortalLink
+#>
+function Get-SafeguardAuditLogAccessRequestSession
+{
+    [CmdletBinding(DefaultParameterSetName="List")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,ParameterSetName="List",Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="Detail",Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="Playback",Position=0)]
+        [Parameter(Mandatory=$true,ParameterSetName="AuditPortalLink",Position=0)]
+        [string]$RequestId,
+        [Parameter(Mandatory=$false,ParameterSetName="List",Position=1)]
+        [Parameter(Mandatory=$true,ParameterSetName="Detail",Position=1)]
+        [Parameter(Mandatory=$true,ParameterSetName="Playback",Position=1)]
+        [Parameter(Mandatory=$true,ParameterSetName="AuditPortalLink",Position=1)]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$SessionId,
+        [Parameter(Mandatory=$true,ParameterSetName="Detail",Position=2)]
+        [ValidateNotNullOrEmpty()]
+        [string]$LogId,
+        [Parameter(Mandatory=$true,ParameterSetName="Playback")]
+        [switch]$Playback,
+        [Parameter(Mandatory=$true,ParameterSetName="AuditPortalLink")]
+        [switch]$AuditPortalLink,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [DateTime]$StartDate,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [DateTime]$EndDate,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$UserId,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$AssetId,
+        [Parameter(Mandatory=$false,ParameterSetName="List")]
+        [ValidateRange(1,[int]::MaxValue)]
+        [int]$AccountId,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [switch]$JsonOutput
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PSCmdlet.ParameterSetName -eq "Detail")
+    {
+        $local:RelUrl = "AuditLog/AccessRequests/Sessions/$RequestId/$SessionId/$LogId"
+        $local:Parameters = @{}
+        if ($Fields)
+        {
+            $local:Parameters["fields"] = ($Fields -join ",")
+        }
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "Playback")
+    {
+        $local:RelUrl = "AuditLog/AccessRequests/Sessions/$RequestId/$SessionId/Playback"
+        $local:Parameters = @{}
+    }
+    elseif ($PSCmdlet.ParameterSetName -eq "AuditPortalLink")
+    {
+        $local:RelUrl = "AuditLog/AccessRequests/Sessions/$RequestId/$SessionId/AuditPortalLink"
+        $local:Parameters = @{}
+    }
+    else
+    {
+        # List mode -- validate parameter combinations
+        if ($PSBoundParameters.ContainsKey("SessionId") -and -not $RequestId)
+        {
+            throw "-SessionId requires -RequestId. Provide a RequestId to filter sessions within a request."
+        }
+        if ($RequestId -and ($PSBoundParameters.ContainsKey("UserId") -or $PSBoundParameters.ContainsKey("AssetId") -or `
+            $PSBoundParameters.ContainsKey("AccountId")))
+        {
+            throw "-UserId, -AssetId, and -AccountId filters are only supported on the top-level list " +
+                  "(without -RequestId). Use -QueryFilter for request-level filtering."
+        }
+
+        $local:RelUrl = "AuditLog/AccessRequests/Sessions"
+        if ($RequestId)
+        {
+            $local:RelUrl += "/$RequestId"
+            if ($PSBoundParameters.ContainsKey("SessionId"))
+            {
+                $local:RelUrl += "/$SessionId"
+            }
+        }
+        $local:Parameters = (Get-AuditLogListParameters -StartDate $StartDate -EndDate $EndDate `
+                                -QueryFilter $QueryFilter -Fields $Fields)
+        if ($PSBoundParameters.ContainsKey("UserId"))
+        {
+            $local:Parameters["userId"] = $UserId
+        }
+        if ($PSBoundParameters.ContainsKey("AssetId"))
+        {
+            $local:Parameters["assetId"] = $AssetId
+        }
+        if ($PSBoundParameters.ContainsKey("AccountId"))
+        {
+            $local:Parameters["accountId"] = $AccountId
+        }
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
+}

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -986,3 +986,182 @@ function Get-SafeguardAuditLogPlatformScript
                                Core GET $local:RelUrl -Parameters $local:Parameters -JsonOutput:$JsonOutput
     }
 }
+
+<#
+.SYNOPSIS
+Get audit log maintenance configuration from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet retrieves the current audit log maintenance configuration including
+retention periods, schedule settings, archive server configuration, and timestamps
+for the last maintenance operations.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.EXAMPLE
+Get-SafeguardAuditLogMaintenanceConfig -Insecure
+
+.EXAMPLE
+Get-SafeguardAuditLogMaintenanceConfig -Appliance 10.5.32.54 -AccessToken $token
+#>
+function Get-SafeguardAuditLogMaintenanceConfig
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET "AuditLog/Maintenance"
+}
+
+<#
+.SYNOPSIS
+Set audit log maintenance configuration in Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet updates the audit log maintenance configuration. You can modify
+retention periods, schedule settings, and archive server configuration. Pass
+the full configuration object (from Get-SafeguardAuditLogMaintenanceConfig)
+with your modifications applied.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER MaintenanceObject
+A PSObject or hashtable containing the maintenance configuration to set.
+
+.EXAMPLE
+$config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+$config.DaysToRetainLogs = 180
+Set-SafeguardAuditLogMaintenanceConfig -Insecure $config
+
+.EXAMPLE
+Set-SafeguardAuditLogMaintenanceConfig -Insecure -MaintenanceObject @{ DaysToRetainLogs = 365; DayOfWeek = "Sunday"; StartHour = 3 }
+#>
+function Set-SafeguardAuditLogMaintenanceConfig
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$MaintenanceObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core PUT "AuditLog/Maintenance" -Body $MaintenanceObject
+}
+
+<#
+.SYNOPSIS
+Trigger an immediate audit log maintenance run in Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet triggers an immediate audit log maintenance cycle on the appliance.
+The maintenance operation runs asynchronously. Monitor progress by polling
+Get-SafeguardAuditLogMaintenanceConfig and watching the LastScheduledMaintenance
+timestamp update.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.EXAMPLE
+Invoke-SafeguardAuditLogMaintenance -Insecure
+#>
+function Invoke-SafeguardAuditLogMaintenance
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core POST "AuditLog/Maintenance/RunNow"
+}
+
+<#
+.SYNOPSIS
+Get audit log signing certificate history from Safeguard via the web API.
+
+.DESCRIPTION
+This cmdlet retrieves the history of signing certificates used for audit log
+integrity verification. Each entry includes the certificate details, installation
+date, and replacement date (if superseded).
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.EXAMPLE
+Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+
+.EXAMPLE
+Get-SafeguardAuditLogSigningCertificateHistory | Select-Object Subject, InstalledDate, ReplacedDate
+#>
+function Get-SafeguardAuditLogSigningCertificateHistory
+{
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+                           Core GET "AuditLog/Retention/SigningCertificate/History"
+}

--- a/src/auditlog.psm1
+++ b/src/auditlog.psm1
@@ -1373,7 +1373,7 @@ function Edit-SafeguardScheduledAuditLogReport
             $ReportObject = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                                    Core GET "Me/ScheduledAuditLogReports/$ReportId"
         }
-        $local:Id = if ($PSBoundParameters.ContainsKey("ReportId")) { $ReportId } else { $ReportObject.Id }
+        if ($PSBoundParameters.ContainsKey("ReportId")) { $local:Id = $ReportId } else { $local:Id = $ReportObject.Id }
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                Core PUT "Me/ScheduledAuditLogReports/$($local:Id)" -Body $ReportObject
     }

--- a/src/profiles.psm1
+++ b/src/profiles.psm1
@@ -696,7 +696,7 @@ function New-SafeguardAccountPasswordRule
     if ($AllowedLastCharType) { $local:Body.AllowedLastCharacterType = $AllowedLastCharType }
 
     if ($MaxConsecutiveAlpha) { $local:Body.MaxConsecutiveAlphabeticCharacters = $MaxConsecutiveAlpha }
-    if ($MaxConsecutiveAlphanumeric) { $local:Body.MaxConsecutiveAlphaNumericCharacters = $MaxConsecutiveAlpha }
+    if ($MaxConsecutiveAlphanumeric) { $local:Body.MaxConsecutiveAlphaNumericCharacters = $MaxConsecutiveAlphanumeric }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
         POST "AssetPartitions/$($local:AssetPartitionId)/PasswordRules" -Body $local:Body
@@ -902,7 +902,7 @@ function Edit-SafeguardAccountPasswordRule
     if ($PSBoundParameters.ContainsKey("AllowLowercase")) { $local:RuleObj.AllowLowercaseCharacters = $AllowLowercase }
     if ($PSBoundParameters.ContainsKey("MinLowercase")) { $local:RuleObj.MinLowercaseCharacters = $MinLowercase }
     if ($PSBoundParameters.ContainsKey("AllowNumeric")) { $local:RuleObj.AllowNumericCharacters = $AllowNumeric }
-    if ($PSBoundParameters.ContainsKey("MinNumeric")) { $local:RuleObj.MaxConsecutiveUppercaseCharacters = $MinNumeric }
+    if ($PSBoundParameters.ContainsKey("MinNumeric")) { $local:RuleObj.MinNumericCharacters = $MinNumeric }
     if ($PSBoundParameters.ContainsKey("AllowSymbols")) { $local:RuleObj.AllowNonAlphaNumericCharacters = $AllowSymbols }
     if ($PSBoundParameters.ContainsKey("MinSymbols")) { $local:RuleObj.MinNonAlphaNumericCharacters = $MinSymbols }
     if ($PSBoundParameters.ContainsKey("RepeatedCharRestriction")) { $local:RuleObj.RepeatedCharacterRestriction = $RepeatedCharRestriction }
@@ -933,7 +933,7 @@ function Edit-SafeguardAccountPasswordRule
     if ($PSBoundParameters.ContainsKey("AllowedLastCharType")) { $local:RuleObj.AllowedLastCharacterType = $AllowedLastCharType }
 
     if ($PSBoundParameters.ContainsKey("MaxConsecutiveAlpha")) { $local:RuleObj.MaxConsecutiveAlphabeticCharacters = $MaxConsecutiveAlpha }
-    if ($PSBoundParameters.ContainsKey("MaxConsecutiveAlphanumeric")) { $local:RuleObj.MaxConsecutiveAlphaNumericCharacters = $MaxConsecutiveAlpha }
+    if ($PSBoundParameters.ContainsKey("MaxConsecutiveAlphanumeric")) { $local:RuleObj.MaxConsecutiveAlphaNumericCharacters = $MaxConsecutiveAlphanumeric }
 
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
         PUT "AssetPartitions/$($local:RuleObj.AssetPartitionId)/PasswordRules/$($local:RuleObj.Id)" -Body $local:RuleObj

--- a/src/reasoncodes.psm1
+++ b/src/reasoncodes.psm1
@@ -394,3 +394,51 @@ function Remove-SafeguardReasonCode
     $local:Id = (Resolve-SafeguardReasonCodeId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ReasonCode $ReasonCodeToDelete)
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "ReasonCodes/$($local:Id)"
 }
+
+<#
+.SYNOPSIS
+Get the available reason code scopes from Safeguard via the Web API.
+
+.DESCRIPTION
+Reason code scopes define the contexts in which reason codes can be applied.
+This cmdlet returns the list of available scopes that can be assigned to
+reason codes (e.g., access requests, password releases, session requests).
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardReasonCodeScope -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardReasonCodeScope
+#>
+function Get-SafeguardReasonCodeScope
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes/Scopes"
+}

--- a/src/reasoncodes.psm1
+++ b/src/reasoncodes.psm1
@@ -1,0 +1,396 @@
+<# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
+# Helpers
+function Resolve-SafeguardReasonCodeId
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$ReasonCode
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($ReasonCode.Id -as [int])
+    {
+        $ReasonCode = $ReasonCode.Id
+    }
+
+    if (-not ($ReasonCode -as [int]))
+    {
+        try
+        {
+            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
+                                 -Parameters @{ filter = "Name ieq '$ReasonCode'" })
+        }
+        catch
+        {
+            Write-Verbose $_
+            Write-Verbose "Caught exception with ieq filter, trying with q parameter"
+            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
+                                 -Parameters @{ q = $ReasonCode })
+        }
+        if (-not $local:ReasonCodes)
+        {
+            throw "Unable to find reason code matching '$ReasonCode'"
+        }
+        if ($local:ReasonCodes.Count -ne 1)
+        {
+            throw "Found $($local:ReasonCodes.Count) reason codes matching '$ReasonCode'"
+        }
+        $local:ReasonCodes[0].Id
+    }
+    else
+    {
+        $ReasonCode
+    }
+}
+
+<#
+.SYNOPSIS
+Get reason codes from Safeguard via the Web API.
+
+.DESCRIPTION
+Reason codes are used in access request workflows to require users to select
+a reason when requesting privileged access. This cmdlet returns all reason
+codes or a specific reason code by ID or name.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReasonCodeToGet
+An integer containing the ID of the reason code to get or a string containing the name.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardReasonCode -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardReasonCode "Maintenance Window"
+#>
+function Get-SafeguardReasonCode
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,Position=0)]
+        [object]$ReasonCodeToGet,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Parameters = $null
+    if ($Fields)
+    {
+        $local:Parameters = @{ fields = ($Fields -join ",") }
+    }
+
+    if ($PSBoundParameters.ContainsKey("ReasonCodeToGet"))
+    {
+        $local:Id = (Resolve-SafeguardReasonCodeId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ReasonCode $ReasonCodeToGet)
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes/$($local:Id)" -Parameters $local:Parameters
+    }
+    else
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" -Parameters $local:Parameters
+    }
+}
+
+<#
+.SYNOPSIS
+Search for a reason code in Safeguard via the Web API.
+
+.DESCRIPTION
+Search for reason codes by string query or by a filter. The search is
+performed across name and description fields when using SearchString. Use
+QueryFilter for SCIM-style server-side filtering.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER SearchString
+A string to search for in the reason code name or description.
+
+.PARAMETER QueryFilter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER OrderBy
+An array of the property names to order by.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Find-SafeguardReasonCode "maintenance"
+
+.EXAMPLE
+Find-SafeguardReasonCode -QueryFilter "Name contains 'emergency'"
+#>
+function Find-SafeguardReasonCode
+{
+    [CmdletBinding(DefaultParameterSetName="Search")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Search",Mandatory=$true,Position=0)]
+        [string]$SearchString,
+        [Parameter(ParameterSetName="Filter",Mandatory=$true)]
+        [string]$QueryFilter,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [string[]]$OrderBy
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Parameters = @{}
+    if ($SearchString)
+    {
+        $local:Parameters["q"] = $SearchString
+    }
+    if ($QueryFilter)
+    {
+        $local:Parameters["filter"] = $QueryFilter
+    }
+    if ($Fields)
+    {
+        $local:Parameters["fields"] = ($Fields -join ",")
+    }
+    if ($OrderBy)
+    {
+        $local:Parameters["orderby"] = ($OrderBy -join ",")
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" -Parameters $local:Parameters
+}
+
+<#
+.SYNOPSIS
+Create a new reason code in Safeguard via the Web API.
+
+.DESCRIPTION
+Create a new reason code that can be assigned to access request policies.
+Users will be required to select a reason code when requesting access via
+those policies.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Name
+A string containing the name of the reason code.
+
+.PARAMETER Description
+A string containing the description of the reason code.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+New-SafeguardReasonCode "Emergency Access" -Description "Unplanned emergency requiring immediate access"
+
+.EXAMPLE
+New-SafeguardReasonCode -Name "Maintenance Window" -Description "Scheduled maintenance window"
+#>
+function New-SafeguardReasonCode
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$Name,
+        [Parameter(Mandatory=$false)]
+        [string]$Description
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Body = @{
+        Name = $Name
+    }
+    if ($PSBoundParameters.ContainsKey("Description"))
+    {
+        $local:Body.Description = $Description
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "ReasonCodes" -Body $local:Body
+}
+
+<#
+.SYNOPSIS
+Edit an existing reason code in Safeguard via the Web API.
+
+.DESCRIPTION
+Edit an existing reason code. Use Get-SafeguardReasonCode to retrieve the
+object, modify its properties, and pass it to this cmdlet.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReasonCodeObject
+An object containing the reason code with updated properties.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+$rc = Get-SafeguardReasonCode "Maintenance Window"
+$rc.Description = "Updated description"
+Edit-SafeguardReasonCode $rc
+
+.EXAMPLE
+Get-SafeguardReasonCode 5 | Edit-SafeguardReasonCode
+#>
+function Edit-SafeguardReasonCode
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)]
+        [object]$ReasonCodeObject
+    )
+
+    begin
+    {
+        if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+        if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+    }
+
+    process
+    {
+        if (-not $ReasonCodeObject)
+        {
+            throw "ReasonCodeObject must not be null"
+        }
+        $local:Id = (Resolve-SafeguardReasonCodeId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ReasonCode $ReasonCodeObject)
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "ReasonCodes/$($local:Id)" -Body $ReasonCodeObject
+    }
+}
+
+<#
+.SYNOPSIS
+Remove a reason code from Safeguard via the Web API.
+
+.DESCRIPTION
+Remove a reason code from Safeguard. The reason code must not be assigned
+to any access policies.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER ReasonCodeToDelete
+An integer containing the ID of the reason code to remove or a string containing
+the name.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Remove-SafeguardReasonCode "Maintenance Window"
+
+.EXAMPLE
+Remove-SafeguardReasonCode 5
+#>
+function Remove-SafeguardReasonCode
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$ReasonCodeToDelete
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Id = (Resolve-SafeguardReasonCodeId -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure -ReasonCode $ReasonCodeToDelete)
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "ReasonCodes/$($local:Id)"
+}

--- a/src/runningtasks.psm1
+++ b/src/runningtasks.psm1
@@ -1,0 +1,184 @@
+<# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
+
+<#
+.SYNOPSIS
+Get running tasks from Safeguard via the Web API.
+
+.DESCRIPTION
+Get a list of currently running or recently completed tasks on the Safeguard
+appliance. Tasks include password checks, password changes, account discovery,
+asset discovery, SSH key operations, and more.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER TaskName
+A string containing the task name to filter by (e.g. TestConnection,
+CheckPassword, ChangePassword, DiscoverAccounts, DiscoverAssets).
+
+.PARAMETER TaskId
+A string containing the specific task ID to retrieve. Requires TaskName.
+
+.PARAMETER Fields
+An array of the property names to return.
+
+.PARAMETER Filter
+A string to pass to the -filter query parameter in the Safeguard Web API.
+
+.PARAMETER IncludeSubmitted
+Include tasks that have been submitted but not yet started.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardRunningTask
+
+.EXAMPLE
+Get-SafeguardRunningTask -TaskName CheckPassword
+
+.EXAMPLE
+Get-SafeguardRunningTask -TaskName TestConnection -TaskId "abc-123"
+#>
+function Get-SafeguardRunningTask
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false,Position=0)]
+        [ValidateSet("Unknown","TestConnection","CheckPassword","ChangePassword",
+            "InstallSshKey","ChangeSshKey","UpdateDependentAsset","DiscoverSshHostKey",
+            "DiscoverAccounts","DiscoverAssets","Archive","RestoreAccount","SuspendAccount",
+            "PasswordSyncAccounts","DiscoverServices","DirectoryAssetSync",
+            "DirectoryAssetDeleteSync","DirectoryProviderSync","DirectoryProviderDeleteSync",
+            "CheckSshKey","DiscoverSshKeys","SshKeySyncAccounts","LocalIdentityProviderSync",
+            "RevokeSshKey","RetrieveSshHostKey","CheckApiKey","ChangeApiKey",
+            "ElevateAccount","DemoteAccount","CheckFile","ChangeFile")]
+        [string]$TaskName,
+        [Parameter(Mandatory=$false)]
+        [string]$TaskId,
+        [Parameter(Mandatory=$false)]
+        [string[]]$Fields,
+        [Parameter(Mandatory=$false)]
+        [string]$Filter,
+        [Parameter(Mandatory=$false)]
+        [switch]$IncludeSubmitted
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($TaskId -and -not $TaskName)
+    {
+        throw "TaskName is required when specifying TaskId"
+    }
+
+    $local:RelPath = "RunningTasks"
+    if ($TaskName)
+    {
+        $local:RelPath = "$($local:RelPath)/$TaskName"
+        if ($TaskId)
+        {
+            $local:RelPath = "$($local:RelPath)/$TaskId"
+        }
+    }
+
+    $local:Parameters = @{}
+    if ($Fields)
+    {
+        $local:Parameters["fields"] = ($Fields -join ",")
+    }
+    if ($Filter)
+    {
+        $local:Parameters["filter"] = $Filter
+    }
+    if ($IncludeSubmitted)
+    {
+        $local:Parameters["includeSubmitted"] = $true
+    }
+    if ($local:Parameters.Count -eq 0)
+    {
+        $local:Parameters = $null
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelPath -Parameters $local:Parameters
+}
+
+<#
+.SYNOPSIS
+Cancel a running task in Safeguard via the Web API.
+
+.DESCRIPTION
+Cancel a queued or running task on the Safeguard appliance. Both the task
+name and task ID are required to identify the task to cancel.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER TaskName
+A string containing the task name (e.g. TestConnection, CheckPassword).
+
+.PARAMETER TaskId
+A string containing the task ID to cancel.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Stop-SafeguardRunningTask -TaskName CheckPassword -TaskId "abc-123"
+
+.EXAMPLE
+Stop-SafeguardRunningTask TestConnection "def-456"
+#>
+function Stop-SafeguardRunningTask
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [ValidateSet("Unknown","TestConnection","CheckPassword","ChangePassword",
+            "InstallSshKey","ChangeSshKey","UpdateDependentAsset","DiscoverSshHostKey",
+            "DiscoverAccounts","DiscoverAssets","Archive","RestoreAccount","SuspendAccount",
+            "PasswordSyncAccounts","DiscoverServices","DirectoryAssetSync",
+            "DirectoryAssetDeleteSync","DirectoryProviderSync","DirectoryProviderDeleteSync",
+            "CheckSshKey","DiscoverSshKeys","SshKeySyncAccounts","LocalIdentityProviderSync",
+            "RevokeSshKey","RetrieveSshHostKey","CheckApiKey","ChangeApiKey",
+            "ElevateAccount","DemoteAccount","CheckFile","ChangeFile")]
+        [string]$TaskName,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$TaskId
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core DELETE "RunningTasks/$TaskName/$TaskId"
+}

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -11,7 +11,7 @@
 RootModule = 'safeguard-ps.psm1'
 
 # Version number of this module.
-ModuleVersion = '8.2.99999'
+ModuleVersion = '8.3.99999'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -308,6 +308,7 @@ FunctionsToExport = @(
     # auditlog.psm1
     'Get-SafeguardAuditLog',
     'Get-SafeguardAuditLogAccessRequestActivity','Get-SafeguardAuditLogAccessRequestSession',
+    'Get-SafeguardAuditLogObjectChange','Get-SafeguardAuditLogDiscoveredItem',
     # tags.psm1
     'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag',
     'Add-SafeguardAssetTag', 'Remove-SafeguardAssetTag',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -307,6 +307,7 @@ FunctionsToExport = @(
     'Get-SafeguardSyslogServer','New-SafeguardSyslogServer','Remove-SafeguardSyslogServer','Edit-SafeguardSyslogServer',
     # auditlog.psm1
     'Get-SafeguardAuditLog',
+    'Get-SafeguardAuditLogAccessRequestActivity','Get-SafeguardAuditLogAccessRequestSession',
     # tags.psm1
     'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag',
     'Add-SafeguardAssetTag', 'Remove-SafeguardAssetTag',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -312,6 +312,9 @@ FunctionsToExport = @(
     'Get-SafeguardAuditLogPlatformScript',
     'Get-SafeguardAuditLogMaintenanceConfig','Set-SafeguardAuditLogMaintenanceConfig',
     'Invoke-SafeguardAuditLogMaintenance','Get-SafeguardAuditLogSigningCertificateHistory',
+    'Get-SafeguardScheduledAuditLogReport','New-SafeguardScheduledAuditLogReport',
+    'Edit-SafeguardScheduledAuditLogReport','Remove-SafeguardScheduledAuditLogReport',
+    'Invoke-SafeguardScheduledAuditLogReport',
     # tags.psm1
     'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag',
     'Add-SafeguardAssetTag', 'Remove-SafeguardAssetTag',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -309,6 +309,7 @@ FunctionsToExport = @(
     'Get-SafeguardAuditLog',
     'Get-SafeguardAuditLogAccessRequestActivity','Get-SafeguardAuditLogAccessRequestSession',
     'Get-SafeguardAuditLogObjectChange','Get-SafeguardAuditLogDiscoveredItem',
+    'Get-SafeguardAuditLogPlatformScript',
     # tags.psm1
     'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag',
     'Add-SafeguardAssetTag', 'Remove-SafeguardAssetTag',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -102,7 +102,9 @@ NestedModules = @(
     'syslog.psm1',
     'auditlog.psm1',
     'tags.psm1',
-    'customplatforms.psm1'
+    'customplatforms.psm1',
+    'reasoncodes.psm1',
+    'runningtasks.psm1'
     )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -292,6 +294,7 @@ FunctionsToExport = @(
     'Get-SafeguardReportAssetAccountPasswordHistory',
     # setting.psm1
     'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting','Get-SafeguardCoreSetting','Set-SafeguardCoreSetting',
+    'Get-SafeguardDailyMessage','Set-SafeguardDailyMessage','Get-SafeguardLoginMessage','Set-SafeguardLoginMessage',
     # deleted.psm1
     'Get-SafeguardDeletedAsset','Remove-SafeguardDeletedAsset','Restore-SafeguardDeletedAsset',
     'Get-SafeguardDeletedAssetAccount','Remove-SafeguardDeletedAssetAccount','Restore-SafeguardDeletedAssetAccount',
@@ -320,7 +323,12 @@ FunctionsToExport = @(
     'Test-SafeguardCustomPlatformScript'
     'Get-SafeguardCustomPlatformScriptParameter'
     'New-SafeguardCustomPlatformAsset'
-    'Set-SafeguardCustomPlatformAssetParameter'
+    'Set-SafeguardCustomPlatformAssetParameter',
+    # reasoncodes.psm1
+    'Get-SafeguardReasonCode','Find-SafeguardReasonCode','New-SafeguardReasonCode',
+    'Edit-SafeguardReasonCode','Remove-SafeguardReasonCode',
+    # runningtasks.psm1
+    'Get-SafeguardRunningTask','Stop-SafeguardRunningTask'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -335,7 +335,7 @@ FunctionsToExport = @(
     'Set-SafeguardCustomPlatformAssetParameter',
     # reasoncodes.psm1
     'Get-SafeguardReasonCode','Find-SafeguardReasonCode','New-SafeguardReasonCode',
-    'Edit-SafeguardReasonCode','Remove-SafeguardReasonCode',
+    'Edit-SafeguardReasonCode','Remove-SafeguardReasonCode','Get-SafeguardReasonCodeScope',
     # runningtasks.psm1
     'Get-SafeguardRunningTask','Stop-SafeguardRunningTask'
 )

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -310,6 +310,8 @@ FunctionsToExport = @(
     'Get-SafeguardAuditLogAccessRequestActivity','Get-SafeguardAuditLogAccessRequestSession',
     'Get-SafeguardAuditLogObjectChange','Get-SafeguardAuditLogDiscoveredItem',
     'Get-SafeguardAuditLogPlatformScript',
+    'Get-SafeguardAuditLogMaintenanceConfig','Set-SafeguardAuditLogMaintenanceConfig',
+    'Invoke-SafeguardAuditLogMaintenance','Get-SafeguardAuditLogSigningCertificateHistory',
     # tags.psm1
     'Get-SafeguardTag', 'Get-SafeguardTagOccurrence', 'Get-SafeguardAssetTag', 'Update-SafeguardAssetTag',
     'Add-SafeguardAssetTag', 'Remove-SafeguardAssetTag',

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -295,6 +295,7 @@ FunctionsToExport = @(
     # setting.psm1
     'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting','Get-SafeguardCoreSetting','Set-SafeguardCoreSetting',
     'Get-SafeguardDailyMessage','Set-SafeguardDailyMessage','Get-SafeguardLoginMessage','Set-SafeguardLoginMessage',
+    'Get-SafeguardUserPasswordRule','Set-SafeguardUserPasswordRule','New-SafeguardUserPassword','Test-SafeguardUserPassword',
     # deleted.psm1
     'Get-SafeguardDeletedAsset','Remove-SafeguardDeletedAsset','Restore-SafeguardDeletedAsset',
     'Get-SafeguardDeletedAssetAccount','Remove-SafeguardDeletedAssetAccount','Restore-SafeguardDeletedAssetAccount',

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1512,6 +1512,13 @@ function Connect-Safeguard
                     }
                     catch
                     {
+                        if ($_.Exception.Message -match "resource owner" -or
+                            ($_.ErrorDetails -and $_.ErrorDetails.Message -match "resource owner"))
+                        {
+                            throw "Resource Owner password grant is disabled on this appliance. " +
+                                  "Use Connect-Safeguard with -Pkce for non-interactive login, " +
+                                  "or -Browser for interactive browser-based login."
+                        }
                         Import-Module -Name "$PSScriptRoot\sg-utilities.psm1" -Scope Local
                         Out-SafeguardExceptionIfPossible $_
                     }

--- a/src/settings.psm1
+++ b/src/settings.psm1
@@ -539,3 +539,442 @@ function Set-SafeguardLoginMessage
         Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "LoginMessage" -Body $local:Body
     }
 }
+
+
+<#
+.SYNOPSIS
+Get the user password rule from Safeguard via the Web API.
+
+.DESCRIPTION
+Get the password rule that governs Safeguard user passwords. This is the
+appliance-wide password policy for local Safeguard user accounts (not managed
+asset account passwords, which are controlled by account password rules under
+asset partitions).
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardUserPasswordRule
+
+.EXAMPLE
+Get-SafeguardUserPasswordRule -Appliance 10.5.32.54 -Insecure
+#>
+function Get-SafeguardUserPasswordRule
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "UserPasswordRule"
+}
+
+
+<#
+.SYNOPSIS
+Set the user password rule in Safeguard via the Web API.
+
+.DESCRIPTION
+Update the password rule that governs Safeguard user passwords. You can pass
+individual attributes to modify specific settings, or pass a full rule object
+retrieved from Get-SafeguardUserPasswordRule. When using individual attributes,
+the current rule is fetched, your changes are merged, and the result is saved.
+To clear nullable properties (such as MaxConsecutive* fields), use the
+-RuleObject parameter with the desired values set to null.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Name
+A string containing the name of the password rule (max 255 characters).
+
+.PARAMETER Description
+A string containing the description of the password rule.
+
+.PARAMETER MinCharacters
+An integer for the minimum password length (min 3, max 255).
+
+.PARAMETER MaxCharacters
+An integer for the maximum password length (min 3, max 255).
+
+.PARAMETER AllowUppercase
+A boolean for whether to allow uppercase characters.
+
+.PARAMETER MinUppercase
+An integer for the minimum number of uppercase characters.
+
+.PARAMETER MaxConsecutiveUppercase
+An integer for the maximum number of consecutive uppercase characters.
+
+.PARAMETER InvalidUppercaseChars
+A string array of uppercase characters that may not be used.
+
+.PARAMETER AllowLowercase
+A boolean for whether to allow lowercase characters.
+
+.PARAMETER MinLowercase
+An integer for the minimum number of lowercase characters.
+
+.PARAMETER MaxConsecutiveLowercase
+An integer for the maximum number of consecutive lowercase characters.
+
+.PARAMETER InvalidLowercaseChars
+A string containing invalid lowercase characters. Each character is split
+into individual array elements.
+
+.PARAMETER AllowNumeric
+A boolean for whether to allow numeric characters.
+
+.PARAMETER MinNumeric
+An integer for the minimum number of numeric characters.
+
+.PARAMETER MaxConsecutiveNumeric
+An integer for the maximum number of consecutive numeric characters.
+
+.PARAMETER InvalidNumericChars
+A string containing invalid numeric characters. Each character is split
+into individual array elements.
+
+.PARAMETER AllowSymbols
+A boolean for whether to allow non-alphanumeric (symbol) characters.
+
+.PARAMETER MinSymbols
+An integer for the minimum number of symbol characters.
+
+.PARAMETER MaxConsecutiveSymbols
+An integer for the maximum number of consecutive symbol characters.
+
+.PARAMETER InvalidSymbolChars
+A string containing symbol characters to exclude. Mutually exclusive with
+AllowedSymbolChars.
+
+.PARAMETER AllowedSymbolChars
+A string containing the only symbol characters to allow. Mutually exclusive
+with InvalidSymbolChars.
+
+.PARAMETER AllowedFirstCharType
+The type of character allowed as the first character (All, AlphaNumeric,
+or Alphabetic).
+
+.PARAMETER AllowedLastCharType
+The type of character allowed as the last character (All, AlphaNumeric,
+or Alphabetic).
+
+.PARAMETER MaxConsecutiveAlpha
+An integer for the maximum number of consecutive alphabetic characters.
+
+.PARAMETER MaxConsecutiveAlphanumeric
+An integer for the maximum number of consecutive alphanumeric characters.
+
+.PARAMETER RepeatedCharRestriction
+The repeated character restriction (NotSpecified,
+NoConsecutiveRepeatedCharacters, NoRepeatedCharacters,
+AllowRepeatedCharacters).
+
+.PARAMETER RuleObject
+An object containing the full user password rule. Use
+Get-SafeguardUserPasswordRule to retrieve the current object, modify it,
+and pass it to this parameter.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardUserPasswordRule -MinCharacters 14 -MaxCharacters 64
+
+.EXAMPLE
+$rule = Get-SafeguardUserPasswordRule
+$rule.MinCharacters = 16
+Set-SafeguardUserPasswordRule -RuleObject $rule
+#>
+function Set-SafeguardUserPasswordRule
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$Name,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$Description,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MinCharacters,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxCharacters,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [bool]$AllowUppercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MinUppercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveUppercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string[]]$InvalidUppercaseChars,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [bool]$AllowLowercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MinLowercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveLowercase,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$InvalidLowercaseChars,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [bool]$AllowNumeric,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MinNumeric,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveNumeric,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$InvalidNumericChars,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [bool]$AllowSymbols,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MinSymbols,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveSymbols,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$InvalidSymbolChars,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$AllowedSymbolChars,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [ValidateSet("All", "AlphaNumeric", "Alphabetic", IgnoreCase=$true)]
+        [string]$AllowedFirstCharType,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [ValidateSet("All", "AlphaNumeric", "Alphabetic", IgnoreCase=$true)]
+        [string]$AllowedLastCharType,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveAlpha,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [int]$MaxConsecutiveAlphanumeric,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [ValidateSet("NotSpecified", "NoConsecutiveRepeatedCharacters", "NoRepeatedCharacters", "AllowRepeatedCharacters", IgnoreCase=$true)]
+        [string]$RepeatedCharRestriction,
+        [Parameter(ParameterSetName="Object",Mandatory=$true,Position=0)]
+        [object]$RuleObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PsCmdlet.ParameterSetName -eq "Object")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "UserPasswordRule" -Body $RuleObject
+    }
+    else
+    {
+        if ($PSBoundParameters.ContainsKey("InvalidSymbolChars") -and $PSBoundParameters.ContainsKey("AllowedSymbolChars"))
+        {
+            throw "InvalidSymbolChars and AllowedSymbolChars are mutually exclusive."
+        }
+
+        $local:RuleObj = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "UserPasswordRule")
+
+        if ($PSBoundParameters.ContainsKey("Name")) { $local:RuleObj.Name = $Name }
+        if ($PSBoundParameters.ContainsKey("Description")) { $local:RuleObj.Description = $Description }
+        if ($PSBoundParameters.ContainsKey("MinCharacters")) { $local:RuleObj.MinCharacters = $MinCharacters }
+        if ($PSBoundParameters.ContainsKey("MaxCharacters")) { $local:RuleObj.MaxCharacters = $MaxCharacters }
+        if ($PSBoundParameters.ContainsKey("AllowUppercase")) { $local:RuleObj.AllowUppercaseCharacters = $AllowUppercase }
+        if ($PSBoundParameters.ContainsKey("MinUppercase")) { $local:RuleObj.MinUppercaseCharacters = $MinUppercase }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveUppercase")) { $local:RuleObj.MaxConsecutiveUppercaseCharacters = $MaxConsecutiveUppercase }
+        if ($PSBoundParameters.ContainsKey("InvalidUppercaseChars")) { $local:RuleObj.InvalidUppercaseCharacters = $InvalidUppercaseChars }
+        if ($PSBoundParameters.ContainsKey("AllowLowercase")) { $local:RuleObj.AllowLowercaseCharacters = $AllowLowercase }
+        if ($PSBoundParameters.ContainsKey("MinLowercase")) { $local:RuleObj.MinLowercaseCharacters = $MinLowercase }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveLowercase")) { $local:RuleObj.MaxConsecutiveLowercaseCharacters = $MaxConsecutiveLowercase }
+        if ($PSBoundParameters.ContainsKey("InvalidLowercaseChars")) { $local:RuleObj.InvalidLowercaseCharacters = [string[]]($InvalidLowercaseChars -split "(?<=.)(?=.)") }
+        if ($PSBoundParameters.ContainsKey("AllowNumeric")) { $local:RuleObj.AllowNumericCharacters = $AllowNumeric }
+        if ($PSBoundParameters.ContainsKey("MinNumeric")) { $local:RuleObj.MinNumericCharacters = $MinNumeric }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveNumeric")) { $local:RuleObj.MaxConsecutiveNumericCharacters = $MaxConsecutiveNumeric }
+        if ($PSBoundParameters.ContainsKey("InvalidNumericChars")) { $local:RuleObj.InvalidNumericCharacters = [string[]]($InvalidNumericChars -split "(?<=.)(?=.)") }
+        if ($PSBoundParameters.ContainsKey("AllowSymbols")) { $local:RuleObj.AllowNonAlphaNumericCharacters = $AllowSymbols }
+        if ($PSBoundParameters.ContainsKey("MinSymbols")) { $local:RuleObj.MinNonAlphaNumericCharacters = $MinSymbols }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveSymbols")) { $local:RuleObj.MaxConsecutiveNonAlphaNumericCharacters = $MaxConsecutiveSymbols }
+        if ($PSBoundParameters.ContainsKey("InvalidSymbolChars"))
+        {
+            $local:RuleObj.InvalidNonAlphaNumericCharacters = [string[]]($InvalidSymbolChars -split "(?<=.)(?=.)")
+            $local:RuleObj.NonAlphaNumericRestrictionType = "Exclude"
+        }
+        if ($PSBoundParameters.ContainsKey("AllowedSymbolChars"))
+        {
+            $local:RuleObj.AllowedNonAlphaNumericCharacters = [string[]]($AllowedSymbolChars -split "(?<=.)(?=.)")
+            $local:RuleObj.NonAlphaNumericRestrictionType = "Include"
+        }
+        if ($PSBoundParameters.ContainsKey("AllowedFirstCharType")) { $local:RuleObj.AllowedFirstCharacterType = $AllowedFirstCharType }
+        if ($PSBoundParameters.ContainsKey("AllowedLastCharType")) { $local:RuleObj.AllowedLastCharacterType = $AllowedLastCharType }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveAlpha")) { $local:RuleObj.MaxConsecutiveAlphabeticCharacters = $MaxConsecutiveAlpha }
+        if ($PSBoundParameters.ContainsKey("MaxConsecutiveAlphanumeric")) { $local:RuleObj.MaxConsecutiveAlphaNumericCharacters = $MaxConsecutiveAlphanumeric }
+        if ($PSBoundParameters.ContainsKey("RepeatedCharRestriction")) { $local:RuleObj.RepeatedCharacterRestriction = $RepeatedCharRestriction }
+
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "UserPasswordRule" -Body $local:RuleObj
+    }
+}
+
+
+<#
+.SYNOPSIS
+Generate a random password using the Safeguard user password rule via the
+Web API.
+
+.DESCRIPTION
+Generate a random password that complies with the current user password rule
+configured on the Safeguard appliance. Optionally pass a custom rule object
+to generate a password using different constraints without modifying the
+saved rule.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER RuleObject
+An optional UserPasswordRule object to use for generation instead of the
+currently saved rule. Retrieve with Get-SafeguardUserPasswordRule.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A string containing the generated password.
+
+.EXAMPLE
+New-SafeguardUserPassword
+
+.EXAMPLE
+$rule = Get-SafeguardUserPasswordRule
+$rule.MinCharacters = 20
+New-SafeguardUserPassword -RuleObject $rule
+#>
+function New-SafeguardUserPassword
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [object]$RuleObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if (-not $RuleObject)
+    {
+        $RuleObject = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "UserPasswordRule")
+    }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core POST "UserPasswordRule/GeneratePassword" -Body $RuleObject
+}
+
+
+<#
+.SYNOPSIS
+Validate a password against the Safeguard user password rule via the Web API.
+
+.DESCRIPTION
+Test whether a proposed password meets the requirements of the user password
+rule configured on the Safeguard appliance. Returns $true if the password is
+valid, or $false if it does not meet the rule requirements. Other errors
+(authentication failures, network errors) are thrown as exceptions.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Password
+A SecureString containing the password to validate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A boolean indicating whether the password is valid.
+
+.EXAMPLE
+Test-SafeguardUserPassword -Password (ConvertTo-SecureString "MyP@ssw0rd123" -AsPlainText -Force)
+
+.EXAMPLE
+Test-SafeguardUserPassword -Password (Read-Host "Password" -AsSecureString)
+#>
+function Test-SafeguardUserPassword
+{
+    [CmdletBinding()]
+    [OutputType([bool])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true,Position=0)]
+        [SecureString]$Password
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:PasswordPlainText = [System.Net.NetworkCredential]::new("", $Password).Password
+
+    try
+    {
+        $null = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            POST "UserPasswordRule/ValidatePassword" -JsonBody (ConvertTo-Json $local:PasswordPlainText)
+        $true
+    }
+    catch
+    {
+        if ($_.Exception.HttpStatusCode -eq 400 -and $_.Exception.ErrorCode -eq 60247)
+        {
+            $false
+        }
+        else
+        {
+            throw
+        }
+    }
+}

--- a/src/settings.psm1
+++ b/src/settings.psm1
@@ -278,3 +278,264 @@ function Set-SafeguardCoreSetting
 	$SettingName = $SettingObject.Name
 	Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Settings/$SettingName" -Body $SettingObject
 }
+
+
+<#
+.SYNOPSIS
+Get the Message of the Day from Safeguard via the Web API.
+
+.DESCRIPTION
+Get the daily message (Message of the Day) configured on the Safeguard
+appliance. This message is displayed to users after login.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardDailyMessage -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardDailyMessage
+#>
+function Get-SafeguardDailyMessage
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DailyMessage"
+}
+
+
+<#
+.SYNOPSIS
+Set the Message of the Day in Safeguard via the Web API.
+
+.DESCRIPTION
+Update the daily message (Message of the Day) on the Safeguard appliance.
+You can pass individual attributes or a full message object retrieved from
+Get-SafeguardDailyMessage.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Message
+A string containing the message text.
+
+.PARAMETER Subject
+A string containing the message subject line.
+
+.PARAMETER UseRss
+Whether to use an RSS feed for the daily message.
+
+.PARAMETER Address
+The RSS feed URL when UseRss is enabled.
+
+.PARAMETER MessageObject
+An object containing the full daily message configuration. Use
+Get-SafeguardDailyMessage to retrieve the current object, modify it, and
+pass it to this parameter.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardDailyMessage -Message "System maintenance tonight at 10 PM"
+
+.EXAMPLE
+Set-SafeguardDailyMessage -Message "Check the feed" -UseRss $true -Address "https://rss.example.com/feed"
+
+.EXAMPLE
+$msg = Get-SafeguardDailyMessage
+$msg.Message = "Updated message"
+Set-SafeguardDailyMessage -MessageObject $msg
+#>
+function Set-SafeguardDailyMessage
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false,Position=0)]
+        [string]$Message,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$Subject,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [bool]$UseRss,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$false)]
+        [string]$Address,
+        [Parameter(ParameterSetName="Object",Mandatory=$true,Position=0)]
+        [object]$MessageObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PsCmdlet.ParameterSetName -eq "Object")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DailyMessage" -Body $MessageObject
+    }
+    else
+    {
+        $local:Body = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "DailyMessage")
+        if ($PSBoundParameters.ContainsKey("Message")) { $local:Body.Message = $Message }
+        if ($PSBoundParameters.ContainsKey("Subject")) { $local:Body.Subject = $Subject }
+        if ($PSBoundParameters.ContainsKey("UseRss")) { $local:Body.UseRss = $UseRss }
+        if ($PSBoundParameters.ContainsKey("Address")) { $local:Body.Address = $Address }
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "DailyMessage" -Body $local:Body
+    }
+}
+
+
+<#
+.SYNOPSIS
+Get the login message from Safeguard via the Web API.
+
+.DESCRIPTION
+Get the login message (login banner) configured on the Safeguard appliance.
+This message is displayed on the login page before authentication.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Get-SafeguardLoginMessage -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardLoginMessage
+#>
+function Get-SafeguardLoginMessage
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "LoginMessage"
+}
+
+
+<#
+.SYNOPSIS
+Set the login message in Safeguard via the Web API.
+
+.DESCRIPTION
+Update the login message (login banner) on the Safeguard appliance. You can
+pass a simple message string or a full message object retrieved from
+Get-SafeguardLoginMessage.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER Message
+A string containing the login message text.
+
+.PARAMETER MessageObject
+An object containing the full login message configuration. Use
+Get-SafeguardLoginMessage to retrieve the current object, modify it, and
+pass it to this parameter.
+
+.INPUTS
+None.
+
+.OUTPUTS
+JSON response from Safeguard Web API.
+
+.EXAMPLE
+Set-SafeguardLoginMessage -Message "Authorized users only. All access is monitored."
+
+.EXAMPLE
+$msg = Get-SafeguardLoginMessage
+$msg.Message = "Updated banner"
+Set-SafeguardLoginMessage -MessageObject $msg
+#>
+function Set-SafeguardLoginMessage
+{
+    [CmdletBinding(DefaultParameterSetName="Attributes")]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(ParameterSetName="Attributes",Mandatory=$true,Position=0)]
+        [string]$Message,
+        [Parameter(ParameterSetName="Object",Mandatory=$true,Position=0)]
+        [object]$MessageObject
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ($PsCmdlet.ParameterSetName -eq "Object")
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "LoginMessage" -Body $MessageObject
+    }
+    else
+    {
+        $local:Body = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "LoginMessage")
+        $local:Body.Message = $Message
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "LoginMessage" -Body $local:Body
+    }
+}

--- a/test/Suites/Suite-AuditLog.ps1
+++ b/test/Suites/Suite-AuditLog.ps1
@@ -1,0 +1,283 @@
+@{
+    Name        = "AuditLog"
+    Description = "Tests audit log list queries, bug fixes, PlatformScripts, and -Id detail lookups"
+    Tags        = @("auditlog", "core")
+
+    Setup = {
+        param($Context)
+        # No special setup needed -- audit logs are always populated on an active appliance
+    }
+
+    Execute = {
+        param($Context)
+
+        # --- Basic list queries (existing behavior, verify no regressions) ---
+
+        Test-SgPsAssert "List Appliance audit log (default 1 day)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Appliance)
+            $logs -is [Array] -and $logs.Count -gt 0
+        }
+
+        Test-SgPsAssert "List Logins audit log (default 1 day)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Logins)
+            $logs -is [Array] -and $logs.Count -gt 0
+        }
+
+        Test-SgPsAssert "List ObjectChanges audit log (default 1 day)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure ObjectChanges)
+            $logs -is [Array] -and $logs.Count -gt 0
+        }
+
+        Test-SgPsAssert "List AllActivity audit log (default 1 day)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure AllActivity)
+            $logs -is [Array] -and $logs.Count -gt 0
+        }
+
+        # --- Bug fix: DiscoveryServices URL was AuditLog/Services, now AuditLog/Discovery/Services ---
+
+        Test-SgPsAssert "DiscoveryServices returns without error (bug fix)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure DiscoveryServices)
+            $logs -is [Array]
+        }
+
+        # --- Bug fix: DiscoverySshKeys URL was AuditLog/SshKeys, now AuditLog/Discovery/SshKeys ---
+
+        Test-SgPsAssert "DiscoverySshKeys returns without error (bug fix)" {
+            $logs = @(Get-SafeguardAuditLog -Insecure DiscoverySshKeys)
+            $logs -is [Array]
+        }
+
+        # --- New log type: PlatformScripts ---
+
+        Test-SgPsAssert "PlatformScripts log type is accepted" {
+            $logs = @(Get-SafeguardAuditLog -Insecure PlatformScripts)
+            $logs -is [Array]
+        }
+
+        # --- Time range parameter sets ---
+
+        Test-SgPsAssert "Query with -Hours parameter" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Appliance -Hours 2)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "Query with -Minutes parameter" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Appliance -Minutes 30)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "Query with -StartDate and -Days" {
+            $start = (Get-Date).AddDays(-2)
+            $logs = @(Get-SafeguardAuditLog -Insecure Appliance -StartDate $start -Days 1)
+            $logs -is [Array]
+        }
+
+        # --- Fields filter ---
+
+        Test-SgPsAssert "Fields filter limits returned properties" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Logins -Fields "LogId","LogTime","EventName" -Minutes 60)
+            $logs -is [Array] -and ($logs.Count -eq 0 -or $null -ne $logs[0].LogId)
+        }
+
+        # --- JsonOutput ---
+
+        Test-SgPsAssert "JsonOutput returns a string" {
+            $json = Get-SafeguardAuditLog -Insecure Appliance -Minutes 10 -JsonOutput
+            $json -is [string]
+        }
+
+        # --- CsvOutput ---
+
+        Test-SgPsAssert "CsvOutput returns CSV data" {
+            $csv = Get-SafeguardAuditLog -Insecure Appliance -Minutes 10 -CsvOutput
+            # CSV comes back as a string; verify it is not empty and contains a header-like pattern
+            $null -ne $csv -and $csv.Length -gt 0
+        }
+
+        # --- QueryFilter ---
+
+        Test-SgPsAssert "QueryFilter filters results" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Logins `
+                -QueryFilter "EventName eq 'UserAuthenticated'" -Hours 12)
+            $logs -is [Array]
+        }
+
+        # --- Detail lookup by Id (deterministic: fetch list first, then use first entry's ID) ---
+        # Note: Do not use @() wrapping here -- Invoke-SafeguardMethod returns Object[]
+        # and @() double-wraps it into a 1-element array containing the inner array.
+
+        Test-SgPsAssert "Detail lookup for Logins by Id" {
+            $result = Get-SafeguardAuditLog -Insecure Logins -Minutes 60
+            if ($null -eq $result)
+            {
+                $result = Get-SafeguardAuditLog -Insecure Logins -Days 7
+            }
+            if ($null -ne $result)
+            {
+                $entry = if ($result -is [Array]) { $result[0] } else { $result }
+                $logId = [string]$entry.LogId
+                $detail = Get-SafeguardAuditLog -Insecure Logins -Id $logId
+                $null -ne $detail -and $detail.LogId -eq $logId
+            }
+            else
+            {
+                Write-Host "  (skipped -- no login audit data available)"
+                $true
+            }
+        }
+
+        Test-SgPsAssert "Detail lookup for Appliance by Id" {
+            $result = Get-SafeguardAuditLog -Insecure Appliance -Minutes 60
+            if ($null -eq $result)
+            {
+                $result = Get-SafeguardAuditLog -Insecure Appliance -Days 7
+            }
+            if ($null -ne $result)
+            {
+                $entry = if ($result -is [Array]) { $result[0] } else { $result }
+                $logId = [string]$entry.LogId
+                $detail = Get-SafeguardAuditLog -Insecure Appliance -Id $logId
+                $null -ne $detail -and $detail.LogId -eq $logId
+            }
+            else
+            {
+                Write-Host "  (skipped -- no appliance audit data available)"
+                $true
+            }
+        }
+
+        Test-SgPsAssert "Detail lookup for Patches by Id" {
+            $result = Get-SafeguardAuditLog -Insecure Patches -Days 30
+            $hasData = $null -ne $result -and (
+                ($result -is [Array] -and $result.Count -gt 0) -or
+                ($result -isnot [Array])
+            )
+            if ($hasData)
+            {
+                $entry = if ($result -is [Array]) { $result[0] } else { $result }
+                $logId = [string]$entry.LogId
+                $detail = Get-SafeguardAuditLog -Insecure Patches -Id $logId
+                $null -ne $detail -and $detail.LogId -eq $logId
+            }
+            else
+            {
+                Write-Host "  (skipped -- no patch audit data available)"
+                $true
+            }
+        }
+
+        Test-SgPsAssert "Detail lookup with Fields filter" {
+            $result = Get-SafeguardAuditLog -Insecure Logins -Minutes 60
+            if ($null -eq $result)
+            {
+                $result = Get-SafeguardAuditLog -Insecure Logins -Days 7
+            }
+            if ($null -ne $result)
+            {
+                $entry = if ($result -is [Array]) { $result[0] } else { $result }
+                $logId = [string]$entry.LogId
+                $detail = Get-SafeguardAuditLog -Insecure Logins -Id $logId `
+                    -Fields "LogId","EventName"
+                $null -ne $detail -and $detail.LogId -eq $logId
+            }
+            else
+            {
+                Write-Host "  (skipped -- no login audit data available)"
+                $true
+            }
+        }
+
+        # --- Error cases: -Id with unsupported log types ---
+
+        Test-SgPsAssert "Throws when -Id used with ObjectChanges (hierarchical)" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLog -Insecure ObjectChanges -Id "fake"
+            }
+            catch { $threw = $_ -match "hierarchical" }
+            $threw
+        }
+
+        Test-SgPsAssert "Throws when -Id used with CredentialManagement (hierarchical)" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLog -Insecure CredentialManagement -Id "fake"
+            }
+            catch { $threw = $_ -match "hierarchical" }
+            $threw
+        }
+
+        Test-SgPsAssert "Throws when -Id used with PlatformScripts (hierarchical)" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLog -Insecure PlatformScripts -Id "fake"
+            }
+            catch { $threw = $_ -match "hierarchical" }
+            $threw
+        }
+
+        Test-SgPsAssert "Throws when -Id used with AllActivity (no detail endpoint)" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLog -Insecure AllActivity -Id "fake"
+            }
+            catch { $threw = $_ -match "hierarchical" }
+            $threw
+        }
+
+        Test-SgPsAssert "Throws when -Id used with Maintenance (config only)" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLog -Insecure Maintenance -Id "fake"
+            }
+            catch { $threw = $_ -match "hierarchical" }
+            $threw
+        }
+
+        # --- Other log types that should still work ---
+
+        Test-SgPsAssert "DiscoveryAccounts returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure DiscoveryAccounts)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "DiscoveryAssets returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure DiscoveryAssets)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "Licenses returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Licenses)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "DirectorySync returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure DirectorySync)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "Archives returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure Archives)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "AccessRequests returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure AccessRequests)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "AccessRequestActivities returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure AccessRequestActivities)
+            $logs -is [Array]
+        }
+
+        Test-SgPsAssert "AccessRequestSessions returns without error" {
+            $logs = @(Get-SafeguardAuditLog -Insecure AccessRequestSessions)
+            $logs -is [Array]
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-AuditLogAccessRequests.ps1
+++ b/test/Suites/Suite-AuditLogAccessRequests.ps1
@@ -1,0 +1,273 @@
+@{
+    Name        = "AuditLogAccessRequests"
+    Description = "Tests access request activity and session audit log drill-down cmdlets"
+    Tags        = @("auditlog", "accessrequests")
+
+    Setup = {
+        param($Context)
+        # No special setup needed -- audit logs are read-only
+        # Capture whether access request data exists for conditional drill-down tests
+        $activities = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+            -StartDate (Get-Date).AddDays(-90)
+        if ($null -ne $activities -and $activities -is [Array] -and $activities.Count -gt 0)
+        {
+            $Context.SuiteData["HasActivityData"] = $true
+            $Context.SuiteData["FirstActivity"] = $activities[0]
+        }
+        elseif ($null -ne $activities -and $activities -isnot [Array])
+        {
+            $Context.SuiteData["HasActivityData"] = $true
+            $Context.SuiteData["FirstActivity"] = $activities
+        }
+        else
+        {
+            $Context.SuiteData["HasActivityData"] = $false
+        }
+
+        $sessions = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+            -StartDate (Get-Date).AddDays(-90)
+        if ($null -ne $sessions -and $sessions -is [Array] -and $sessions.Count -gt 0)
+        {
+            $Context.SuiteData["HasSessionData"] = $true
+            $Context.SuiteData["FirstSession"] = $sessions[0]
+        }
+        elseif ($null -ne $sessions -and $sessions -isnot [Array])
+        {
+            $Context.SuiteData["HasSessionData"] = $true
+            $Context.SuiteData["FirstSession"] = $sessions
+        }
+        else
+        {
+            $Context.SuiteData["HasSessionData"] = $false
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        # =======================================================
+        # Get-SafeguardAuditLogAccessRequestActivity -- List mode
+        # =======================================================
+
+        Test-SgPsAssert "Activity list returns array (default)" {
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure
+            # Empty array or populated array are both valid
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Activity list with StartDate" {
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -StartDate (Get-Date).AddDays(-7)
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Activity list with StartDate and EndDate" {
+            $start = (Get-Date).AddDays(-7)
+            $end = (Get-Date).AddDays(-1)
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -StartDate $start -EndDate $end
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Activity list with QueryFilter" {
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -QueryFilter "EventName eq 'AccessRequestCreated'"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Activity list with Fields" {
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -Fields "Id","LogTime","EventName"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Activity list with JsonOutput" {
+            $json = Get-SafeguardAuditLogAccessRequestActivity -Insecure -JsonOutput
+            $null -eq $json -or $json -is [string]
+        }
+
+        # --- Activity drill-down (conditional on data availability) ---
+
+        Test-SgPsAssert "Activity drill-down by RequestId" {
+            if (-not $Context.SuiteData["HasActivityData"])
+            {
+                Write-Host "  (skipped -- no access request activity data)"
+                return $true
+            }
+            $entry = $Context.SuiteData["FirstActivity"]
+            $requestId = [string]$entry.RequestId
+            $result = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -RequestId $requestId
+            $null -ne $result
+        }
+
+        Test-SgPsAssert "Activity detail by RequestId and LogId" {
+            if (-not $Context.SuiteData["HasActivityData"])
+            {
+                Write-Host "  (skipped -- no access request activity data)"
+                return $true
+            }
+            $entry = $Context.SuiteData["FirstActivity"]
+            $requestId = [string]$entry.RequestId
+            # The API may use Id or LogId as the detail key
+            $logId = if ($null -ne $entry.Id) { [string]$entry.Id } else { [string]$entry.LogId }
+            if ([string]::IsNullOrEmpty($logId))
+            {
+                Write-Host "  (skipped -- no usable Id or LogId on entry)"
+                return $true
+            }
+            $detail = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                -RequestId $requestId -LogId $logId
+            $null -ne $detail
+        }
+
+        # --- Activity error cases ---
+
+        Test-SgPsAssert "Activity throws when UserId used with RequestId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                    -RequestId "fake" -UserId 1
+            }
+            catch { $threw = $_ -match "only supported on the top-level" }
+            $threw
+        }
+
+        Test-SgPsAssert "Activity throws when AssetId used with RequestId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                    -RequestId "fake" -AssetId 1
+            }
+            catch { $threw = $_ -match "only supported on the top-level" }
+            $threw
+        }
+
+        Test-SgPsAssert "Activity throws when AccountId used with RequestId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestActivity -Insecure `
+                    -RequestId "fake" -AccountId 1
+            }
+            catch { $threw = $_ -match "only supported on the top-level" }
+            $threw
+        }
+
+        Test-SgPsAssert "Activity rejects UserId of 0" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestActivity -Insecure -UserId 0
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        # =======================================================
+        # Get-SafeguardAuditLogAccessRequestSession -- List mode
+        # =======================================================
+
+        Test-SgPsAssert "Session list returns array (default)" {
+            $result = Get-SafeguardAuditLogAccessRequestSession -Insecure
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Session list with StartDate" {
+            $result = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                -StartDate (Get-Date).AddDays(-7)
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Session list with Fields" {
+            $result = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                -Fields "Id","LogTime","EventName"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "Session list with JsonOutput" {
+            $json = Get-SafeguardAuditLogAccessRequestSession -Insecure -JsonOutput
+            $null -eq $json -or $json -is [string]
+        }
+
+        # --- Session drill-down (conditional on data availability) ---
+
+        Test-SgPsAssert "Session drill-down by RequestId" {
+            if (-not $Context.SuiteData["HasSessionData"])
+            {
+                Write-Host "  (skipped -- no access request session data)"
+                return $true
+            }
+            $entry = $Context.SuiteData["FirstSession"]
+            $requestId = [string]$entry.RequestId
+            $result = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                -RequestId $requestId
+            $null -ne $result
+        }
+
+        Test-SgPsAssert "Session drill-down by RequestId and SessionId" {
+            if (-not $Context.SuiteData["HasSessionData"])
+            {
+                Write-Host "  (skipped -- no access request session data)"
+                return $true
+            }
+            $entry = $Context.SuiteData["FirstSession"]
+            $requestId = [string]$entry.RequestId
+            $sessionId = [int]$entry.SessionId
+            if ($sessionId -gt 0)
+            {
+                $result = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                    -RequestId $requestId -SessionId $sessionId
+                $null -ne $result
+            }
+            else
+            {
+                Write-Host "  (skipped -- SessionId not available in data)"
+                $true
+            }
+        }
+
+        # --- Session error cases ---
+
+        Test-SgPsAssert "Session throws when SessionId used without RequestId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestSession -Insecure -SessionId 1
+            }
+            catch { $threw = $_ -match "requires -RequestId" }
+            $threw
+        }
+
+        Test-SgPsAssert "Session throws when UserId used with RequestId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                    -RequestId "fake" -UserId 1
+            }
+            catch { $threw = $_ -match "only supported on the top-level" }
+            $threw
+        }
+
+        Test-SgPsAssert "Session rejects SessionId of 0" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                    -RequestId "fake" -SessionId 0
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "Session rejects negative SessionId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogAccessRequestSession -Insecure `
+                    -RequestId "fake" -SessionId -1
+            }
+            catch { $threw = $true }
+            $threw
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-AuditLogMaintenance.ps1
+++ b/test/Suites/Suite-AuditLogMaintenance.ps1
@@ -1,0 +1,149 @@
+@{
+    Name        = "AuditLogMaintenance"
+    Description = "Tests for audit log maintenance configuration, run-now, and signing certificate history cmdlets"
+    Tags        = @("auditlog","maintenance","certificates")
+
+    Setup = {
+        param($Context)
+        # Store original maintenance config for restoration
+        $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+        $Context.SuiteData["OriginalConfig"] = $config
+    }
+
+    Execute = {
+        param($Context)
+        $originalConfig = $Context.SuiteData["OriginalConfig"]
+
+        # --- Get-SafeguardAuditLogMaintenanceConfig tests ---
+        Test-SgPsAssert "Get maintenance config returns object" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $null -ne $config
+        }
+        Test-SgPsAssert "Maintenance config has expected properties" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $null -ne $config.DayOfWeek -and
+                $null -ne $config.StartHour -and
+                $null -ne $config.DaysToRetainLogs -and
+                $null -ne $config.NextScheduledMaintenance
+        }
+        Test-SgPsAssert "Maintenance config DaysToRetainLogs is positive integer" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $config.DaysToRetainLogs -gt 0
+        }
+        Test-SgPsAssert "Maintenance config has TimeZone info" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $null -ne $config.TimeZoneId -and $null -ne $config.TimeZoneDisplayName
+        }
+        Test-SgPsAssert "Maintenance config has scheduling timestamps" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $null -ne $config.NextScheduledMaintenance -and
+                $null -ne $config.LastScheduledMaintenance
+        }
+
+        # --- Set-SafeguardAuditLogMaintenanceConfig tests ---
+        Test-SgPsAssert "Set maintenance config changes StartHour" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $newHour = if ($config.StartHour -eq 5) { 6 } else { 5 }
+            $config.StartHour = $newHour
+            $updated = Set-SafeguardAuditLogMaintenanceConfig -Insecure $config
+            $updated.StartHour -eq $newHour
+        }
+        Test-SgPsAssert "Set maintenance config change persisted" {
+            $readback = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $readback.StartHour -eq 5 -or $readback.StartHour -eq 6
+        }
+        Test-SgPsAssert "Set maintenance config changes DayOfWeek" {
+            $config = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $newDay = if ($config.DayOfWeek -eq "Sunday") { "Monday" } else { "Sunday" }
+            $config.DayOfWeek = $newDay
+            $updated = Set-SafeguardAuditLogMaintenanceConfig -Insecure $config
+            $updated.DayOfWeek -eq $newDay
+        }
+        Test-SgPsAssert "Set maintenance config DayOfWeek persisted" {
+            $readback = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $readback.DayOfWeek -eq "Sunday" -or $readback.DayOfWeek -eq "Monday"
+        }
+        Test-SgPsAssert "Set maintenance config restore original values" {
+            $restored = Set-SafeguardAuditLogMaintenanceConfig -Insecure $originalConfig
+            $restored.StartHour -eq $originalConfig.StartHour -and
+                $restored.DayOfWeek -eq $originalConfig.DayOfWeek
+        }
+        Test-SgPsAssert "Restored config readback matches original" {
+            $readback = Get-SafeguardAuditLogMaintenanceConfig -Insecure
+            $readback.StartHour -eq $originalConfig.StartHour -and
+                $readback.DayOfWeek -eq $originalConfig.DayOfWeek -and
+                $readback.DaysToRetainLogs -eq $originalConfig.DaysToRetainLogs
+        }
+
+        # --- Invoke-SafeguardAuditLogMaintenance tests ---
+        Test-SgPsAssert "Invoke maintenance does not throw unexpected error" {
+            $threw = $false
+            try { Invoke-SafeguardAuditLogMaintenance -Insecure }
+            catch {
+                # 60818 means a maintenance operation is already in progress -- acceptable
+                if ($_ -match "60818") { $threw = $false }
+                else { $threw = $true }
+            }
+            -not $threw
+        }
+        Test-SgPsAssert "Invoke maintenance returns empty or already-in-progress" {
+            $success = $false
+            try {
+                $result = Invoke-SafeguardAuditLogMaintenance -Insecure
+                $success = ($null -eq $result -or $result -eq "")
+            }
+            catch {
+                # Already in progress is acceptable
+                $success = ($_ -match "60818")
+            }
+            $success
+        }
+
+        # --- Get-SafeguardAuditLogSigningCertificateHistory tests ---
+        Test-SgPsAssert "Get signing certificate history returns array" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $history -is [Array] -or $null -ne $history
+        }
+        Test-SgPsAssert "Signing certificate history has at least one entry" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            if ($history -is [Array]) { $history.Count -ge 1 }
+            else { $null -ne $history }
+        }
+        Test-SgPsAssert "Signing certificate entry has Subject" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $entry = if ($history -is [Array]) { $history[0] } else { $history }
+            $null -ne $entry.Subject -and $entry.Subject.Length -gt 0
+        }
+        Test-SgPsAssert "Signing certificate entry has Thumbprint" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $entry = if ($history -is [Array]) { $history[0] } else { $history }
+            $null -ne $entry.Thumbprint -and $entry.Thumbprint.Length -gt 0
+        }
+        Test-SgPsAssert "Signing certificate entry has InstalledDate" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $entry = if ($history -is [Array]) { $history[0] } else { $history }
+            $null -ne $entry.InstalledDate
+        }
+        Test-SgPsAssert "Signing certificate entry has CertificateType AuditLogSigning" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $entry = if ($history -is [Array]) { $history[0] } else { $history }
+            $entry.CertificateType -eq "AuditLogSigning"
+        }
+        Test-SgPsAssert "Signing certificate entry has NotBefore and NotAfter" {
+            $history = Get-SafeguardAuditLogSigningCertificateHistory -Insecure
+            $entry = if ($history -is [Array]) { $history[0] } else { $history }
+            $null -ne $entry.NotBefore -and $null -ne $entry.NotAfter
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+        # Restore original maintenance config in case tests left it modified
+        $originalConfig = $Context.SuiteData["OriginalConfig"]
+        if ($originalConfig)
+        {
+            try { Set-SafeguardAuditLogMaintenanceConfig -Insecure $originalConfig | Out-Null }
+            catch {}
+        }
+    }
+}

--- a/test/Suites/Suite-AuditLogObjectChanges.ps1
+++ b/test/Suites/Suite-AuditLogObjectChanges.ps1
@@ -1,0 +1,273 @@
+@{
+    Name        = "AuditLogObjectChanges"
+    Description = "Tests object change and discovery drill-down audit log cmdlets"
+    Tags        = @("auditlog", "objectchanges", "discovery")
+
+    Setup = {
+        param($Context)
+        # ObjectChanges has abundant data; capture first entry for drill-down tests
+        $changes = Get-SafeguardAuditLogObjectChange -Insecure User `
+            -StartDate (Get-Date).AddDays(-30)
+        if ($changes -is [Array] -and $changes.Count -gt 0)
+        {
+            $Context.SuiteData["HasObjectChangeData"] = $true
+            $Context.SuiteData["FirstChange"] = $changes[0]
+            # Find a distinct ObjectId with changes
+            $Context.SuiteData["TestObjectType"] = "User"
+            $Context.SuiteData["TestObjectId"] = [string]$changes[0].ObjectId
+            $Context.SuiteData["TestLogId"] = [string]$changes[0].Id
+        }
+        else
+        {
+            $Context.SuiteData["HasObjectChangeData"] = $false
+        }
+
+        # Check if discovery data exists (requires AssetAdmin role from test runner)
+        $Context.SuiteData["HasDiscoveryData"] = $false
+        try
+        {
+            $discAccounts = Invoke-SafeguardMethod -Insecure Core GET "AuditLog/Discovery/Accounts" `
+                -Parameters @{ startDate = (Get-Date).AddDays(-90).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ") }
+            if ($discAccounts -is [Array] -and $discAccounts.Count -gt 0)
+            {
+                $Context.SuiteData["HasDiscoveryData"] = $true
+                $Context.SuiteData["DiscoveryLogId"] = [string]$discAccounts[0].Id
+                $Context.SuiteData["DiscoveryType"] = "Accounts"
+            }
+        }
+        catch
+        {
+            # 403 or other error -- discovery data not accessible
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        # =======================================================
+        # Get-SafeguardAuditLogObjectChange -- ByType
+        # =======================================================
+
+        Test-SgPsAssert "ObjectChange ByType returns results for User" {
+            $result = Get-SafeguardAuditLogObjectChange -Insecure User `
+                -StartDate (Get-Date).AddDays(-30)
+            $result -is [Array] -and $result.Count -gt 0
+        }
+
+        Test-SgPsAssert "ObjectChange ByType with StartDate and EndDate" {
+            $start = (Get-Date).AddDays(-7)
+            $end = (Get-Date)
+            $result = Get-SafeguardAuditLogObjectChange -Insecure User `
+                -StartDate $start -EndDate $end
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "ObjectChange ByType with QueryFilter" {
+            $result = Get-SafeguardAuditLogObjectChange -Insecure User `
+                -StartDate (Get-Date).AddDays(-30) `
+                -QueryFilter "EventName eq 'UserCreated'"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "ObjectChange ByType with Fields" {
+            $result = Get-SafeguardAuditLogObjectChange -Insecure User `
+                -StartDate (Get-Date).AddDays(-30) `
+                -Fields "Id","LogTime","EventName","ObjectName"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "ObjectChange ByType with JsonOutput" {
+            $json = Get-SafeguardAuditLogObjectChange -Insecure User `
+                -StartDate (Get-Date).AddDays(-1) -JsonOutput
+            $null -eq $json -or $json -is [string]
+        }
+
+        Test-SgPsAssert "ObjectChange accepts various object types" {
+            # Test with a type that may or may not have data
+            $result = Get-SafeguardAuditLogObjectChange -Insecure IdentityProvider `
+                -StartDate (Get-Date).AddDays(-30)
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        # =======================================================
+        # Get-SafeguardAuditLogObjectChange -- ByObject
+        # =======================================================
+
+        Test-SgPsAssert "ObjectChange ByObject returns changes for a specific object" {
+            if (-not $Context.SuiteData["HasObjectChangeData"])
+            {
+                Write-Host "  (skipped -- no object change data)"
+                return $true
+            }
+            $objType = $Context.SuiteData["TestObjectType"]
+            $objId = $Context.SuiteData["TestObjectId"]
+            $result = Get-SafeguardAuditLogObjectChange -Insecure $objType `
+                -ObjectId $objId -StartDate (Get-Date).AddDays(-30)
+            $result -is [Array] -and $result.Count -gt 0
+        }
+
+        Test-SgPsAssert "ObjectChange ByObject all entries have matching ObjectId" {
+            if (-not $Context.SuiteData["HasObjectChangeData"])
+            {
+                Write-Host "  (skipped -- no object change data)"
+                return $true
+            }
+            $objType = $Context.SuiteData["TestObjectType"]
+            $objId = $Context.SuiteData["TestObjectId"]
+            $result = Get-SafeguardAuditLogObjectChange -Insecure $objType `
+                -ObjectId $objId -StartDate (Get-Date).AddDays(-30)
+            $allMatch = $true
+            foreach ($entry in $result)
+            {
+                if ([string]$entry.ObjectId -ne $objId)
+                {
+                    $allMatch = $false
+                    break
+                }
+            }
+            $allMatch
+        }
+
+        # =======================================================
+        # Get-SafeguardAuditLogObjectChange -- Detail
+        # =======================================================
+
+        Test-SgPsAssert "ObjectChange Detail returns a single entry" {
+            if (-not $Context.SuiteData["HasObjectChangeData"])
+            {
+                Write-Host "  (skipped -- no object change data)"
+                return $true
+            }
+            $objType = $Context.SuiteData["TestObjectType"]
+            $objId = $Context.SuiteData["TestObjectId"]
+            $logId = $Context.SuiteData["TestLogId"]
+            $detail = Get-SafeguardAuditLogObjectChange -Insecure $objType `
+                -ObjectId $objId -LogId $logId
+            $null -ne $detail -and $detail.Id -eq $logId
+        }
+
+        Test-SgPsAssert "ObjectChange Detail has expected properties" {
+            if (-not $Context.SuiteData["HasObjectChangeData"])
+            {
+                Write-Host "  (skipped -- no object change data)"
+                return $true
+            }
+            $objType = $Context.SuiteData["TestObjectType"]
+            $objId = $Context.SuiteData["TestObjectId"]
+            $logId = $Context.SuiteData["TestLogId"]
+            $detail = Get-SafeguardAuditLogObjectChange -Insecure $objType `
+                -ObjectId $objId -LogId $logId
+            $null -ne $detail.EventName -and
+                $null -ne $detail.LogTime -and
+                [string]$detail.ObjectId -eq $objId
+        }
+
+        Test-SgPsAssert "ObjectChange Detail with Fields limits output" {
+            if (-not $Context.SuiteData["HasObjectChangeData"])
+            {
+                Write-Host "  (skipped -- no object change data)"
+                return $true
+            }
+            $objType = $Context.SuiteData["TestObjectType"]
+            $objId = $Context.SuiteData["TestObjectId"]
+            $logId = $Context.SuiteData["TestLogId"]
+            $detail = Get-SafeguardAuditLogObjectChange -Insecure $objType `
+                -ObjectId $objId -LogId $logId -Fields "Id","EventName"
+            $null -ne $detail -and $null -ne $detail.Id
+        }
+
+        # =======================================================
+        # Error cases
+        # =======================================================
+
+        Test-SgPsAssert "ObjectChange rejects StartDate later than EndDate" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogObjectChange -Insecure User `
+                    -StartDate (Get-Date) -EndDate (Get-Date).AddDays(-7)
+            }
+            catch { $threw = $_ -match "StartDate must not be later" }
+            $threw
+        }
+
+        Test-SgPsAssert "ObjectChange rejects empty ObjectType" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogObjectChange -Insecure ""
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "ObjectChange handles nonexistent ObjectType gracefully" {
+            # API should return empty or 400 for nonsense types
+            $threw = $false
+            try {
+                $result = Get-SafeguardAuditLogObjectChange -Insecure "FakeTypeXyz123" `
+                    -StartDate (Get-Date).AddDays(-1)
+                # If no error, result should be empty
+                $null -eq $result -or ($result -is [Array] -and $result.Count -eq 0)
+            }
+            catch {
+                # API rejected the type -- also acceptable
+                $threw = $true
+            }
+            $threw -or ($null -eq $result -or ($result -is [Array] -and $result.Count -eq 0))
+        }
+
+        # =======================================================
+        # Get-SafeguardAuditLogDiscoveredItem
+        # =======================================================
+
+        Test-SgPsAssert "DiscoveredItem with valid DiscoveryType and LogId" {
+            if (-not $Context.SuiteData["HasDiscoveryData"])
+            {
+                Write-Host "  (skipped -- no discovery data or insufficient permissions)"
+                return $true
+            }
+            $discType = $Context.SuiteData["DiscoveryType"]
+            $discId = $Context.SuiteData["DiscoveryLogId"]
+            $result = Get-SafeguardAuditLogDiscoveredItem -Insecure $discType `
+                -DiscoveryLogId $discId
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "DiscoveredItem rejects invalid DiscoveryType" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogDiscoveredItem -Insecure "SshKeys" `
+                    -DiscoveryLogId "fake"
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "DiscoveredItem rejects empty DiscoveryLogId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogDiscoveredItem -Insecure Accounts `
+                    -DiscoveryLogId ""
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "DiscoveredItem handles nonexistent LogId" {
+            # API should return 404 or empty for a fake ID
+            $threw = $false
+            try {
+                $result = Get-SafeguardAuditLogDiscoveredItem -Insecure Accounts `
+                    -DiscoveryLogId "00000000-0000-0000-0000-000000000000"
+                $null -eq $result -or ($result -is [Array] -and $result.Count -eq 0)
+            }
+            catch {
+                $threw = $true
+            }
+            $threw -or ($null -eq $result -or ($result -is [Array] -and $result.Count -eq 0))
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-AuditLogPlatformScripts.ps1
+++ b/test/Suites/Suite-AuditLogPlatformScripts.ps1
@@ -1,0 +1,232 @@
+@{
+    Name        = "AuditLogPlatformScripts"
+    Description = "Tests platform script change audit log cmdlet"
+    Tags        = @("auditlog", "platformscripts")
+
+    Setup = {
+        param($Context)
+        # PlatformScripts audit requires AssetAdmin role (test runner provides this)
+        $Context.SuiteData["HasData"] = $false
+        try
+        {
+            $scripts = Get-SafeguardAuditLogPlatformScript -Insecure
+            if ($null -ne $scripts -and $scripts -is [Array] -and $scripts.Count -gt 0)
+            {
+                $Context.SuiteData["HasData"] = $true
+                $Context.SuiteData["FirstEntry"] = $scripts[0]
+                $Context.SuiteData["PlatformId"] = [int]$scripts[0].PlatformId
+                $Context.SuiteData["LogId"] = [string]$scripts[0].Id
+            }
+            elseif ($null -ne $scripts -and $scripts -isnot [Array])
+            {
+                $Context.SuiteData["HasData"] = $true
+                $Context.SuiteData["FirstEntry"] = $scripts
+                $Context.SuiteData["PlatformId"] = [int]$scripts.PlatformId
+                $Context.SuiteData["LogId"] = [string]$scripts.Id
+            }
+            $Context.SuiteData["HasAccess"] = $true
+        }
+        catch
+        {
+            if ($_ -match "403")
+            {
+                $Context.SuiteData["HasAccess"] = $false
+                Write-Host "  WARNING: No access to PlatformScripts audit (requires AssetAdmin)"
+            }
+            else
+            {
+                throw
+            }
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        # =======================================================
+        # Access check -- skip all if no permissions
+        # =======================================================
+
+        Test-SgPsAssert "Has access to PlatformScripts audit endpoint" {
+            if (-not $Context.SuiteData["HasAccess"])
+            {
+                Write-Host "  (skipped -- insufficient permissions)"
+                return $true
+            }
+            $true
+        }
+
+        # =======================================================
+        # List mode
+        # =======================================================
+
+        Test-SgPsAssert "List returns array or empty" {
+            if (-not $Context.SuiteData["HasAccess"]) { return $true }
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "List with QueryFilter" {
+            if (-not $Context.SuiteData["HasAccess"]) { return $true }
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -QueryFilter "PlatformDisplayName contains 'Linux'"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "List with Fields" {
+            if (-not $Context.SuiteData["HasAccess"]) { return $true }
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -Fields "Id","LogTime","PlatformId","PlatformDisplayName"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        Test-SgPsAssert "List with JsonOutput" {
+            if (-not $Context.SuiteData["HasAccess"]) { return $true }
+            $json = Get-SafeguardAuditLogPlatformScript -Insecure -JsonOutput
+            $null -eq $json -or $json -is [string]
+        }
+
+        # =======================================================
+        # ByPlatform mode
+        # =======================================================
+
+        Test-SgPsAssert "ByPlatform returns results for known platform" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId $pid2
+            $null -ne $result -and
+                (($result -is [Array] -and $result.Count -gt 0) -or $result -is [PSCustomObject])
+        }
+
+        Test-SgPsAssert "ByPlatform all entries have matching PlatformId" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId $pid2
+            $entries = if ($result -is [Array]) { $result } else { @($result) }
+            $allMatch = $true
+            foreach ($e in $entries)
+            {
+                if ([int]$e.PlatformId -ne $pid2) { $allMatch = $false; break }
+            }
+            $allMatch
+        }
+
+        Test-SgPsAssert "ByPlatform with QueryFilter" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId $pid2 `
+                -QueryFilter "PlatformDisplayName ne 'nonexistent'"
+            $null -eq $result -or $result -is [Array] -or $result -is [PSCustomObject]
+        }
+
+        # =======================================================
+        # Detail mode
+        # =======================================================
+
+        Test-SgPsAssert "Detail returns script content" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $lid = $Context.SuiteData["LogId"]
+            $detail = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -PlatformId $pid2 -LogId $lid
+            # Detail endpoint returns the script content (string or object), not metadata
+            $null -ne $detail
+        }
+
+        Test-SgPsAssert "Detail returns non-empty content" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $lid = $Context.SuiteData["LogId"]
+            $detail = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -PlatformId $pid2 -LogId $lid
+            if ($detail -is [string]) { $detail.Length -gt 0 }
+            else { $null -ne $detail }
+        }
+
+        Test-SgPsAssert "Detail with JsonOutput returns string" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $lid = $Context.SuiteData["LogId"]
+            $result = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -PlatformId $pid2 -LogId $lid -JsonOutput
+            $null -eq $result -or $result -is [string]
+        }
+
+        # =======================================================
+        # Raw mode
+        # =======================================================
+
+        Test-SgPsAssert "Raw returns script content" {
+            if (-not $Context.SuiteData["HasData"])
+            {
+                Write-Host "  (skipped -- no platform script audit data)"
+                return $true
+            }
+            $pid2 = $Context.SuiteData["PlatformId"]
+            $lid = $Context.SuiteData["LogId"]
+            $rawContent = Get-SafeguardAuditLogPlatformScript -Insecure `
+                -PlatformId $pid2 -LogId $lid -Raw
+            # Raw should return non-null content (script JSON or text)
+            $null -ne $rawContent
+        }
+
+        # =======================================================
+        # Error cases
+        # =======================================================
+
+        Test-SgPsAssert "Rejects PlatformId of 0" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId 0
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "Rejects negative PlatformId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId -1
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        Test-SgPsAssert "Rejects empty LogId" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardAuditLogPlatformScript -Insecure -PlatformId 1 -LogId ""
+            }
+            catch { $threw = $true }
+            $threw
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-AuditLogScheduledReports.ps1
+++ b/test/Suites/Suite-AuditLogScheduledReports.ps1
@@ -1,0 +1,160 @@
+@{
+    Name        = "AuditLogScheduledReports"
+    Description = "Tests for scheduled audit log report CRUD and execution cmdlets"
+    Tags        = @("auditlog","scheduledreports")
+
+    Setup = {
+        param($Context)
+        $prefix = $Context.TestPrefix
+        $reportName = "${prefix}SchedReport"
+        $Context.SuiteData["ReportName"] = $reportName
+
+        # Pre-cleanup: remove any stale test reports
+        $existing = Get-SafeguardScheduledAuditLogReport -Insecure
+        foreach ($r in $existing)
+        {
+            if ($r.Name -like "${prefix}*")
+            {
+                try { Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId $r.Id } catch {}
+            }
+        }
+    }
+
+    Execute = {
+        param($Context)
+        $reportName = $Context.SuiteData["ReportName"]
+
+        # --- New-SafeguardScheduledAuditLogReport tests ---
+        Test-SgPsAssert "Create report with name only" {
+            $report = New-SafeguardScheduledAuditLogReport -Insecure -Name "${reportName}Basic"
+            $Context.SuiteData["BasicId"] = $report.Id
+            $report.Name -eq "${reportName}Basic" -and $null -ne $report.Id
+        }
+        Test-SgPsAssert "Create report with all attributes" {
+            $report = New-SafeguardScheduledAuditLogReport -Insecure -Name "${reportName}Full" `
+                -Description "Full test report" -CategoryOption Login -SerializationFormat Csv
+            $Context.SuiteData["FullId"] = $report.Id
+            $report.Name -eq "${reportName}Full" -and
+                $report.Description -eq "Full test report" -and
+                $report.CategoryOption -eq "Login" -and
+                $report.SerializationFormat -eq "Csv"
+        }
+        Test-SgPsAssert "Create report with Body parameter" {
+            $report = New-SafeguardScheduledAuditLogReport -Insecure -Body @{
+                Name = "${reportName}Body"
+                CategoryOption = "Password"
+                SerializationFormat = "Json"
+            }
+            $Context.SuiteData["BodyId"] = $report.Id
+            $report.Name -eq "${reportName}Body" -and
+                $report.CategoryOption -eq "Password"
+        }
+        Test-SgPsAssert "Created report persisted with correct values" {
+            $readback = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["FullId"]
+            $readback.Name -eq "${reportName}Full" -and
+                $readback.Description -eq "Full test report" -and
+                $readback.CategoryOption -eq "Login" -and
+                $readback.SerializationFormat -eq "Csv"
+        }
+
+        # --- Get-SafeguardScheduledAuditLogReport tests ---
+        Test-SgPsAssert "Get all reports returns array" {
+            $all = Get-SafeguardScheduledAuditLogReport -Insecure
+            $all -is [Array] -and $all.Count -ge 3
+        }
+        Test-SgPsAssert "Get report by ID returns correct report" {
+            $report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $report.Id -eq $Context.SuiteData["BasicId"] -and
+                $report.Name -eq "${reportName}Basic"
+        }
+        Test-SgPsAssert "Get report has scheduling properties" {
+            $report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["FullId"]
+            $null -ne $report.ScheduleType -and $null -ne $report.CreatedDate
+        }
+
+        # --- Edit-SafeguardScheduledAuditLogReport tests ---
+        Test-SgPsAssert "Edit report changes description" {
+            $report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $report.Description = "Edited description"
+            $edited = Edit-SafeguardScheduledAuditLogReport -Insecure -ReportId $report.Id -ReportObject $report
+            $edited.Description -eq "Edited description"
+        }
+        Test-SgPsAssert "Edit report description persisted" {
+            $readback = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $readback.Description -eq "Edited description"
+        }
+        Test-SgPsAssert "Edit report changes category" {
+            $report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $report.CategoryOption = "ObjectChange"
+            $edited = Edit-SafeguardScheduledAuditLogReport -Insecure -ReportId $report.Id -ReportObject $report
+            $edited.CategoryOption -eq "ObjectChange"
+        }
+        Test-SgPsAssert "Edit report via pipeline" {
+            $report = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $report.SerializationFormat = "Csv"
+            $edited = $report | Edit-SafeguardScheduledAuditLogReport -Insecure
+            $edited.SerializationFormat -eq "Csv"
+        }
+        Test-SgPsAssert "Edit report pipeline change persisted" {
+            $readback = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"]
+            $readback.SerializationFormat -eq "Csv" -and
+                $readback.CategoryOption -eq "ObjectChange"
+        }
+
+        # --- Invoke-SafeguardScheduledAuditLogReport tests ---
+        Test-SgPsAssert "Execute report does not throw" {
+            $threw = $false
+            try { $null = Invoke-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["FullId"] }
+            catch { $threw = $true }
+            -not $threw
+        }
+        Test-SgPsAssert "Execute report returns array" {
+            $results = Invoke-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["FullId"]
+            $results -is [Array]
+        }
+
+        # --- Remove-SafeguardScheduledAuditLogReport tests ---
+        Test-SgPsAssert "Remove report does not throw" {
+            $threw = $false
+            try { Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BodyId"] }
+            catch { $threw = $true }
+            -not $threw
+        }
+        Test-SgPsAssert "Remove report confirmed via get" {
+            $threw = $false
+            try { $null = Get-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BodyId"] }
+            catch { $threw = $true }
+            $threw
+        }
+        Test-SgPsAssert "Remove second report" {
+            $threw = $false
+            try { Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["BasicId"] }
+            catch { $threw = $true }
+            -not $threw
+        }
+        Test-SgPsAssert "Remove last report" {
+            $threw = $false
+            try { Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId $Context.SuiteData["FullId"] }
+            catch { $threw = $true }
+            -not $threw
+        }
+        Test-SgPsAssert "All test reports cleaned up" {
+            $remaining = Get-SafeguardScheduledAuditLogReport -Insecure
+            $testReports = $remaining | Where-Object { $_.Name -like "${reportName}*" }
+            $null -eq $testReports -or $testReports.Count -eq 0
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+        # Remove any lingering test reports
+        $existing = Get-SafeguardScheduledAuditLogReport -Insecure
+        foreach ($r in $existing)
+        {
+            if ($r.Name -like "$($Context.TestPrefix)*")
+            {
+                try { Remove-SafeguardScheduledAuditLogReport -Insecure -ReportId $r.Id } catch {}
+            }
+        }
+    }
+}

--- a/test/Suites/Suite-Messages.ps1
+++ b/test/Suites/Suite-Messages.ps1
@@ -1,0 +1,145 @@
+@{
+    Name        = "Messages"
+    Description = "Tests daily message and login message get/set operations"
+    Tags        = @("messages", "settings")
+
+    Setup = {
+        param($Context)
+
+        # Save original messages for restoration
+        $dailyMsg = Get-SafeguardDailyMessage -Insecure
+        $loginMsg = Get-SafeguardLoginMessage -Insecure
+        $Context.SuiteData["OriginalDailyMessage"] = $dailyMsg
+        $Context.SuiteData["OriginalLoginMessage"] = $loginMsg
+
+        Register-SgPsTestCleanup -Description "Restore original daily message" -Action {
+            param($Ctx)
+            try {
+                Set-SafeguardDailyMessage -Insecure -MessageObject $Ctx.SuiteData['OriginalDailyMessage']
+            } catch {}
+        }
+
+        Register-SgPsTestCleanup -Description "Restore original login message" -Action {
+            param($Ctx)
+            try {
+                Set-SafeguardLoginMessage -Insecure -MessageObject $Ctx.SuiteData['OriginalLoginMessage']
+            } catch {}
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        # ===================== DailyMessage =====================
+
+        # --- Get-SafeguardDailyMessage ---
+        Test-SgPsAssert "Get-SafeguardDailyMessage returns an object" {
+            $msg = Get-SafeguardDailyMessage -Insecure
+            # DailyMessage always has a Message property (possibly empty string)
+            $null -ne $msg -and $msg.PSObject.Properties.Name -contains "Message"
+        }
+
+        # --- Set-SafeguardDailyMessage with attributes ---
+        Test-SgPsAssert "Set-SafeguardDailyMessage sets message text" {
+            $result = Set-SafeguardDailyMessage -Insecure -Message "SgPsTest daily message"
+            $result.Message -eq "SgPsTest daily message"
+        }
+
+        Test-SgPsAssert "Set-SafeguardDailyMessage change persisted" {
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $readback.Message -eq "SgPsTest daily message"
+        }
+
+        # --- Set-SafeguardDailyMessage with subject ---
+        Test-SgPsAssert "Set-SafeguardDailyMessage sets subject" {
+            $result = Set-SafeguardDailyMessage -Insecure -Message "Message with subject" -Subject "Test Subject"
+            $result.Message -eq "Message with subject" -and $result.Subject -eq "Test Subject"
+        }
+
+        Test-SgPsAssert "Set-SafeguardDailyMessage subject persisted" {
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $readback.Subject -eq "Test Subject"
+        }
+
+        # --- Set-SafeguardDailyMessage with object ---
+        Test-SgPsAssert "Set-SafeguardDailyMessage with MessageObject" {
+            $msg = Get-SafeguardDailyMessage -Insecure
+            $msg.Message = "Object-based update"
+            $msg.Subject = "Object Subject"
+            $result = Set-SafeguardDailyMessage -Insecure -MessageObject $msg
+            $result.Message -eq "Object-based update" -and $result.Subject -eq "Object Subject"
+        }
+
+        Test-SgPsAssert "Set-SafeguardDailyMessage object change persisted" {
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $readback.Message -eq "Object-based update"
+        }
+
+        # --- Set-SafeguardDailyMessage second update ---
+        Test-SgPsAssert "Set-SafeguardDailyMessage second update to prove edit" {
+            $result = Set-SafeguardDailyMessage -Insecure -Message "Second update"
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $result.Message -eq "Second update" -and $readback.Message -eq "Second update"
+        }
+
+        # --- Set-SafeguardDailyMessage UseRss/Address roundtrip ---
+        Test-SgPsAssert "Set-SafeguardDailyMessage UseRss and Address" {
+            $result = Set-SafeguardDailyMessage -Insecure -Message "RSS test" -UseRss $true -Address "https://rss.example.com/feed"
+            $result.UseRss -eq $true -and $result.Address -eq "https://rss.example.com/feed"
+        }
+
+        Test-SgPsAssert "Set-SafeguardDailyMessage UseRss persisted" {
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $readback.UseRss -eq $true -and $readback.Address -eq "https://rss.example.com/feed"
+        }
+
+        Test-SgPsAssert "Set-SafeguardDailyMessage disable UseRss" {
+            $result = Set-SafeguardDailyMessage -Insecure -UseRss $false
+            $readback = Get-SafeguardDailyMessage -Insecure
+            $result.UseRss -eq $false -and $readback.UseRss -eq $false
+        }
+
+        # ===================== LoginMessage =====================
+
+        # --- Get-SafeguardLoginMessage ---
+        Test-SgPsAssert "Get-SafeguardLoginMessage returns an object" {
+            $msg = Get-SafeguardLoginMessage -Insecure
+            $null -ne $msg -and $msg.PSObject.Properties.Name -contains "Message"
+        }
+
+        # --- Set-SafeguardLoginMessage with string ---
+        Test-SgPsAssert "Set-SafeguardLoginMessage sets message text" {
+            $result = Set-SafeguardLoginMessage -Insecure -Message "SgPsTest login banner"
+            $result.Message -eq "SgPsTest login banner"
+        }
+
+        Test-SgPsAssert "Set-SafeguardLoginMessage change persisted" {
+            $readback = Get-SafeguardLoginMessage -Insecure
+            $readback.Message -eq "SgPsTest login banner"
+        }
+
+        # --- Set-SafeguardLoginMessage with object ---
+        Test-SgPsAssert "Set-SafeguardLoginMessage with MessageObject" {
+            $msg = Get-SafeguardLoginMessage -Insecure
+            $msg.Message = "Object login banner"
+            $result = Set-SafeguardLoginMessage -Insecure -MessageObject $msg
+            $result.Message -eq "Object login banner"
+        }
+
+        Test-SgPsAssert "Set-SafeguardLoginMessage object change persisted" {
+            $readback = Get-SafeguardLoginMessage -Insecure
+            $readback.Message -eq "Object login banner"
+        }
+
+        # --- Set-SafeguardLoginMessage second update ---
+        Test-SgPsAssert "Set-SafeguardLoginMessage second update to prove edit" {
+            $result = Set-SafeguardLoginMessage -Insecure -Message "Second login banner"
+            $readback = Get-SafeguardLoginMessage -Insecure
+            $result.Message -eq "Second login banner" -and $readback.Message -eq "Second login banner"
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-ReasonCodes.ps1
+++ b/test/Suites/Suite-ReasonCodes.ps1
@@ -1,0 +1,142 @@
+@{
+    Name        = "ReasonCodes"
+    Description = "Tests reason code CRUD operations"
+    Tags        = @("reasoncodes", "core")
+
+    Setup = {
+        param($Context)
+
+        $prefix = $Context.TestPrefix
+        $rcName1 = "${prefix}_RC1"
+        $rcName2 = "${prefix}_RC2"
+
+        # Pre-cleanup stale objects from previous runs
+        try {
+            $stale = Get-SafeguardReasonCode -Insecure
+            @($stale) | Where-Object { $_.Name -like "${prefix}_RC*" } | ForEach-Object {
+                try { Remove-SafeguardReasonCode -Insecure $_.Id } catch {}
+            }
+        } catch {}
+
+        $Context.SuiteData["RcName1"] = $rcName1
+        $Context.SuiteData["RcName2"] = $rcName2
+    }
+
+    Execute = {
+        param($Context)
+
+        $rcName1 = $Context.SuiteData["RcName1"]
+        $rcName2 = $Context.SuiteData["RcName2"]
+
+        # --- Get-SafeguardReasonCode (list all) ---
+        Test-SgPsAssert "Get-SafeguardReasonCode lists reason codes" {
+            $list = @(Get-SafeguardReasonCode -Insecure)
+            $list -is [Array]
+        }
+
+        # --- New-SafeguardReasonCode ---
+        Test-SgPsAssert "New-SafeguardReasonCode creates a reason code" {
+            $rc = New-SafeguardReasonCode -Insecure -Name $rcName1 -Description "Test reason code 1"
+            $Context.SuiteData["RcId1"] = $rc.Id
+
+            Register-SgPsTestCleanup -Description "Delete test reason code $rcName1" -Action {
+                param($Ctx)
+                try { Remove-SafeguardReasonCode -Insecure $Ctx.SuiteData['RcId1'] } catch {}
+            }
+
+            $null -ne $rc.Id -and $rc.Name -eq $rcName1 -and $rc.Description -eq "Test reason code 1"
+        }
+
+        # --- Get-SafeguardReasonCode by ID readback ---
+        Test-SgPsAssert "Get-SafeguardReasonCode by ID returns correct object" {
+            $rc = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId1"]
+            $rc.Name -eq $rcName1 -and $rc.Description -eq "Test reason code 1"
+        }
+
+        # --- Get-SafeguardReasonCode by Name ---
+        Test-SgPsAssert "Get-SafeguardReasonCode by name" {
+            $rc = Get-SafeguardReasonCode -Insecure $rcName1
+            $rc.Id -eq $Context.SuiteData["RcId1"]
+        }
+
+        # --- Get-SafeguardReasonCode with Fields ---
+        Test-SgPsAssert "Get-SafeguardReasonCode with Fields" {
+            $rc = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId1"] -Fields "Id","Name"
+            $null -ne $rc.Id -and $rc.Name -eq $rcName1
+        }
+
+        # --- Find-SafeguardReasonCode ---
+        Test-SgPsAssert "Find-SafeguardReasonCode by search string" {
+            $results = Find-SafeguardReasonCode -Insecure $rcName1
+            $found = @($results) | Where-Object { $_.Name -eq $rcName1 }
+            $null -ne $found
+        }
+
+        # --- New second reason code for edit test ---
+        Test-SgPsAssert "New-SafeguardReasonCode creates second reason code" {
+            $rc2 = New-SafeguardReasonCode -Insecure -Name $rcName2 -Description "Test reason code 2"
+            $Context.SuiteData["RcId2"] = $rc2.Id
+
+            Register-SgPsTestCleanup -Description "Delete test reason code $rcName2" -Action {
+                param($Ctx)
+                try { Remove-SafeguardReasonCode -Insecure $Ctx.SuiteData['RcId2'] } catch {}
+            }
+
+            $rc2.Name -eq $rcName2
+        }
+
+        # --- Edit-SafeguardReasonCode ---
+        Test-SgPsAssert "Edit-SafeguardReasonCode updates description" {
+            $rc = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+            $rc.Description = "Updated description"
+            $edited = Edit-SafeguardReasonCode -Insecure $rc
+            $edited.Description -eq "Updated description" -and $edited.Name -eq $rcName2
+        }
+
+        Test-SgPsAssert "Edit-SafeguardReasonCode change persisted" {
+            $readback = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+            $readback.Description -eq "Updated description" -and $readback.Name -eq $rcName2
+        }
+
+        # --- Edit-SafeguardReasonCode via pipeline ---
+        Test-SgPsAssert "Edit-SafeguardReasonCode via pipeline" {
+            $rc = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+            $rc.Description = "Pipeline edit"
+            $edited = $rc | Edit-SafeguardReasonCode -Insecure
+            $edited.Description -eq "Pipeline edit"
+        }
+
+        Test-SgPsAssert "Edit-SafeguardReasonCode pipeline change persisted" {
+            $readback = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+            $readback.Description -eq "Pipeline edit"
+        }
+
+        # --- Remove-SafeguardReasonCode ---
+        Test-SgPsAssert "Remove-SafeguardReasonCode removes by ID" {
+            Remove-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+            $found = $false
+            try {
+                $null = Get-SafeguardReasonCode -Insecure $Context.SuiteData["RcId2"]
+                $found = $true
+            } catch {}
+            -not $found
+        }
+
+        # --- Remove-SafeguardReasonCode by name ---
+        Test-SgPsAssert "Remove-SafeguardReasonCode removes by name" {
+            # Create a temporary one to delete by name
+            $temp = New-SafeguardReasonCode -Insecure -Name "${rcName2}_temp" -Description "Temp for delete test"
+            Remove-SafeguardReasonCode -Insecure "${rcName2}_temp"
+            $found = $false
+            try {
+                $null = Get-SafeguardReasonCode -Insecure $temp.Id
+                $found = $true
+            } catch {}
+            -not $found
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-RunningTasks.ps1
+++ b/test/Suites/Suite-RunningTasks.ps1
@@ -1,0 +1,99 @@
+@{
+    Name        = "RunningTasks"
+    Description = "Tests running task list and monitoring operations"
+    Tags        = @("runningtasks", "core")
+
+    Setup = {
+        param($Context)
+
+        $prefix = $Context.TestPrefix
+        $testAsset = "${prefix}_TaskAsset"
+
+        # Pre-cleanup
+        Remove-SgPsStaleTestObject -Collection "Assets" -Name $testAsset
+
+        # Create a test asset to trigger a TestConnection task
+        $asset = New-SafeguardAsset -Insecure -DisplayName $testAsset `
+            -Platform 521 -NetworkAddress "10.0.99.99" `
+            -ServiceAccountCredentialType "None" -NoSshHostKeyDiscovery
+        $Context.SuiteData["AssetId"] = $asset.Id
+
+        Register-SgPsTestCleanup -Description "Delete running task test asset" -Action {
+            param($Ctx)
+            try { Remove-SafeguardAsset -Insecure $Ctx.SuiteData['AssetId'] } catch {}
+        }
+    }
+
+    Execute = {
+        param($Context)
+
+        # --- Get-SafeguardRunningTask (list all) ---
+        Test-SgPsAssert "Get-SafeguardRunningTask lists tasks" {
+            $list = @(Get-SafeguardRunningTask -Insecure)
+            $list -is [Array]
+        }
+
+        # --- Get-SafeguardRunningTask with IncludeSubmitted ---
+        Test-SgPsAssert "Get-SafeguardRunningTask with IncludeSubmitted" {
+            $list = @(Get-SafeguardRunningTask -Insecure -IncludeSubmitted)
+            $list -is [Array]
+        }
+
+        # --- Get-SafeguardRunningTask by TaskName ---
+        Test-SgPsAssert "Get-SafeguardRunningTask by TaskName" {
+            $list = @(Get-SafeguardRunningTask -Insecure -TaskName TestConnection)
+            $list -is [Array]
+        }
+
+        # --- Trigger a TestConnection to exercise task visibility ---
+        Test-SgPsAssert "Trigger TestConnection and see running task" {
+            $assetId = $Context.SuiteData["AssetId"]
+            # Fire and forget -- TestConnection against unreachable IP will queue/run briefly
+            try { Test-SafeguardAsset -Insecure $assetId } catch {}
+            # Check that we can query tasks without error
+            $list = @(Get-SafeguardRunningTask -Insecure -TaskName TestConnection -IncludeSubmitted)
+            $list -is [Array]
+        }
+
+        # --- Get-SafeguardRunningTask with Fields ---
+        Test-SgPsAssert "Get-SafeguardRunningTask with Fields filter" {
+            $list = @(Get-SafeguardRunningTask -Insecure -Fields "TaskId","Name" -IncludeSubmitted)
+            # Whether empty or populated, the call should succeed and return an array
+            $list -is [Array]
+        }
+
+        # --- Validate TaskName parameter rejects invalid values ---
+        Test-SgPsAssert "Get-SafeguardRunningTask rejects invalid TaskName" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardRunningTask -Insecure -TaskName "NotAValidTask"
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        # --- Stop-SafeguardRunningTask rejects invalid TaskName ---
+        Test-SgPsAssert "Stop-SafeguardRunningTask rejects invalid TaskName" {
+            $threw = $false
+            try {
+                $null = Stop-SafeguardRunningTask -Insecure -TaskName "NotAValidTask" -TaskId "fake"
+            }
+            catch { $threw = $true }
+            $threw
+        }
+
+        # --- TaskId requires TaskName ---
+        Test-SgPsAssert "Get-SafeguardRunningTask throws when TaskId without TaskName" {
+            $threw = $false
+            try {
+                $null = Get-SafeguardRunningTask -Insecure -TaskId "fake-id"
+            }
+            catch { $threw = $true }
+            $threw
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+    }
+}

--- a/test/Suites/Suite-UserPasswordRule.ps1
+++ b/test/Suites/Suite-UserPasswordRule.ps1
@@ -5,7 +5,6 @@
 
     Setup = {
         param($Context)
-        $prefix = $Context.TestPrefix
 
         # Save original rule so we can restore it in cleanup
         $originalRule = Get-SafeguardUserPasswordRule -Insecure

--- a/test/Suites/Suite-UserPasswordRule.ps1
+++ b/test/Suites/Suite-UserPasswordRule.ps1
@@ -1,0 +1,148 @@
+@{
+    Name        = "UserPasswordRule"
+    Description = "Tests for user password rule management cmdlets"
+    Tags        = @("userpasswordrule", "settings")
+
+    Setup = {
+        param($Context)
+        $prefix = $Context.TestPrefix
+
+        # Save original rule so we can restore it in cleanup
+        $originalRule = Get-SafeguardUserPasswordRule -Insecure
+        $Context.SuiteData["OriginalRule"] = $originalRule
+
+        Register-SgPsTestCleanup -Description "Restore original user password rule" -Action {
+            param($Ctx)
+            try { Set-SafeguardUserPasswordRule -Insecure -RuleObject $Ctx.SuiteData["OriginalRule"] } catch {}
+        }
+    }
+
+    Execute = {
+        param($Context)
+        $original = $Context.SuiteData["OriginalRule"]
+
+        # -- GET --
+
+        Test-SgPsAssert "Get user password rule returns object with Name" {
+            $rule = Get-SafeguardUserPasswordRule -Insecure
+            $null -ne $rule -and $null -ne $rule.Name -and $rule.Name.Length -gt 0
+        }
+
+        Test-SgPsAssert "Get user password rule has expected properties" {
+            $rule = Get-SafeguardUserPasswordRule -Insecure
+            $null -ne $rule.MinCharacters -and
+                $null -ne $rule.MaxCharacters -and
+                $null -ne $rule.AllowUppercaseCharacters -and
+                $null -ne $rule.AllowLowercaseCharacters -and
+                $null -ne $rule.AllowNumericCharacters -and
+                $null -ne $rule.AllowNonAlphaNumericCharacters
+        }
+
+        # -- SET via Attributes --
+
+        $newMin = if ($original.MinCharacters -eq 14) { 15 } else { 14 }
+        Test-SgPsAssert "Set user password rule MinCharacters via attribute" {
+            $result = Set-SafeguardUserPasswordRule -Insecure -MinCharacters $newMin
+            $result.MinCharacters -eq $newMin
+        }
+
+        Test-SgPsAssert "Set MinCharacters persisted via readback" {
+            $readback = Get-SafeguardUserPasswordRule -Insecure
+            $readback.MinCharacters -eq $newMin
+        }
+
+        $newMax = if ($original.MaxCharacters -eq 100) { 80 } else { 100 }
+        Test-SgPsAssert "Set user password rule MaxCharacters via attribute" {
+            $result = Set-SafeguardUserPasswordRule -Insecure -MaxCharacters $newMax
+            $result.MaxCharacters -eq $newMax
+        }
+
+        Test-SgPsAssert "Set MaxCharacters persisted via readback" {
+            $readback = Get-SafeguardUserPasswordRule -Insecure
+            $readback.MaxCharacters -eq $newMax
+        }
+
+        # -- SET via Object --
+
+        Test-SgPsAssert "Set user password rule via RuleObject" {
+            $ruleObj = Get-SafeguardUserPasswordRule -Insecure
+            $ruleObj.Description = "SgPsTest modified rule"
+            $result = Set-SafeguardUserPasswordRule -Insecure -RuleObject $ruleObj
+            $result.Description -eq "SgPsTest modified rule"
+        }
+
+        Test-SgPsAssert "Set via RuleObject persisted via readback" {
+            $readback = Get-SafeguardUserPasswordRule -Insecure
+            $readback.Description -eq "SgPsTest modified rule"
+        }
+
+        # -- SET does not clobber unrelated properties --
+
+        Test-SgPsAssert "Set attribute does not clobber other properties" {
+            $before = Get-SafeguardUserPasswordRule -Insecure
+            $beforeName = $before.Name
+            $null = Set-SafeguardUserPasswordRule -Insecure -Description "Another change"
+            $after = Get-SafeguardUserPasswordRule -Insecure
+            $after.Name -eq $beforeName
+        }
+
+        # -- Restore before generate/validate tests --
+        Set-SafeguardUserPasswordRule -Insecure -RuleObject $original | Out-Null
+
+        # -- GENERATE PASSWORD --
+
+        Test-SgPsAssert "New-SafeguardUserPassword returns a non-empty string" {
+            $password = New-SafeguardUserPassword -Insecure
+            $null -ne $password -and $password.Length -gt 0
+        }
+
+        Test-SgPsAssert "Generated password meets rule length constraints" {
+            $rule = Get-SafeguardUserPasswordRule -Insecure
+            $password = New-SafeguardUserPassword -Insecure
+            $password.Length -ge $rule.MinCharacters -and $password.Length -le $rule.MaxCharacters
+        }
+
+        Test-SgPsAssert "New-SafeguardUserPassword with custom RuleObject" {
+            $customRule = Get-SafeguardUserPasswordRule -Insecure
+            $customRule.MinCharacters = 20
+            $customRule.MaxCharacters = 25
+            $password = New-SafeguardUserPassword -Insecure -RuleObject $customRule
+            $password.Length -ge 20 -and $password.Length -le 25
+        }
+
+        # -- VALIDATE PASSWORD --
+
+        Test-SgPsAssert "Test-SafeguardUserPassword returns true for generated password" {
+            $password = New-SafeguardUserPassword -Insecure
+            $secPassword = ConvertTo-SecureString $password -AsPlainText -Force
+            $result = Test-SafeguardUserPassword -Insecure -Password $secPassword
+            $result -eq $true
+        }
+
+        Test-SgPsAssert "Test-SafeguardUserPassword returns false for too-short password" {
+            $secPassword = ConvertTo-SecureString "a" -AsPlainText -Force
+            $result = Test-SafeguardUserPassword -Insecure -Password $secPassword
+            $result -eq $false
+        }
+
+        # -- Restore original rule --
+
+        Test-SgPsAssert "Restore original rule succeeds" {
+            $result = Set-SafeguardUserPasswordRule -Insecure -RuleObject $original
+            $result.MinCharacters -eq $original.MinCharacters -and
+                $result.MaxCharacters -eq $original.MaxCharacters
+        }
+
+        Test-SgPsAssert "Restore original rule verified via readback" {
+            $readback = Get-SafeguardUserPasswordRule -Insecure
+            $readback.MinCharacters -eq $original.MinCharacters -and
+                $readback.MaxCharacters -eq $original.MaxCharacters -and
+                $readback.Name -eq $original.Name
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+        # Registered cleanup restores original rule automatically
+    }
+}


### PR DESCRIPTION
Adds ~30 new cmdlets and fixes several bugs to close key API coverage gaps identified in the gap analysis.

New modules

 - reasoncodes.psm1 — Full CRUD for access request reason codes (Get/New/Edit/Remove-SafeguardReasonCode, Get-SafeguardReasonCodeScope)
 - runningtasks.psm1 — Task monitoring and cancellation (Get-SafeguardRunningTask, Stop-SafeguardRunningTask)

New cmdlets in existing modules

 - settings.psm1 — Get/Set-SafeguardDailyMessage, Get/Set-SafeguardLoginMessage, Get/Set-SafeguardUserPasswordRule, New-SafeguardUserPassword, Test-SafeguardUserPassword
 - auditlog.psm1 — 12 new cmdlets across 6 phases:
  - Access request drill-down (activity, session, playback, audit portal links)
  - Platform script change auditing (list, detail, raw content)
  - Object change history (by type, object ID, individual log entry)
  - Discovery job results (accounts, assets, services found)
  - Maintenance config management (get/set/run-now)
  - Signing certificate rotation history
  - Scheduled audit log reports (full CRUD + execute)

Bug fixes

 - Fixed DiscoveryServices/DiscoverySshKeys URL mappings in Get-SafeguardAuditLog
 - Fixed 3 copy-paste bugs in Edit-SafeguardAccountPasswordRule (profiles.psm1)
 - Added ROG-disabled error detection in Connect-Safeguard — suggests -Pkce or -Browser instead of showing a cryptic 400 error

Improvements to existing cmdlets

 - Get-SafeguardAuditLog: Added PlatformScripts log type, -Id parameter for detail lookups, proper parameter set separation

Testing

 - 10 new integration test suites (~160 tests), all passing against live appliance