### PR TITLE
Use 3-digit SemVer in global-variables.yml for consistency

### DIFF
--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.3"
+    value: "8.3.0"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -28,9 +28,9 @@ if ($IsTagBuild -eq "True") {
 } else {
     $local:BuildNumber = ($BuildId - 102500) # shrink shared build number appropriately
     Write-Host "BuildNumber = $($local:BuildNumber)"
-    $local:VersionString = "${Version}.0"
+    $local:VersionString = "${Version}"
     $local:PrereleaseSuffix = "pre$($local:BuildNumber)"
-    $local:ReleaseTag = "dev/v${Version}.0-$($local:PrereleaseSuffix)"
+    $local:ReleaseTag = "dev/v${Version}-$($local:PrereleaseSuffix)"
     Write-Host "Dev build: VersionString = $($local:VersionString), PrereleaseSuffix = $($local:PrereleaseSuffix), ReleaseTag = $($local:ReleaseTag)"
 }
 

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -26,9 +26,9 @@ if [ "$isTagBuild" = "True" ]; then
 else
     buildNumber=$(expr $buildId - 102500) # shrink shared build number appropriately
     echo "buildNumber = ${buildNumber}"
-    versionString="$verNum.0"
+    versionString="$verNum"
     prereleaseSuffix="pre${buildNumber}"
-    releaseTag="dev/v${verNum}.0-${prereleaseSuffix}"
+    releaseTag="dev/v${verNum}-${prereleaseSuffix}"
     echo "Dev build: VersionString = $versionString, PrereleaseSuffix = $prereleaseSuffix, ReleaseTag = $releaseTag"
 fi
 


### PR DESCRIPTION
All other repos store the full 3-digit version (e.g. \8.3.0\) in \global-variables.yml\. safeguard-ps was storing 2-digit (\8.3\) and appending \.0\ in the version scripts. This aligns it with the convention used everywhere else.