### PR TITLE
Fix version scheme for PSGallery prerelease compatibility

### DIFF
--- a/pipeline-templates/build-windows-steps.yml
+++ b/pipeline-templates/build-windows-steps.yml
@@ -79,3 +79,32 @@ steps:
       Write-Host "Module imported successfully under PS 5.1"
   displayName: 'Verify PS 5.1 compatibility (parse and import)'
 
+- task: PowerShell@2
+  inputs:
+    targetType: inline
+    pwsh: false
+    failOnStderr: true
+    script: |
+      $ErrorActionPreference = "Stop"
+      Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
+      Write-Host "Running PS 5.1 unit tests via Pester..."
+      $testDir = Join-Path "$(System.DefaultWorkingDirectory)" "test" "Unit"
+      if (-not (Test-Path $testDir))
+      {
+          Write-Host "No unit test directory found at $testDir, skipping."
+          return
+      }
+      $pesterModule = Get-Module -Name Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
+      if (-not $pesterModule -or $pesterModule.Version -lt [Version]"5.0.0")
+      {
+          Write-Host "Installing Pester 5..."
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+      }
+      Import-Module Pester -MinimumVersion 5.0.0
+      $config = New-PesterConfiguration
+      $config.Run.Path = $testDir
+      $config.Run.Exit = $true
+      $config.Output.Verbosity = "Detailed"
+      $results = Invoke-Pester -Configuration $config
+  displayName: 'Run unit tests under PS 5.1'
+

--- a/pipeline-templates/build-windows-steps.yml
+++ b/pipeline-templates/build-windows-steps.yml
@@ -88,10 +88,10 @@ steps:
       $ErrorActionPreference = "Stop"
       Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
       Write-Host "Running PS 5.1 unit tests via Pester..."
-      $testDir = Join-Path (Join-Path "$(System.DefaultWorkingDirectory)" "test") "Unit"
-      if (-not (Test-Path $testDir))
+      $testFile = Join-Path (Join-Path (Join-Path "$(System.DefaultWorkingDirectory)" "test") "Unit") "resolve-functions.Tests.ps1"
+      if (-not (Test-Path $testFile))
       {
-          Write-Host "No unit test directory found at $testDir, skipping."
+          Write-Host "No unit test file found at $testFile, skipping."
           return
       }
       $pesterModule = Get-Module -Name Pester -ListAvailable | Sort-Object Version -Descending | Select-Object -First 1
@@ -102,7 +102,7 @@ steps:
       }
       Import-Module Pester -MinimumVersion 5.0.0
       $config = New-PesterConfiguration
-      $config.Run.Path = $testDir
+      $config.Run.Path = $testFile
       $config.Run.Exit = $true
       $config.Output.Verbosity = "Detailed"
       $results = Invoke-Pester -Configuration $config

--- a/pipeline-templates/build-windows-steps.yml
+++ b/pipeline-templates/build-windows-steps.yml
@@ -88,7 +88,7 @@ steps:
       $ErrorActionPreference = "Stop"
       Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
       Write-Host "Running PS 5.1 unit tests via Pester..."
-      $testDir = Join-Path "$(System.DefaultWorkingDirectory)" "test" "Unit"
+      $testDir = Join-Path (Join-Path "$(System.DefaultWorkingDirectory)" "test") "Unit"
       if (-not (Test-Path $testDir))
       {
           Write-Host "No unit test directory found at $testDir, skipping."

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.3.1"
+    value: "8.4.0"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/pipeline-templates/install-forpipeline.ps1
+++ b/pipeline-templates/install-forpipeline.ps1
@@ -24,7 +24,7 @@ $ModuleName = "safeguard-ps"
 $Module = (Join-Path $RepoRoot "src\$ModuleName.psd1")
 $ModuleCatalog = (Join-Path $RepoRoot "src\$ModuleName.cat")
 
-$CodeVersion = "$($VersionString.Split(".")[0..1] -join ".").99999"
+$CodeVersion = "$($VersionString.Split(".")[0..2] -join ".").99999"
 $BuildVersion = "$($VersionString)"
 Write-Host "Replacing CodeVersion: $CodeVersion with BuildVersion: $BuildVersion"
 (Get-Content $Module -Raw).replace($CodeVersion, $BuildVersion) | Set-Content $Module

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -17,27 +17,20 @@ Write-Host "TagName = $TagName"
 Write-Host "IsTagBuild = $IsTagBuild"
 
 if ($IsTagBuild -eq "True") {
-    if ($TagName -notmatch '^v\d+\.\d+\.\d+(\.\d+)?$') {
-        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+$') {
+        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>"
         exit 1
     }
-    $local:BuildNumber = ($BuildId - 250000)
-    $local:TagVersion = $TagName -replace '^v', ''
-    $local:Segments = $local:TagVersion.Split(".")
-    if ($local:Segments.Count -eq 3) {
-        $local:VersionString = "$($local:TagVersion).$($local:BuildNumber)"
-    } else {
-        $local:VersionString = $local:TagVersion
-    }
+    $local:VersionString = $TagName -replace '^v', ''
     $local:PrereleaseSuffix = ""
     $local:ReleaseTag = $TagName
     Write-Host "Tag build: VersionString = $($local:VersionString), ReleaseTag = $($local:ReleaseTag)"
 } else {
     $local:BuildNumber = ($BuildId - 250000) # shrink shared build number appropriately
     Write-Host "BuildNumber = $($local:BuildNumber)"
-    $local:VersionString = "${Version}.${local:BuildNumber}"
-    $local:PrereleaseSuffix = "pre"
-    $local:ReleaseTag = "dev/v${Version}.${local:BuildNumber}-$($local:PrereleaseSuffix)"
+    $local:VersionString = "$Version"
+    $local:PrereleaseSuffix = "pre$($local:BuildNumber)"
+    $local:ReleaseTag = "dev/v${Version}-$($local:PrereleaseSuffix)"
     Write-Host "Dev build: VersionString = $($local:VersionString), PrereleaseSuffix = $($local:PrereleaseSuffix), ReleaseTag = $($local:ReleaseTag)"
 }
 

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -36,7 +36,7 @@ if ($IsTagBuild -eq "True") {
     $local:BuildNumber = ($BuildId - 250000) # shrink shared build number appropriately
     Write-Host "BuildNumber = $($local:BuildNumber)"
     $local:VersionString = "${Version}.${local:BuildNumber}"
-    $local:PrereleaseSuffix = "pre$($local:BuildNumber)"
+    $local:PrereleaseSuffix = "pre"
     $local:ReleaseTag = "dev/v${Version}.${local:BuildNumber}-$($local:PrereleaseSuffix)"
     Write-Host "Dev build: VersionString = $($local:VersionString), PrereleaseSuffix = $($local:PrereleaseSuffix), ReleaseTag = $($local:ReleaseTag)"
 }

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -17,8 +17,8 @@ Write-Host "TagName = $TagName"
 Write-Host "IsTagBuild = $IsTagBuild"
 
 if ($IsTagBuild -eq "True") {
-    if ($TagName -notmatch '^v\d+\.\d+\.\d+$') {
-        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>"
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
+        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>.<build>"
         exit 1
     }
     $local:VersionString = $TagName -replace '^v', ''
@@ -26,11 +26,11 @@ if ($IsTagBuild -eq "True") {
     $local:ReleaseTag = $TagName
     Write-Host "Tag build: VersionString = $($local:VersionString), ReleaseTag = $($local:ReleaseTag)"
 } else {
-    $local:BuildNumber = ($BuildId - 102500) # shrink shared build number appropriately
+    $local:BuildNumber = ($BuildId - 250000) # shrink shared build number appropriately
     Write-Host "BuildNumber = $($local:BuildNumber)"
-    $local:VersionString = "${Version}"
+    $local:VersionString = "${Version}.${local:BuildNumber}"
     $local:PrereleaseSuffix = "pre$($local:BuildNumber)"
-    $local:ReleaseTag = "dev/v${Version}-$($local:PrereleaseSuffix)"
+    $local:ReleaseTag = "dev/v${Version}.${local:BuildNumber}-$($local:PrereleaseSuffix)"
     Write-Host "Dev build: VersionString = $($local:VersionString), PrereleaseSuffix = $($local:PrereleaseSuffix), ReleaseTag = $($local:ReleaseTag)"
 }
 

--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -17,11 +17,18 @@ Write-Host "TagName = $TagName"
 Write-Host "IsTagBuild = $IsTagBuild"
 
 if ($IsTagBuild -eq "True") {
-    if ($TagName -notmatch '^v\d+\.\d+\.\d+\.\d+$') {
-        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>.<build>"
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+(\.\d+)?$') {
+        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
         exit 1
     }
-    $local:VersionString = $TagName -replace '^v', ''
+    $local:BuildNumber = ($BuildId - 250000)
+    $local:TagVersion = $TagName -replace '^v', ''
+    $local:Segments = $local:TagVersion.Split(".")
+    if ($local:Segments.Count -eq 3) {
+        $local:VersionString = "$($local:TagVersion).$($local:BuildNumber)"
+    } else {
+        $local:VersionString = $local:TagVersion
+    }
     $local:PrereleaseSuffix = ""
     $local:ReleaseTag = $TagName
     Write-Host "Tag build: VersionString = $($local:VersionString), ReleaseTag = $($local:ReleaseTag)"

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -15,27 +15,20 @@ echo "tagName = $tagName"
 echo "isTagBuild = $isTagBuild"
 
 if [ "$isTagBuild" = "True" ]; then
-    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
-        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>"
         exit 1
     fi
-    buildNumber=$(expr $buildId - 250000)
-    tagVersion="${tagName#v}"
-    segmentCount=$(echo "$tagVersion" | awk -F. '{print NF}')
-    if [ "$segmentCount" -eq 3 ]; then
-        versionString="${tagVersion}.${buildNumber}"
-    else
-        versionString="$tagVersion"
-    fi
+    versionString="${tagName#v}"
     prereleaseSuffix=""
     releaseTag="$tagName"
     echo "Tag build: VersionString = $versionString, ReleaseTag = $releaseTag"
 else
     buildNumber=$(expr $buildId - 250000) # shrink shared build number appropriately
     echo "buildNumber = ${buildNumber}"
-    versionString="${verNum}.${buildNumber}"
-    prereleaseSuffix="pre"
-    releaseTag="dev/v${verNum}.${buildNumber}-${prereleaseSuffix}"
+    versionString="${verNum}"
+    prereleaseSuffix="pre${buildNumber}"
+    releaseTag="dev/v${verNum}-${prereleaseSuffix}"
     echo "Dev build: VersionString = $versionString, PrereleaseSuffix = $prereleaseSuffix, ReleaseTag = $releaseTag"
 fi
 

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -15,11 +15,18 @@ echo "tagName = $tagName"
 echo "isTagBuild = $isTagBuild"
 
 if [ "$isTagBuild" = "True" ]; then
-    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
-        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>.<build>"
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
         exit 1
     fi
-    versionString="${tagName#v}"
+    buildNumber=$(expr $buildId - 250000)
+    tagVersion="${tagName#v}"
+    segmentCount=$(echo "$tagVersion" | awk -F. '{print NF}')
+    if [ "$segmentCount" -eq 3 ]; then
+        versionString="${tagVersion}.${buildNumber}"
+    else
+        versionString="$tagVersion"
+    fi
     prereleaseSuffix=""
     releaseTag="$tagName"
     echo "Tag build: VersionString = $versionString, ReleaseTag = $releaseTag"

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -34,7 +34,7 @@ else
     buildNumber=$(expr $buildId - 250000) # shrink shared build number appropriately
     echo "buildNumber = ${buildNumber}"
     versionString="${verNum}.${buildNumber}"
-    prereleaseSuffix="pre${buildNumber}"
+    prereleaseSuffix="pre"
     releaseTag="dev/v${verNum}.${buildNumber}-${prereleaseSuffix}"
     echo "Dev build: VersionString = $versionString, PrereleaseSuffix = $prereleaseSuffix, ReleaseTag = $releaseTag"
 fi

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -15,8 +15,8 @@ echo "tagName = $tagName"
 echo "isTagBuild = $isTagBuild"
 
 if [ "$isTagBuild" = "True" ]; then
-    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>"
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>.<build>"
         exit 1
     fi
     versionString="${tagName#v}"
@@ -24,11 +24,11 @@ if [ "$isTagBuild" = "True" ]; then
     releaseTag="$tagName"
     echo "Tag build: VersionString = $versionString, ReleaseTag = $releaseTag"
 else
-    buildNumber=$(expr $buildId - 102500) # shrink shared build number appropriately
+    buildNumber=$(expr $buildId - 250000) # shrink shared build number appropriately
     echo "buildNumber = ${buildNumber}"
-    versionString="$verNum"
+    versionString="${verNum}.${buildNumber}"
     prereleaseSuffix="pre${buildNumber}"
-    releaseTag="dev/v${verNum}-${prereleaseSuffix}"
+    releaseTag="dev/v${verNum}.${buildNumber}-${prereleaseSuffix}"
     echo "Dev build: VersionString = $versionString, PrereleaseSuffix = $prereleaseSuffix, ReleaseTag = $releaseTag"
 fi
 

--- a/src/a2a.psm1
+++ b/src/a2a.psm1
@@ -26,11 +26,11 @@ function Resolve-SafeguardA2aId
     {
         try
         {
-            $local:A2as = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
+            $local:A2as = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
                                 -Parameters @{ filter = "AppName ieq '$A2a'" })
             if (-not $local:A2as)
             {
-                $local:A2as = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
+                $local:A2as = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
                                     -Parameters @{ filter = "CertificateUser ieq '$A2a'" })
             }
         }
@@ -38,7 +38,7 @@ function Resolve-SafeguardA2aId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:A2as = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
+            $local:A2as = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET A2ARegistrations `
                                 -Parameters @{ q = $A2as })
         }
         if (-not $local:A2as)
@@ -92,14 +92,14 @@ function Resolve-SafeguardA2aAccountId
         }
         try
         {
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                     Core GET "A2ARegistrations/$A2aId/RetrievableAccounts" -Parameters @{ filter = $local:Filter })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                     Core GET "A2ARegistrations/$A2aId/RetrievableAccounts" -Parameters @{ q = $Account })
         }
         if (-not $local:Accounts)

--- a/src/assetpartitions.psm1
+++ b/src/assetpartitions.psm1
@@ -26,14 +26,14 @@ function Resolve-SafeguardAssetPartitionId
     {
         try
         {
-            $local:Partitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
+            $local:Partitions = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
                                  -Parameters @{ filter = "Name ieq '$AssetPartition'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Partitions = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
+            $local:Partitions = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AssetPartitions `
                                      -Parameters @{ q = $AssetPartition; fields = "Id" })
         }
         if (-not $local:Partitions)

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -44,11 +44,11 @@ function Resolve-SafeguardAsset
     {
         try
         {
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ filter = "Name ieq '$Asset'" })
             if (-not $local:Assets)
             {
-                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+                $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                      -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
             }
         }
@@ -56,7 +56,7 @@ function Resolve-SafeguardAsset
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $Asset })
         }
         if (-not $local:Assets)
@@ -132,11 +132,11 @@ function Resolve-SafeguardAssetId
     {
         try
         {
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ filter = "Name ieq '$Asset'"; fields = "Id" })
             if (-not $local:Assets)
             {
-                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+                $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                      -Parameters @{ filter = "NetworkAddress ieq '$Asset'"; fields = "Id" })
             }
         }
@@ -144,7 +144,7 @@ function Resolve-SafeguardAssetId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $Asset; fields = "Id" })
         }
         if (-not $local:Assets)
@@ -237,14 +237,14 @@ function Resolve-SafeguardAssetAccountId
     {
         try
         {
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                    -Parameters @{ filter = "Name ieq '$Account'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                    -Parameters @{ q = $Account; fields = "Id" })
         }
         if (-not $local:Accounts)

--- a/src/customplatforms.psm1
+++ b/src/customplatforms.psm1
@@ -47,6 +47,7 @@ Get-SafeguardCustomPlatform 65536
 function Get-SafeguardCustomPlatform
 {
     [CmdletBinding()]
+    [OutputType([object[]])]
     Param(
         [Parameter(Mandatory=$false)]
         [string]$Appliance,
@@ -84,7 +85,7 @@ function Get-SafeguardCustomPlatform
         else
         {
             $local:Parameters["filter"] = "PlatformFamily eq 'Custom' and DisplayName icontains '$PlatformToGet'"
-            $local:Results = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
+            $local:Results = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
                 GET Platforms -Parameters $local:Parameters)
             if (-not $local:Results)
             {

--- a/src/datatypes.psm1
+++ b/src/datatypes.psm1
@@ -27,14 +27,14 @@ function Resolve-SafeguardPlatform
         Write-Host "Searching for platforms with '$Platform'"
         try
         {
-            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+            $local:Platforms = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
                                     -Parameters @{ Filter = "DisplayName icontains '$Platform' and Id ge 500" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with icontains filter, trying with contains filter"
-            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+            $local:Platforms = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
                                     -Parameters @{ Filter = "DisplayName contains '$Platform' and Id ge 500" })
         }
         if (-not $local:Platforms)
@@ -89,7 +89,7 @@ function Resolve-SafeguardLdapDirectoryPlatform
         Write-Host "Searching for LDAP platforms with '$Platform'"
         try
         {
-            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+            $local:Platforms = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
                                     -Parameters @{ filter = "DisplayName icontains '$Platform' and DeviceClass eq 'Directory' and Id ne 522 and Id ge 500"; `
                                                    fields = "Id,DisplayName"; orderby = "Id" })
         }
@@ -97,13 +97,13 @@ function Resolve-SafeguardLdapDirectoryPlatform
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with icontains filter, trying with contains filter"
-            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+            $local:Platforms = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
                                     -Parameters @{ filter = "DisplayName contains '$Platform' and DeviceClass eq 'Directory' and Id ne 522 and Id ge 500"; `
                                                    fields = "Id,DisplayName"; orderby = "Id" })
         }
         if (-not $local:Platforms)
         {
-            $local:Platforms = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
+            $local:Platforms = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Platforms `
                                     -Parameters @{ q = "$Platform"; filter = "Id ge 500 and Id ne 522 and DeviceClass eq 'Directory'"; `
                                                    fields = "Id,DisplayName"; orderby = "Id" })
         }

--- a/src/deleted.psm1
+++ b/src/deleted.psm1
@@ -34,11 +34,11 @@ function Resolve-SafeguardDeletedAssetId
     {
         try
         {
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ filter = "Name ieq '$Asset'"; fields = "Id" })
             if (-not $local:Assets)
             {
-                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+                $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                      -Parameters @{ filter = "NetworkAddress ieq '$Asset'"; fields = "Id" })
             }
         }
@@ -46,7 +46,7 @@ function Resolve-SafeguardDeletedAssetId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $Asset; fields = "Id" })
         }
         if (-not $local:Assets)
@@ -293,14 +293,14 @@ function Resolve-SafeguardDeletedAssetAccountId
     {
         try
         {
-            $local:AssetAccounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:AssetAccounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                 -Parameters @{ filter = "Name ieq '$AssetAccount'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:AssetAccounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:AssetAccounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $AssetAccount; fields = "Id" })
         }
         if (-not $local:AssetAccounts)
@@ -547,14 +547,14 @@ function Resolve-SafeguardDeletedUserId
     {
         try
         {
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ filter = "Name ieq '$User' or DisplayName ieq '$User'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $User; fields = "Id" })
         }
         if (-not $local:Users)

--- a/src/directories.psm1
+++ b/src/directories.psm1
@@ -26,11 +26,11 @@ function Resolve-SafeguardDirectoryIdentityProviderId
     {
         try
         {
-            $local:Idps = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
+            $local:Idps = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
                                -Parameters @{ Filter = "Name ieq '$Directory'" })
             if (-not $local:Idps)
             {
-                $local:Idps = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
+                $local:Idps = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
                                    -Parameters @{ Filter = "DirectoryProperties.Domains.DomainName ieq '$Directory'" })
             }
         }
@@ -38,7 +38,7 @@ function Resolve-SafeguardDirectoryIdentityProviderId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Idps = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
+            $local:Idps = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET IdentityProviders `
                                       -Parameters @{ q = $Directory })
         }
         if (-not $local:Idps)
@@ -80,16 +80,16 @@ function Resolve-SafeguardDirectoryId
 
     if (-not ($Directory -as [int]))
     {
-        $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
+        $local:Directories = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
                                  -Parameters @{ filter = "IsDirectory eq true and Name ieq '$Directory'" })
         if (-not $local:Directories)
         {
-            $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
+            $local:Directories = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
                                      -Parameters @{ filter = "IsDirectory eq true and NetworkAddress ieq '$Directory'" })
         }
         if (-not $local:Directories)
         {
-            $local:Directories = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
+            $local:Directories = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Assets `
                                      -Parameters @{ filter = "IsDirectory eq true and DirectoryAssetProperties.Domains.DomainName ieq '$Directory'" })
         }
 
@@ -144,14 +144,14 @@ function Resolve-SafeguardDirectoryAccountId
         }
         try
         {
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
                                    -Parameters @{ filter = "Name ieq '$Account'" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
                                    -Parameters @{ q = $Account })
         }
         if (-not $local:Accounts)

--- a/src/discovery.psm1
+++ b/src/discovery.psm1
@@ -44,14 +44,14 @@ function Resolve-SafeguardAccountDiscoveryScheduleId
     {
         try
         {
-            $local:Schedules = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Schedules = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                     -Parameters @{ filter = "Name ieq '$Schedule'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Schedules = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Schedules = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                     -Parameters @{ q = $Schedule; fields = "Id" })
         }
         if (-not $local:Schedules)

--- a/src/entitlements.psm1
+++ b/src/entitlements.psm1
@@ -26,14 +26,14 @@ function Resolve-SafeguardEntitlementId
     {
         try
         {
-            $local:Entitlements = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Roles `
+            $local:Entitlements = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Roles `
                                  -Parameters @{ filter = "Name ieq '$Entitlement'" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Entitlements = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Roles `
+            $local:Entitlements = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Roles `
                                  -Parameters @{ q = $Entitlement })
         }
         if (-not $local:Entitlements)

--- a/src/events.psm1
+++ b/src/events.psm1
@@ -28,25 +28,25 @@ function Resolve-Event
         catch {}
         if (-not $local:FoundEvent)
         {
-            $local:Events = ((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+            $local:Events = @((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
                                   -Parameters @{ fields = "Name,Category,Description" }) | Where-Object { $_.Name -match "$EventObj" })
             if (($local:Events).Count -eq 0)
             {
-                $local:Events = ((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                $local:Events = @((Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
                                       -Parameters @{ fields = "Name,Category,Description" }) | Where-Object { $_.Category -match "$EventObj" })
             }
             if (($local:Events).Count -eq 0)
             {
                 try
                 {
-                    $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                    $local:Events = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
                                         -Parameters @{ filter = "Description icontains '$EventObj'"; fields = "Name,Category,Description" })
                 }
                 catch
                 {
                     Write-Verbose $_
                     Write-Verbose "Caught exception with icontains filter, trying with contains filter"
-                    $local:Events = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
+                    $local:Events = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Events `
                                         -Parameters @{ filter = "Description contains '$EventObj'"; fields = "Name,Category,Description" })
                 }
             }

--- a/src/groups.psm1
+++ b/src/groups.psm1
@@ -38,7 +38,7 @@ function Resolve-SafeguardGroupId
     if (-not ($Group -as [int]))
     {
         $local:EscapedName = $Group -replace "'", "\'"
-        $local:Groups = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+        $local:Groups = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
                                                 -Parameters @{ filter = "Name ieq '$($local:EscapedName)'" })
         if (-not $local:Groups)
         {

--- a/src/policies.psm1
+++ b/src/policies.psm1
@@ -26,11 +26,11 @@ function Resolve-SafeguardPolicyAssetId
     {
         try
         {
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
                                  -Parameters @{ filter = "Name ieq '$Asset'" })
             if (-not $local:Assets)
             {
-                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+                $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
                                      -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
             }
         }
@@ -38,7 +38,7 @@ function Resolve-SafeguardPolicyAssetId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET PolicyAssets `
                                  -Parameters @{ q = $Asset })
         }
         if (-not $local:Assets)
@@ -98,14 +98,14 @@ function Resolve-SafeguardPolicyAccountId
         }
         try
         {
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
                                    -Parameters @{ filter = "$($local:PreFilter)Name ieq '$Account'" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Accounts = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
+            $local:Accounts = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET $local:RelativeUrl `
                                    -Parameters @{ q = $Account })
         }
         if (-not $local:Accounts)
@@ -156,7 +156,7 @@ function Resolve-SafeguardAccessPolicyId
         }
         try
         {
-            $local:AccessPolicies = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AccessPolicies `
+            $local:AccessPolicies = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AccessPolicies `
                                  -Parameters @{ filter = $local:Filter })
         }
         catch
@@ -168,7 +168,7 @@ function Resolve-SafeguardAccessPolicyId
             {
                 $local:Params["filter"] = "RoleId eq $EntitlementId"
             }
-            $local:AccessPolicies = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AccessPolicies `
+            $local:AccessPolicies = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET AccessPolicies `
                                  -Parameters $local:Params)
         }
         if (-not $local:AccessPolicies)

--- a/src/profiles.psm1
+++ b/src/profiles.psm1
@@ -55,14 +55,14 @@ function Resolve-SafeguardProfileItemId
     {
         try
         {
-            $local:ItemList = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:ItemList = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                    -Parameters @{ filter = "Name ieq '$Item'"; fields = "Id" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:ItemList = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:ItemList = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                    -Parameters @{ q = $Item; fields = "Id" })
         }
         if (-not $local:ItemList)

--- a/src/reasoncodes.psm1
+++ b/src/reasoncodes.psm1
@@ -26,14 +26,14 @@ function Resolve-SafeguardReasonCodeId
     {
         try
         {
-            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
+            $local:ReasonCodes = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
                                  -Parameters @{ filter = "Name ieq '$ReasonCode'" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
+            $local:ReasonCodes = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "ReasonCodes" `
                                  -Parameters @{ q = $ReasonCode })
         }
         if (-not $local:ReasonCodes)

--- a/src/requests.psm1
+++ b/src/requests.psm1
@@ -27,11 +27,11 @@ function Resolve-SafeguardRequestableAssetId
     {
         try
         {
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
                                  -Parameters @{ filter = "Name ieq '$Asset'" })
             if (-not $local:Assets)
             {
-                $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
+                $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
                                      -Parameters @{ filter = "NetworkAddress ieq '$Asset'" })
             }
         }
@@ -39,7 +39,7 @@ function Resolve-SafeguardRequestableAssetId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Assets = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
+            $local:Assets = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Me/AccessRequestAssets" `
                                  -Parameters @{ q = $Asset })
         }
         if (-not $local:Assets)

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -11,7 +11,7 @@
 RootModule = 'safeguard-ps.psm1'
 
 # Version number of this module.
-ModuleVersion = '8.3.99999'
+ModuleVersion = '8.4.0.99999'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/sg-utilities.psm1
+++ b/src/sg-utilities.psm1
@@ -629,14 +629,14 @@ function Resolve-ReasonCodeId
     {
         try
         {
-            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+            $local:ReasonCodes = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                       Core GET ReasonCodes -Parameters @{ filter = "Name ieq '$ReasonCode'" })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:ReasonCodes = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
+            $local:ReasonCodes = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure `
                                       Core GET ReasonCodes -Parameters @{ q = $ReasonCode })
         }
         if (-not $local:ReasonCodes)

--- a/src/syslog.psm1
+++ b/src/syslog.psm1
@@ -28,11 +28,11 @@ function Resolve-SafeguardSyslogServerId
     {
         try
         {
-            $local:Resources = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Resources = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ filter = "Name ieq '$ToResolve'"; fields = "Id" })
             if (-not $local:Resources)
             {
-                $local:Resources = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+                $local:Resources = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                      -Parameters @{ filter = "NetworkAddress ieq '$ToResolve'"; fields = "Id" })
             }
         }
@@ -40,7 +40,7 @@ function Resolve-SafeguardSyslogServerId
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Resources = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
+            $local:Resources = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" `
                                  -Parameters @{ q = $ToResolve; fields = "Id" })
         }
         if (-not $local:Resources)

--- a/src/tags.psm1
+++ b/src/tags.psm1
@@ -96,11 +96,11 @@ function Resolve-SafeguardTagId {
     if (-not ($Tag -as [int])) {
         # get tag based on name
         $local:EscapedTagName = $Tag -replace "'", "\'"
-        $local:Tags = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" -Parameters @{ filter = "Name ieq '$($local:EscapedTagName)'"; fields = "Id,AssetPartitionId" })
+        $local:Tags = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)" -Parameters @{ filter = "Name ieq '$($local:EscapedTagName)'"; fields = "Id,AssetPartitionId" })
     } else {
         # Tag ID was supplied as param, not tag name
         # Confirm that the tag with this ID actually exists.
-        $local:Tags = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)/$($Tag)" -Parameters @{ fields = "Id,AssetPartitionId" })
+        $local:Tags = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "$($local:RelPath)/$($Tag)" -Parameters @{ fields = "Id,AssetPartitionId" })
     }
 
     if (-not $local:Tags)

--- a/src/users.psm1
+++ b/src/users.psm1
@@ -32,14 +32,14 @@ function Resolve-SafeguardUserObject
         }
         try
         {
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
                                 -Parameters @{ filter = $local:Filter })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
                                 -Parameters @{ q = $User })
         }
         if (-not $local:Users)
@@ -89,14 +89,14 @@ function Resolve-SafeguardUserId
         }
         try
         {
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
                                 -Parameters @{ filter = $local:Filter })
         }
         catch
         {
             Write-Verbose $_
             Write-Verbose "Caught exception with ieq filter, trying with q parameter"
-            $local:Users = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
+            $local:Users = @(Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET Users `
                                 -Parameters @{ q = $User })
         }
         if (-not $local:Users)

--- a/test/Unit/resolve-functions.Tests.ps1
+++ b/test/Unit/resolve-functions.Tests.ps1
@@ -175,7 +175,6 @@ Describe 'PS 5.1 .Count behavior simulation' {
     }
 
     It '@() wrapping gives .Count 0 for empty/null result' {
-        $empty = @($null)
         # @($null) gives array with 1 null element, but -not @($null) should handle it
         # The actual pattern uses: if (-not $var) which is what matters
         $fromEmpty = @()

--- a/test/Unit/resolve-functions.Tests.ps1
+++ b/test/Unit/resolve-functions.Tests.ps1
@@ -1,0 +1,194 @@
+#Requires -Modules @{ ModuleName='Pester'; ModuleVersion='5.0.0' }
+
+# Pester 5 tests for Resolve-* functions.
+# Validates that single-result API responses are handled correctly across
+# both PS 5.1 (where PSCustomObject lacks .Count) and PS 7+.
+#
+# These tests mock Invoke-SafeguardMethod to return a single PSCustomObject
+# (simulating the PS 5.1 behavior where Invoke-RestMethod unwraps single-element
+# arrays) and verify that resolve functions return the correct ID without throwing.
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+    $script:RepoRoot = Split-Path -Parent $script:RepoRoot
+    $script:SrcDir = Join-Path $script:RepoRoot 'src'
+    $script:Manifest = Join-Path $script:SrcDir 'safeguard-ps.psd1'
+
+    Get-Module safeguard-ps | Remove-Module -Force -ErrorAction SilentlyContinue
+    Import-Module $script:Manifest -Force
+}
+
+AfterAll {
+    Get-Module safeguard-ps | Remove-Module -Force -ErrorAction SilentlyContinue
+}
+
+Describe 'Resolve-SafeguardDirectoryId - single result handling' {
+    BeforeAll {
+        Import-Module (Join-Path $script:SrcDir 'directories.psm1') -Force
+    }
+
+    It 'Returns correct ID when API returns a single directory object' {
+        # Simulate single PSCustomObject (as PS 5.1 delivers from Invoke-RestMethod)
+        $singleDirectory = [PSCustomObject]@{ Id = 42; Name = "test.corp"; NetworkAddress = "10.0.0.1" }
+
+        Mock Invoke-SafeguardMethod {
+            # First call (Name filter) returns the single object
+            $singleDirectory
+        } -ModuleName directories
+
+        $result = Resolve-SafeguardDirectoryId -Appliance "fake" -AccessToken "fake" -Insecure "test.corp"
+        $result | Should -Be 42
+    }
+
+    It 'Returns correct ID when directory found via DomainName filter (third query)' {
+        $callCount = 0
+        $singleDirectory = [PSCustomObject]@{ Id = 99; Name = "dc1.test.corp"; NetworkAddress = "10.0.0.2" }
+
+        Mock Invoke-SafeguardMethod {
+            $script:callCount++
+            if ($script:callCount -le 2) {
+                # First two queries (Name, NetworkAddress) return empty
+                return @()
+            }
+            # Third query (DomainName) returns the single object
+            $singleDirectory
+        } -ModuleName directories
+
+        $script:callCount = 0
+        $result = Resolve-SafeguardDirectoryId -Appliance "fake" -AccessToken "fake" -Insecure "test.corp"
+        $result | Should -Be 99
+    }
+
+    It 'Throws when no directory is found' {
+        Mock Invoke-SafeguardMethod {
+            return @()
+        } -ModuleName directories
+
+        { Resolve-SafeguardDirectoryId -Appliance "fake" -AccessToken "fake" -Insecure "nonexistent" } |
+            Should -Throw "*Unable to find directory*"
+    }
+
+    It 'Throws with correct count when multiple directories match' {
+        $multipleResults = @(
+            [PSCustomObject]@{ Id = 1; Name = "dir1" },
+            [PSCustomObject]@{ Id = 2; Name = "dir2" }
+        )
+
+        Mock Invoke-SafeguardMethod {
+            $multipleResults
+        } -ModuleName directories
+
+        { Resolve-SafeguardDirectoryId -Appliance "fake" -AccessToken "fake" -Insecure "ambiguous" } |
+            Should -Throw "*Found 2 directories*"
+    }
+}
+
+Describe 'Resolve-SafeguardAsset - single result handling' {
+    BeforeAll {
+        Import-Module (Join-Path $script:SrcDir 'assetpartitions.psm1') -Force
+        Import-Module (Join-Path $script:SrcDir 'assets.psm1') -Force
+    }
+
+    It 'Returns correct asset object when API returns a single asset' {
+        $singleAsset = [PSCustomObject]@{ Id = 55; Name = "myserver"; NetworkAddress = "10.1.1.1" }
+
+        Mock Invoke-SafeguardMethod {
+            $singleAsset
+        } -ModuleName assets
+
+        Mock Resolve-AssetPartitionIdFromSafeguardSession {
+            return $null
+        } -ModuleName assets
+
+        $result = Resolve-SafeguardAsset -Appliance "fake" -AccessToken "fake" -Insecure "myserver"
+        $result.Id | Should -Be 55
+    }
+
+    It 'Throws with correct count when multiple assets match' {
+        $multipleAssets = @(
+            [PSCustomObject]@{ Id = 1; Name = "srv1" },
+            [PSCustomObject]@{ Id = 2; Name = "srv2" }
+        )
+
+        Mock Invoke-SafeguardMethod {
+            $multipleAssets
+        } -ModuleName assets
+
+        Mock Resolve-AssetPartitionIdFromSafeguardSession {
+            return $null
+        } -ModuleName assets
+
+        { Resolve-SafeguardAsset -Appliance "fake" -AccessToken "fake" -Insecure "ambiguous" } |
+            Should -Throw "*Found 2 assets*"
+    }
+}
+
+Describe 'Resolve-SafeguardDirectoryIdentityProviderId - single result handling' {
+    BeforeAll {
+        Import-Module (Join-Path $script:SrcDir 'directories.psm1') -Force
+    }
+
+    It 'Returns correct ID when API returns a single identity provider' {
+        $singleIdp = [PSCustomObject]@{ Id = 77; Name = "ad.corp" }
+
+        Mock Invoke-SafeguardMethod {
+            $singleIdp
+        } -ModuleName directories
+
+        $result = Resolve-SafeguardDirectoryIdentityProviderId -Appliance "fake" -AccessToken "fake" -Insecure "ad.corp"
+        $result | Should -Be 77
+    }
+}
+
+Describe 'Resolve-SafeguardUser - single result handling' {
+    BeforeAll {
+        Import-Module (Join-Path $script:SrcDir 'users.psm1') -Force
+    }
+
+    It 'Returns correct ID when API returns a single user' {
+        $singleUser = [PSCustomObject]@{ Id = 101; UserName = "jdoe"; Name = "John Doe" }
+
+        Mock Invoke-SafeguardMethod {
+            $singleUser
+        } -ModuleName users
+
+        $result = Resolve-SafeguardUserId -Appliance "fake" -AccessToken "fake" -Insecure "jdoe"
+        $result | Should -Be 101
+    }
+}
+
+Describe 'PS 5.1 .Count behavior simulation' {
+    # This test explicitly validates the root cause of the bug:
+    # In PS 5.1, a single PSCustomObject does not have .Count
+    # Our @() wrapping must handle this correctly
+
+    It '@() wrapping ensures .Count works for a single object' {
+        $single = [PSCustomObject]@{ Id = 1 }
+        $wrapped = @($single)
+        $wrapped.Count | Should -Be 1
+    }
+
+    It '@() wrapping preserves correct .Count for multiple objects' {
+        $multi = @([PSCustomObject]@{ Id = 1 }, [PSCustomObject]@{ Id = 2 })
+        $wrapped = @($multi)
+        $wrapped.Count | Should -Be 2
+    }
+
+    It '@() wrapping gives .Count 0 for empty/null result' {
+        $empty = @($null)
+        # @($null) gives array with 1 null element, but -not @($null) should handle it
+        # The actual pattern uses: if (-not $var) which is what matters
+        $fromEmpty = @()
+        $fromEmpty.Count | Should -Be 0
+        (-not $fromEmpty) | Should -Be $true
+    }
+
+    It 'Single object without @() has no .Count in PS 5.1 semantics' {
+        # This test documents the bug behavior - in PS 7 this passes
+        # because .Count is intrinsic, but the logic we test is the fix
+        $single = [PSCustomObject]@{ Id = 1 }
+        # After our fix, we always wrap, so this just validates the fix works
+        $wrapped = @($single)
+        ($wrapped.Count -ne 1) | Should -Be $false
+    }
+}


### PR DESCRIPTION
PSGallery requires exactly 3-segment ModuleVersion when a prerelease suffix is used. The 4-segment scheme from #624 caused publish failures.

Dev builds: `8.4.0-pre116409` (3-segment version + prerelease suffix with build number)
Tagged releases: `8.4.0` (3-segment, no prerelease)