### PR TITLE
Bump version to 8.4.1 for next prerelease cycle

### DIFF
--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.4.0"
+    value: "8.4.1"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -11,7 +11,7 @@
 RootModule = 'safeguard-ps.psm1'
 
 # Version number of this module.
-ModuleVersion = '8.4.0.99999'
+ModuleVersion = '8.4.1.99999'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Increments version after v8.4.0 release. Dev builds will now publish as 8.4.1-pre<buildnumber>.