### PR TITLE
Fix version scheme for PSGallery prerelease compatibility

### DIFF
--- a/pipeline-templates/versionnumber.ps1
+++ b/pipeline-templates/versionnumber.ps1
@@ -17,27 +17,20 @@ Write-Host "TagName = $TagName"
 Write-Host "IsTagBuild = $IsTagBuild"
 
 if ($IsTagBuild -eq "True") {
-    if ($TagName -notmatch '^v\d+\.\d+\.\d+(\.\d+)?$') {
-        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
+    if ($TagName -notmatch '^v\d+\.\d+\.\d+$') {
+        Write-Error "Tag '$TagName' does not match expected format v<major>.<minor>.<patch>"
         exit 1
     }
-    $local:BuildNumber = ($BuildId - 250000)
-    $local:TagVersion = $TagName -replace '^v', ''
-    $local:Segments = $local:TagVersion.Split(".")
-    if ($local:Segments.Count -eq 3) {
-        $local:VersionString = "$($local:TagVersion).$($local:BuildNumber)"
-    } else {
-        $local:VersionString = $local:TagVersion
-    }
+    $local:VersionString = $TagName -replace '^v', ''
     $local:PrereleaseSuffix = ""
     $local:ReleaseTag = $TagName
     Write-Host "Tag build: VersionString = $($local:VersionString), ReleaseTag = $($local:ReleaseTag)"
 } else {
     $local:BuildNumber = ($BuildId - 250000) # shrink shared build number appropriately
     Write-Host "BuildNumber = $($local:BuildNumber)"
-    $local:VersionString = "${Version}.${local:BuildNumber}"
-    $local:PrereleaseSuffix = "pre"
-    $local:ReleaseTag = "dev/v${Version}.${local:BuildNumber}-$($local:PrereleaseSuffix)"
+    $local:VersionString = "$Version"
+    $local:PrereleaseSuffix = "pre$($local:BuildNumber)"
+    $local:ReleaseTag = "dev/v${Version}-$($local:PrereleaseSuffix)"
     Write-Host "Dev build: VersionString = $($local:VersionString), PrereleaseSuffix = $($local:PrereleaseSuffix), ReleaseTag = $($local:ReleaseTag)"
 }
 

--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -15,27 +15,20 @@ echo "tagName = $tagName"
 echo "isTagBuild = $isTagBuild"
 
 if [ "$isTagBuild" = "True" ]; then
-    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
-        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>[.<build>]"
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "##[error]Tag '$tagName' does not match expected format v<major>.<minor>.<patch>"
         exit 1
     fi
-    buildNumber=$(expr $buildId - 250000)
-    tagVersion="${tagName#v}"
-    segmentCount=$(echo "$tagVersion" | awk -F. '{print NF}')
-    if [ "$segmentCount" -eq 3 ]; then
-        versionString="${tagVersion}.${buildNumber}"
-    else
-        versionString="$tagVersion"
-    fi
+    versionString="${tagName#v}"
     prereleaseSuffix=""
     releaseTag="$tagName"
     echo "Tag build: VersionString = $versionString, ReleaseTag = $releaseTag"
 else
     buildNumber=$(expr $buildId - 250000) # shrink shared build number appropriately
     echo "buildNumber = ${buildNumber}"
-    versionString="${verNum}.${buildNumber}"
-    prereleaseSuffix="pre"
-    releaseTag="dev/v${verNum}.${buildNumber}-${prereleaseSuffix}"
+    versionString="${verNum}"
+    prereleaseSuffix="pre${buildNumber}"
+    releaseTag="dev/v${verNum}-${prereleaseSuffix}"
     echo "Dev build: VersionString = $versionString, PrereleaseSuffix = $prereleaseSuffix, ReleaseTag = $releaseTag"
 fi
 


### PR DESCRIPTION
PSGallery requires exactly 3-segment ModuleVersion when a prerelease suffix is used. The 4-segment scheme from #624 caused the post-merge publish to fail (build 366409).

Dev builds: 8.4.0-pre116409 (3-segment + prerelease with build number)
Tagged releases (v8.4.0): 8.4.0 (3-segment, no prerelease)