### PR TITLE
Skills harmonization: rename architecture, add build-and-release and a2a-workflow

### DIFF
--- a/.agents/skills/a2a-workflow/SKILL.md
+++ b/.agents/skills/a2a-workflow/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: a2a-workflow
+description: Use when working on safeguard-ps A2A registrations, certificate authentication, credential retrieval, brokering, or A2A event listeners.
+---
+
+# A2A Workflow
+
+Use this skill when you need to configure Safeguard A2A from PowerShell, retrieve credentials with mutual TLS, broker access requests, or keep long-running handlers in sync with A2A events.
+
+## 1. What A2A is
+
+A2A in `safeguard-ps` is the certificate-authenticated application-to-application path for retrieving or updating managed credentials without using a bearer token session. The management-side cmdlets in `src\a2a.psm1` create and maintain A2A registrations under `Core/A2ARegistrations`, while the caller-side cmdlets in `src\a2acallers.psm1` use a client certificate plus an `A2A <ApiKey>` authorization header against the `/service/a2a/v4/...` endpoints. The module supports direct credential retrieval, bidirectional updates, access-request brokering, and real-time SignalR listeners.
+
+## 2. Setup flow
+
+### Start with the appliance service
+
+Before any caller workflow works, the appliance-side A2A service must be enabled.
+
+Useful cmdlets here are `Get-SafeguardA2aServiceStatus`, `Enable-SafeguardA2aService`, and `Disable-SafeguardA2aService`.
+
+Typical check:
+
+```powershell
+Get-SafeguardA2aServiceStatus -Appliance <address> -Insecure
+Enable-SafeguardA2aService -Appliance <address> -AccessToken $token -Insecure
+```
+
+### Register the certificate user
+
+The A2A registration points at a certificate-authenticated Safeguard user.
+
+Relevant evidence in the repo:
+
+- `samples\certificate-user-demo.ps1` shows certificate-user creation with a thumbprint
+- A2A tests create a certificate user by posting `PrimaryAuthenticationProvider = @{ Id = -2; Identity = <thumbprint> }`
+- test certs live under `test\TestData\CERTS\`
+
+A representative flow is:
+
+1. install the trusted root/intermediate certificates with `Install-SafeguardTrustedCertificate`
+2. create or identify a certificate-authenticated user
+3. capture the certificate thumbprint that will authenticate future A2A calls
+
+The tests use this sequence with `RootCA.pem`, `IntermediateCA.pem`, and `UserCert.pfx`.
+
+### Create the A2A registration
+
+Use the management cmdlets in `a2a.psm1`:
+
+```powershell
+New-SafeguardA2a "Ticket System" TicketSystemUser -Description "Ticket System Requester" -VisibleToCertificateUsers
+Get-SafeguardA2a "Ticket System"
+Edit-SafeguardA2a "Ticket System" -Description "Updated description"
+```
+
+Key management cmdlets are `New-SafeguardA2a`, `Get-SafeguardA2a`, `Edit-SafeguardA2a`, and `Remove-SafeguardA2a`.
+
+### Add credential retrieval and capture the API key
+
+After the registration exists, add retrievable accounts and fetch the generated API key:
+
+```powershell
+Add-SafeguardA2aCredentialRetrieval "Ticket System" <asset> <account>
+Get-SafeguardA2aCredentialRetrieval "Ticket System" <asset> <account>
+Get-SafeguardA2aCredentialRetrievalApiKey "Ticket System" <asset> <account>
+```
+
+Other useful management helpers are `Reset-SafeguardA2aCredentialRetrievalApiKey`, `Get-SafeguardA2aCredentialRetrievalInformation`, `Set-SafeguardA2aCredentialRetrievalIpRestriction`, and `Clear-SafeguardA2aCredentialRetrievalIpRestriction`.
+
+### When bidirectional updates matter
+
+The caller cmdlets `Set-SafeguardA2aPassword` and `Set-SafeguardA2aPrivateKey` write new secrets back through A2A. The integration tests explicitly create registrations with `BidirectionalEnabled = $true` by calling `Invoke-SafeguardMethod` directly, because `New-SafeguardA2a` does not currently expose that flag. If your workflow needs caller-side secret updates, verify the registration is configured for bidirectional use.
+
+## 3. Credential retrieval
+
+### Authentication parameter sets
+
+Every caller cmdlet uses one of three mutual-TLS modes:
+
+- `-CertificateFile [-Password]`
+- `-Thumbprint`
+- `-CertificateObject`
+
+`-CertificateObject` is worth preferring for integrations that load certificates from another secret store, because the help text explicitly calls out in-memory `X509Certificate2` use without persisting a PFX to disk.
+
+If you use `-CertificateFile` without `-Password`, the file-based cmdlets prompt with `Read-Host -AsSecureString`.
+
+### Discovery cmdlet
+
+`Get-SafeguardA2aRetrievableAccount` enumerates the accounts a certificate user can retrieve. It returns an object that includes:
+
+- `AppName`
+- `Description`
+- `Disabled`
+- `CertificateUser`
+- `CertificateUserThumbprint`
+- `ApiKey`
+- `AssetName`
+- `AccountName`
+- `DomainName`
+
+That makes it the quickest way to discover which API key maps to which account.
+
+### Direct retrieval and update cmdlets
+
+Password flow uses `Get-SafeguardA2aPassword` and `Set-SafeguardA2aPassword`. SSH key flow uses `Get-SafeguardA2aPrivateKey` and `Set-SafeguardA2aPrivateKey`, with `-KeyFormat OpenSsh|Ssh2|Putty` when needed. API key secret retrieval uses `Get-SafeguardA2aApiKeySecret`.
+
+Representative examples from the help:
+
+```powershell
+Get-SafeguardA2aPassword <appliance> <apiKey> -Thumbprint <thumbprint> -Insecure
+Get-SafeguardA2aPassword <appliance> $apiKey -CertificateObject $cert
+Get-SafeguardA2aPrivateKey <appliance> $apiKey -CertificateObject $cert -KeyFormat Putty
+Set-SafeguardA2aPassword <appliance> $apiKey -CertificateObject $cert -NewPassword $securePassword
+Set-SafeguardA2aPrivateKey <appliance> $apiKey -CertificateObject $cert -PrivateKey $key
+```
+
+### Management-side query helpers
+
+Use the `a2a.psm1` cmdlets when you are configuring or auditing registrations rather than calling them:
+
+- `Get-SafeguardA2aCredentialRetrieval`
+- `Add-SafeguardA2aCredentialRetrieval`
+- `Remove-SafeguardA2aCredentialRetrieval`
+- `Get-SafeguardA2aCredentialRetrievalApiKey`
+- `Reset-SafeguardA2aCredentialRetrievalApiKey`
+
+`Get-SafeguardA2aCredentialRetrieval` supports:
+
+- lookup by A2A name or ID
+- lookup by asset/account names or IDs
+- `-QueryFilter`
+- `-Fields`
+- `-OrderBy`
+
+The test suite covers both valid and invalid filter cases, so malformed filters should be treated as user input errors, not as a signal to silently retry with a different shape.
+
+## 4. Brokering
+
+A2A brokering is supported.
+
+Management-side broker cmdlets in `a2a.psm1` are `Get-SafeguardA2aAccessRequestBroker`, `Set-SafeguardA2aAccessRequestBroker`, `Clear-SafeguardA2aAccessRequestBroker`, `Get/Set/Clear-SafeguardA2aAccessRequestBrokerIpRestriction`, and `Get/Reset-SafeguardA2aAccessRequestBrokerApiKey`.
+
+`Set-SafeguardA2aAccessRequestBroker` requires at least one of:
+
+- `-Users`
+- `-Groups`
+
+It also validates every `-IpRestrictions` value with `Test-IpAddress` before sending the PUT.
+
+Caller-side request creation lives in `New-SafeguardA2aAccessRequest`.
+
+Important parameters supported by that cmdlet:
+
+- `-ApiKey`
+- `-ForUserName` or `-ForUserId`
+- `-AssetToUse`/`-AccountToUse` or `-AssetIdToUse`/`-AccountIdToUse`
+- `-ForProviderName`
+- `-Emergency`
+- `-ReasonCode`
+- `-ReasonComment`
+- `-TicketNumber`
+- `-RequestedFor`
+- `-RequestedDurationDays|Hours|Minutes`
+
+Accepted access request types include these aliases:
+
+- `Password`
+- `SSHKey` or `SSH`
+- `RemoteDesktop` or `RDP`
+- `RemoteDesktopApplication`, `RDPApplication`, or `RDPApp`
+- `Telnet`
+- `APIKey`
+- `File`
+
+The help text notes that brokering creates the access request on behalf of another user and the target user will then be notified via SignalR.
+
+## 5. Event listeners / SignalR
+
+### Core listener
+
+`Wait-SafeguardA2aEvent` is the low-level real-time listener. It:
+
+1. negotiates against `/service/a2a/signalr/`
+2. opens an SSE stream
+3. sends the SignalR handshake
+4. validates the handshake response
+5. reads and filters events until interrupted
+6. reconnects with exponential backoff for non-fatal failures
+
+You can use it in three modes:
+
+- pipeline output only
+- `-Handler { ... }`
+- `-HandlerScript <path>`
+
+If no handler is provided, it emits `PSCustomObject` items with `EventName` and `EventBody`.
+
+Example:
+
+```powershell
+Wait-SafeguardA2aEvent <appliance> $apiKey -Thumbprint <thumbprint> -Insecure -Event AssetAccountPasswordUpdated
+```
+
+### Higher-level handlers
+
+`Invoke-SafeguardA2aPasswordHandler`:
+
+- fetches the current password first
+- calls the handler with event name `InitialPassword`
+- subscribes only to `AssetAccountPasswordUpdated`
+- re-fetches the password after each matching event
+
+`Invoke-SafeguardA2aSshKeyHandler`:
+
+- fetches the current key first
+- calls the handler with event name `InitialSshKey`
+- subscribes only to `AssetAccountSshKeyUpdated`
+- re-fetches the private key after each matching event
+- respects `-KeyFormat OpenSsh|Ssh2|Putty`
+
+These handler cmdlets require exactly one of `-Handler` or `-HandlerScript`.
+
+## 6. Error scenarios and troubleshooting
+
+### Certificate and trust problems
+
+`Invoke-SafeguardA2aMethodWithCertificate` contains an explicit Windows warning: even when you provide a PFX file, the issuing CA may still need to be installed in the **Intermediate Certificate Authorities** store or Windows may fail to send the client certificate during the HTTPS handshake.
+
+Also watch for:
+
+- `Certificate with thumbprint '<value>' not found in CurrentUser\My store`
+- wrong PFX password when using `-CertificateFile`
+- a certificate chain that was never installed with `Install-SafeguardTrustedCertificate`
+
+### Service and registration problems
+
+Common checks:
+
+- verify `Get-SafeguardA2aServiceStatus`
+- confirm the registration exists with `Get-SafeguardA2a`
+- confirm the account is configured with `Get-SafeguardA2aCredentialRetrieval`
+- fetch the current key with `Get-SafeguardA2aCredentialRetrievalApiKey`
+- ensure bidirectional registration settings if using `Set-SafeguardA2aPassword` or `Set-SafeguardA2aPrivateKey`
+
+### Handler and listener problems
+
+The listener code throws on these usage errors:
+
+- `You must specify -Handler or -HandlerScript`
+- `You may specify -Handler or -HandlerScript but not both`
+- `Handler script not found: <path>`
+
+For `Wait-SafeguardA2aEvent`, fatal 4xx-class errors are treated as non-retryable; other connection failures log a warning and reconnect with backoff.
+
+### Input validation issues
+
+- IP restrictions are validated locally; non-IP strings throw before the REST call.
+- `Get-SafeguardA2aCredentialRetrieval` surfaces bad `-QueryFilter` input as an error.
+- `Set-SafeguardA2aAccessRequestBroker` throws if neither `-Users` nor `-Groups` is supplied.
+
+### Practical debugging checklist
+
+1. Check the appliance service status.
+2. Confirm the certificate user and thumbprint mapping.
+3. Confirm the A2A registration and account linkage.
+4. Re-read or regenerate the relevant API key.
+5. Retry the caller cmdlet with `-Verbose`.
+6. For event issues, start with `Wait-SafeguardA2aEvent` before layering on the password or SSH-key handlers.

--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -11,6 +11,38 @@ description: >-
 
 Use this skill when working directly with the Safeguard Web API, debugging cmdlets that wrap the API, or adding new cmdlet coverage for API endpoints.
 
+## 0. Cmdlet discovery
+
+Before writing any safeguard-ps code, use the built-in discovery tools:
+
+- **`Get-SafeguardCommand`** — searches available cmdlets by up to 3 keywords.
+  Returns matching cmdlet names so you don't have to guess.
+  ```powershell
+  Get-SafeguardCommand User           # all cmdlets with "User" in the name
+  Get-SafeguardCommand A2A Password   # A2A-related password cmdlets
+  Get-SafeguardCommand Trusted Cert   # trusted certificate management
+  ```
+
+- **`Get-Help <Cmdlet> -Full`** — shows complete parameter names, types, and
+  examples for any cmdlet. Always check this before guessing parameter names.
+  ```powershell
+  Get-Help New-SafeguardA2a -Full
+  Get-Help Add-SafeguardA2aCredentialRetrieval -Full
+  ```
+
+Common naming pitfalls (discovered through testing):
+
+| What you might guess | Actual cmdlet/parameter |
+|---|---|
+| `New-SafeguardA2aRegistration` | `New-SafeguardA2a` |
+| `-AccountToAdd` | `-Account` |
+| `-ParentA2a` (on Remove) | `-A2aToDelete` |
+| `Remove-SafeguardTrustedCertificate` | `Uninstall-SafeguardTrustedCertificate` |
+| `Install-SafeguardCertificate` | `Install-SafeguardTrustedCertificate` |
+
+**Rule: always run `Get-SafeguardCommand` first, then `Get-Help` to confirm
+parameter names before calling any cmdlet.**
+
 ## Quick rules
 
 - Prefer existing `Get-Safeguard*`, `Find-Safeguard*`, `New-Safeguard*`, `Edit-Safeguard*`, `Remove-Safeguard*`, and `Close-Safeguard*` cmdlets over raw `Invoke-SafeguardMethod`.

--- a/.agents/skills/appliance-test-setup/SKILL.md
+++ b/.agents/skills/appliance-test-setup/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: appliance-test-setup
+description: >-
+  Use when setting up test objects on a Safeguard appliance for integration
+  testing. Covers the creation sequence for users, assets, accounts,
+  certificates, A2A registrations, and cleanup.
+---
+
+# Appliance Test Setup
+
+Use this skill when you need to create test objects on a live Safeguard
+appliance for integration testing, then clean them up afterward.
+
+## Prerequisites
+
+- A connected safeguard-ps session (`Connect-Safeguard`)
+- An admin user with AssetAdmin, PolicyAdmin, and ApplianceAdmin roles
+- The bootstrap admin (local\Admin) cannot have its roles modified and may
+  lack AssetAdmin/PolicyAdmin — create a dedicated test admin first
+
+## Object creation sequence
+
+Objects have dependencies — create them in this order:
+
+1. **Test admin user** (with all admin roles)
+2. **Asset** (requires PlatformId and AssetPartitionId)
+3. **Account** on the asset
+4. **Client certificate** (for A2A)
+5. **Install certificate** as TrustedCertificate on appliance
+6. **Certificate user** (provider -2, linked by thumbprint)
+7. **A2A registration** (linked to certificate user)
+8. **Credential retrieval** on the A2A registration
+
+## Step-by-step
+
+### 1. Create test admin
+
+```powershell
+$pw = ConvertTo-SecureString "TestAdmin123!" -AsPlainText -Force
+New-SafeguardUser -Provider -1 -NewUserName "TestAdmin" -AdminRoles `
+    GlobalAdmin,ApplianceAdmin,AssetAdmin,PolicyAdmin,UserAdmin,HelpdeskAdmin,OperationsAdmin,SystemAuditor
+Set-SafeguardUserPassword -UserToEdit "TestAdmin" -NewPassword $pw
+```
+
+### 2. Create asset
+
+```powershell
+# Use Get-SafeguardPlatform to find valid PlatformId values
+$asset = New-SafeguardAsset -Name "TestAsset" -NetworkAddress "10.0.0.99" `
+    -Platform 56 -AssetPartitionId -1
+```
+
+Key notes:
+- `PlatformId` is an integer (use `Get-SafeguardPlatform` to list)
+- `AssetPartitionId` -1 means the Default Partition
+- Use `-Description` for test identification
+
+### 3. Create account on asset
+
+```powershell
+$acctPw = ConvertTo-SecureString "AccountP@ss1" -AsPlainText -Force
+$account = New-SafeguardAssetAccount -ParentAsset $asset.Id -NewAccountName "testacct"
+Set-SafeguardAssetAccountPassword -AccountToSet $account.Id -NewPassword $acctPw
+```
+
+### 4. Generate client certificate
+
+```powershell
+# Using OpenSSL (or any cert tool)
+openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem `
+    -days 7 -nodes -subj "/CN=TestA2A"
+openssl pkcs12 -export -in cert.pem -inkey key.pem -out cert.pfx -passout pass:test123
+```
+
+### 5. Install trusted certificate
+
+```powershell
+Install-SafeguardTrustedCertificate -CertificateFile cert.pem
+```
+
+### 6. Create certificate user
+
+```powershell
+$thumbprint = (Get-PfxCertificate cert.pfx).Thumbprint
+New-SafeguardUser -Provider -2 -NewUserName "TestCertUser" -Thumbprint $thumbprint
+```
+
+### 7. Create A2A registration
+
+```powershell
+$a2a = New-SafeguardA2a -CertificateUser "TestCertUser" -Name "TestA2A"
+```
+
+### 8. Add credential retrieval
+
+```powershell
+$retrieval = Add-SafeguardA2aCredentialRetrieval -ParentA2a $a2a.Id -Account $account.Id
+$apiKey = $retrieval.ApiKey
+```
+
+### 9. Enable A2A service (if not already)
+
+```powershell
+Enable-SafeguardA2aService
+# Verify:
+Get-SafeguardA2aServiceStatus
+```
+
+## Cleanup sequence (reverse order)
+
+Always clean up in reverse dependency order:
+
+```powershell
+# 1. Remove A2A registration
+Remove-SafeguardA2a -A2aToDelete $a2a.Id
+
+# 2. Remove certificate user
+Invoke-SafeguardMethod Core DELETE "Users/$certUserId"
+
+# 3. Remove trusted certificate
+Uninstall-SafeguardTrustedCertificate -Thumbprint $thumbprint
+
+# 4. Remove account (deletes with asset, or explicitly)
+Invoke-SafeguardMethod Core DELETE "AssetAccounts/$($account.Id)"
+
+# 5. Remove asset
+Invoke-SafeguardMethod Core DELETE "Assets/$($asset.Id)"
+
+# 6. Remove test admin (must be logged in as a different admin)
+Invoke-SafeguardMethod Core DELETE "Users/$testAdminId"
+```
+
+## Common gotchas
+
+- The bootstrap admin (Id: -2) returns 403 when you try to modify its roles
+- `New-SafeguardAsset` requires integer `PlatformId`, not a platform name or object
+- Certificate identity provider Id is always `-2`
+- Local identity provider Id is always `-1`
+- Default Asset Partition Id is `-1`
+- A2A service must be enabled before credential retrieval works
+- `Remove-SafeguardA2a` uses `-A2aToDelete` (not `-ParentA2a` or `-Id`)

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: architecture-deep-dive
+name: architecture
 description: >-
   Use when working on module internals, understanding the module manifest,
   SignalR event listeners, dynamic groups, custom platform scripts, or
   tracing how feature modules interact with the root module and global state.
 ---
 
-# Safeguard-PS Architecture Deep Dive
+# Safeguard-PS Architecture
 
 Use this skill when you need to reason about how the `safeguard-ps` module is wired together internally, not just how to call a public cmdlet.
 

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: build-and-release
+description: Use when working on Azure Pipelines builds, version stamping, signing, publishing, or release artifacts for safeguard-ps.
+---
+
+# Build and Release
+
+Use this skill when you need to reproduce CI locally, reason about version numbers, update Azure Pipelines, or troubleshoot how `safeguard-ps` is signed and published.
+
+## 1. Pipeline architecture
+
+### Entry point and shared files
+
+The release flow is driven by Azure Pipelines, not GitHub Actions.
+
+- `build.yml` -- only pipeline entry point
+- `pipeline-templates/global-variables.yml` -- shared variables such as the base semantic version and publish flags
+- `pipeline-templates/build-windows-steps.yml` -- Windows validation and module packaging steps
+- `pipeline-templates/build-linux-steps.yml` -- Linux validation plus Docker image build steps
+- `pipeline-templates/versionnumber.ps1` -- Windows version variable derivation
+- `pipeline-templates/versionnumber.sh` -- Linux version variable derivation
+- `pipeline-templates/install-forpipeline.ps1` -- manifest stamping, local install into `PSModulePath`, catalog creation, and strict linting
+
+### Triggers
+
+`build.yml` runs for:
+
+- pushes to `main`, `master`, and `release-*`
+- tags matching `v*`
+- PRs targeting `main`, `master`, and `release-*`
+
+It skips docs-only changes under these path exclusions:
+
+- `**/*.md`
+- `LICENSE`
+- `samples`
+- `.github`
+
+### Job layout
+
+There are four top-level jobs, no YAML `stages:` block:
+
+1. `PRValidation_Windows`
+   - condition: `Build.Reason == PullRequest`
+   - agent: `windows-latest`
+   - runs `build-windows-steps.yml`
+2. `PRValidation_Linux`
+   - condition: `Build.Reason == PullRequest`
+   - agent: `ubuntu-latest`
+   - runs `build-linux-steps.yml`
+3. `BuildAndPublish_Windows`
+   - condition: not pull request
+   - agent: `windows-latest`
+   - runs `build-windows-steps.yml`
+   - then signs and publishes the PowerShell module and creates a GitHub release asset
+4. `BuildAndPublish_Linux`
+   - condition: not pull request
+   - agent: `ubuntu-latest`
+   - runs `build-linux-steps.yml`
+   - then pushes Docker images when `shouldPublishDocker` is true
+
+### What the step templates actually do
+
+`build-windows-steps.yml`:
+
+- computes `VersionString`, `PrereleaseSuffix`, and `ReleaseTag` with `versionnumber.ps1`
+- finds a writable PowerShell module directory from `PSModulePath`
+- runs `install-forpipeline.ps1 <ModuleDir> <VersionString> <IsPrerelease> <PrereleaseSuffix>`
+- imports `safeguard-ps` to prove the staged module loads
+- parses every `src\*.ps1`, `src\*.psm1`, and `src\*.psd1` file under Windows PowerShell 5.1
+- imports the module again under Windows PowerShell 5.1 to catch compatibility regressions
+
+`build-linux-steps.yml`:
+
+- computes the same version variables with `versionnumber.sh`
+- locates a usable module directory from `PSModulePath`
+- runs the same `install-forpipeline.ps1` stamping/install/lint flow under PowerShell
+- builds Docker images for `ubuntu`, `azurelinux`, and `alpine`
+- tags the Alpine image as `oneidentity/safeguard-ps:latest`
+
+## 2. Version strategy
+
+### Source of truth
+
+The base released version lives in `pipeline-templates/global-variables.yml`:
+
+```yaml
+variables:
+  - name: version
+    value: "8.3.0"
+```
+
+The source manifest intentionally keeps a placeholder version:
+
+```powershell
+ModuleVersion = '8.3.99999'
+```
+
+Do not hand-edit the placeholder for normal development work.
+
+### Tag builds
+
+Tag builds are detected when `Build.SourceBranch` starts with `refs/tags/`.
+
+`versionnumber.ps1` and `versionnumber.sh` both require tags to match:
+
+```text
+v<major>.<minor>.<patch>
+```
+
+For a valid tag build:
+
+- `VersionString` becomes the tag without the leading `v`
+- `PrereleaseSuffix` becomes empty
+- `ReleaseTag` stays equal to the Git tag, for example `v8.3.0`
+- `isPrerelease` is false
+- `shouldPublishDocker` is true
+
+### Non-tag builds
+
+For branch and PR builds:
+
+- `VersionString` stays at the base version from `global-variables.yml`
+- `BuildNumber` is computed as `Build.BuildId - 102500`
+- `PrereleaseSuffix` becomes `pre<BuildNumber>`
+- `ReleaseTag` becomes `dev/v<version>-pre<BuildNumber>`
+- `isPrerelease` is true
+- `shouldPublishDocker` is false
+
+Example from the scripts:
+
+```text
+version     = 8.3.0
+Build.BuildId = 102745
+BuildNumber = 245
+PrereleaseSuffix = pre245
+ReleaseTag = dev/v8.3.0-pre245
+```
+
+### Manifest stamping behavior
+
+`install-forpipeline.ps1` converts the source manifest to the build version by:
+
+1. replacing `<major>.<minor>.99999` with `VersionString`
+2. replacing `Prerelease = 'pre'` with the computed prerelease suffix on non-tag builds
+3. commenting out the prerelease line on release builds
+4. creating `src\safeguard-ps.cat` on Windows with `New-FileCatalog`
+5. installing the stamped module into the selected `PSModulePath`
+6. running `./Invoke-PsLint.ps1 -Strict`
+
+## 3. Build commands
+
+### Fast local reproduction
+
+The repo has no compile step; the build is a staged module install from source.
+
+```powershell
+Remove-Module safeguard-ps -ErrorAction SilentlyContinue
+./cleanup-local.ps1
+./install-local.ps1
+Import-Module safeguard-ps
+Get-SafeguardCommand Get Asset
+```
+
+If you want local linting during install:
+
+```powershell
+./install-local.ps1 -WithLinting
+./Invoke-PsLint.ps1 -Strict
+```
+
+### Reproducing the pipeline install logic
+
+To mimic what CI does on Windows:
+
+```powershell
+$moduleDir = (($env:PSModulePath -split ';') | Where-Object { Test-Path $_ })[0]
+./pipeline-templates/versionnumber.ps1 8.3.0 102745 feature-branch False
+./pipeline-templates/install-forpipeline.ps1 $moduleDir 8.3.0 $true pre245
+Import-Module safeguard-ps -Force
+```
+
+To mimic the Linux template logic from PowerShell or `pwsh`:
+
+```powershell
+$moduleDir = (($env:PSModulePath.Split([System.IO.Path]::PathSeparator)) | Where-Object { Test-Path $_ })[0]
+./pipeline-templates/install-forpipeline.ps1 $moduleDir 8.3.0 $true pre245
+```
+
+To reproduce the Docker portion locally:
+
+```powershell
+bash ./docker/build-docker.sh ubuntu 8.3.0
+bash ./docker/build-docker.sh azurelinux 8.3.0
+bash ./docker/build-docker.sh alpine 8.3.0
+```
+
+### Windows compatibility checks worth preserving
+
+The Windows pipeline explicitly validates:
+
+- import under PowerShell 7+
+- parse success for all `src` files under Windows PowerShell 5.1
+- import under Windows PowerShell 5.1
+
+If you touch `src/`, keep those checks mentally in scope even for seemingly small syntax changes.
+
+## 4. Publishing targets
+
+### PowerShell Gallery
+
+The Windows publish job retrieves `PowerShellGalleryApiKey` and runs:
+
+```powershell
+Publish-Module -Name safeguard-ps -NuGetApiKey "$(PowerShellGalleryApiKey)" -Verbose -SkipAutomaticTags -Force
+```
+
+The published artifact is the staged module that `install-forpipeline.ps1` installed into the agent's module path.
+
+### Catalog signing
+
+The module is signed before publish by:
+
+1. downloading and silently installing SSL.com's `eSignerCKA`
+2. loading the code-signing certificate into `Cert:\CurrentUser\My`
+3. locating the generated `safeguard-ps.cat`
+4. finding the x86 `signtool.exe` under `C:\Program Files (x86)\Windows Kits`
+5. signing with SHA-256 and timestamping via `http://ts.ssl.com`
+6. verifying the result with `Get-AuthenticodeSignature`
+
+This pipeline signs the catalog file, not every source file individually.
+
+### GitHub release artifact
+
+After publish, the Windows job zips the installed module directory into:
+
+```text
+safeguard-ps-$(VersionString).zip
+```
+
+Then `GitHubRelease@1` creates a release in `OneIdentity/safeguard-ps` using `$(ReleaseTag)` and uploads the zip as the release asset.
+
+### Docker Hub
+
+The Linux publish job pushes:
+
+- `oneidentity/safeguard-ps:$(VersionString)-ubuntu`
+- `oneidentity/safeguard-ps:$(VersionString)-azurelinux`
+- `oneidentity/safeguard-ps:$(VersionString)-alpine`
+- `oneidentity/safeguard-ps:latest`
+
+Docker pushes only happen when `shouldPublishDocker` is true, which today means tag builds only.
+
+## 5. Service connections / secrets required
+
+### Azure Key Vault and service connections
+
+`build.yml` depends on these Azure DevOps connections:
+
+- `SafeguardOpenSource`
+  - Key Vault: `SafeguardBuildSecrets`
+  - secrets: `PowerShellGalleryApiKey`, `DockerHubAccessToken`, `DockerHubPassword`
+- `OneIdentity.Infrastructure.SPPCodeSigning`
+  - Key Vault: `SPPCodeSigning`
+  - secrets: `SPPCodeSigning-Password`, `SPPCodeSigning-TotpPrivateKey`
+
+### Other external connections
+
+- GitHub service connection: `PangaeaBuild-GitHub`
+- Docker Hub credentials are used by `docker login`
+- SSL.com eSigner account: `ssl.oid.safeguardpp@groups.quest.com`
+
+### Operational gotchas
+
+- PRs from forks cannot access secrets, so signing and publish steps only belong in non-PR jobs.
+- `install-forpipeline.ps1` always runs strict linting; pipeline failures there are usually real release blockers.
+- If signing fails, check both Key Vault secret retrieval and whether `eSignerCKATool.exe load` populated `Cert:\CurrentUser\My`.
+- If a release version looks wrong, inspect `global-variables.yml`, the incoming Git tag, and the `VersionString`/`PrereleaseSuffix` variables emitted by the versionnumber scripts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ Read the `SKILL.md` when your current task matches the trigger.
 | Build and Release | Working on Azure Pipelines, version stamping, signing, PowerShell Gallery publication, Docker publishing, or GitHub releases | `.agents/skills/build-and-release/SKILL.md` |
 | A2A Workflow | Working on A2A registrations, certificate auth, credential retrieval, brokering, or A2A event listeners | `.agents/skills/a2a-workflow/SKILL.md` |
 | New Feature Module | Creating new .psm1 modules, adding cmdlets, updating manifest | `.agents/skills/new-feature-module/SKILL.md` |
+| Appliance Test Setup | Integration test object lifecycle on live appliances | `.agents/skills/appliance-test-setup/SKILL.md` |
 
 ## Keeping this file current
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,17 @@ PSScriptAnalyzer is the linter. The lint script is `Invoke-PsLint.ps1`.
 **All code must pass `Invoke-PsLint.ps1 -Strict` before merging.** 11 rules are excluded
 with documented rationale in the script. Do not add new exclusions without justification.
 
+## Testing
+
+Integration tests live under `test/`, require PowerShell 7 and a live Safeguard appliance, and run through `test/Invoke-SafeguardPsTests.ps1`. Use the testing skill for suite selection, environment setup, and debugging details.
+
+```powershell
+./test/Invoke-SafeguardPsTests.ps1 -ListSuites
+./test/Invoke-SafeguardPsTests.ps1 -Appliance <address> -AdminPassword <password>
+```
+
+See `.agents/skills/testing-guide/SKILL.md` for the full workflow, optional SPS coverage, and suite-to-module mapping.
+
 ## Code conventions
 
 ### Cmdlet naming
@@ -124,7 +135,7 @@ Always use `ConvertTo-Json -Depth 100`. The default depth 2 silently truncates n
 - **`-JsonBody`** -- raw JSON string, sent as-is.
 - **Trap:** Passing a JSON string to `-Body` double-serializes it.
 
-## PowerShell 5.1 compatibility
+### PowerShell 5.1 compatibility
 
 The `src/` directory **must** remain compatible with Windows PowerShell 5.1:
 
@@ -134,14 +145,9 @@ The `src/` directory **must** remain compatible with Windows PowerShell 5.1:
 
 The `test/` directory requires PS 7 and is exempt.
 
-## Versioning
+## CI/CD
 
-`ModuleVersion` has a `99999` placeholder. **Do not edit.** CI replaces it with the build version.
-
-## CI/CD pipeline
-
-Azure Pipelines (not GitHub Actions). CI runs `pipeline-templates/install-forpipeline.ps1` which replaces
-the version placeholder, installs the module, and runs `Invoke-PsLint.ps1 -Strict`.
+See `.agents/skills/build-and-release/SKILL.md` for Azure Pipelines job layout, version stamping, signing, publishing targets, and required service connections.
 
 ## Security
 
@@ -150,6 +156,10 @@ the version placeholder, installs the module, and runs `Invoke-PsLint.ps1 -Stric
 - Certificate PFX files in `test/TestData/CERTS/` use password `a` (test-only certs)
 - `-Insecure` disables SSL verification -- never recommend for production
 
+## Versioning
+
+`ModuleVersion` has a `99999` placeholder. **Do not edit.** CI replaces it with the build version and prerelease suffixes. See `.agents/skills/build-and-release/SKILL.md` for the exact version derivation rules.
+
 ## On-demand skills
 
 The following skills contain deeper reference material loaded only when relevant.
@@ -157,11 +167,13 @@ Read the `SKILL.md` when your current task matches the trigger.
 
 | Skill | When to read | File |
 |-------|-------------|------|
-| Testing Guide | Running, writing, or debugging tests; setting up test environments | `.agents/skills/testing-guide/SKILL.md` |
+| Testing Guide | Running, writing, or debugging integration tests; setting up live test environments | `.agents/skills/testing-guide/SKILL.md` |
 | API Patterns | Making API calls, using filters/query params, exploring Swagger | `.agents/skills/api-patterns/SKILL.md` |
-| Architecture Deep Dive | Working on module internals, SignalR, dynamic groups, custom scripts | `.agents/skills/architecture-deep-dive/SKILL.md` |
+| Architecture | Working on module internals, SignalR, dynamic groups, custom scripts | `.agents/skills/architecture/SKILL.md` |
+| Build and Release | Working on Azure Pipelines, version stamping, signing, PowerShell Gallery publication, Docker publishing, or GitHub releases | `.agents/skills/build-and-release/SKILL.md` |
+| A2A Workflow | Working on A2A registrations, certificate auth, credential retrieval, brokering, or A2A event listeners | `.agents/skills/a2a-workflow/SKILL.md` |
 | New Feature Module | Creating new .psm1 modules, adding cmdlets, updating manifest | `.agents/skills/new-feature-module/SKILL.md` |
 
 ## Keeping this file current
 
-After completing tasks, propose updates for new patterns, corrections, or skill changes.
+After completing tasks, propose updates for new patterns, corrections, or skill changes. Update the routing table when skills are added, renamed, or retired, and keep CI/testing pointers aligned with the actual pipeline and test runner files.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Renamed `architecture-deep-dive` → `architecture`
- Created `build-and-release` skill (extracted CI/CD from AGENTS.md)
- Created `a2a-workflow` skill (A2A cmdlets, cert auth, event listeners)
- Updated AGENTS.md to standard template

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.