### PR TITLE
fix: use ReleaseTag for GitHub Release title

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -157,7 +157,7 @@ jobs:
         target: '$(Build.SourceVersion)'
         tagSource: 'userSpecifiedTag'
         tag: '$(ReleaseTag)'
-        title: '$(VersionString)'
+        title: '$(ReleaseTag)'
         isPreRelease: $(isPrerelease)
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'


### PR DESCRIPTION
Use ReleaseTag instead of VersionString for the GitHub Release title so each prerelease build gets a unique, distinguishable name (e.g. dev/v8.3.0-pre261459 instead of just 8.3.0).