### PR TITLE
Add cmdlets for managing OAuth2 grant types which are enabled on the appliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,6 +956,9 @@ Aliases are shown in parentheses where available.
 - `Set-SafeguardApplianceSetting`
 - `Get-SafeguardCoreSetting`
 - `Set-SafeguardCoreSetting`
+- `Get-SafeguardOAuth2GrantType`
+- `Enable-SafeguardOAuth2GrantType`
+- `Disable-SafeguardOAuth2GrantType`
 - `Get-SafeguardDebugSettings`
 - `Set-SafeguardDebugSettings`
 - `Enable-SafeguardTlsLogging`

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -308,6 +308,7 @@ FunctionsToExport = @(
     # setting.psm1
     'Get-SafeguardApplianceSetting','Set-SafeguardApplianceSetting','Get-SafeguardCoreSetting','Set-SafeguardCoreSetting',
     'Get-SafeguardDailyMessage','Set-SafeguardDailyMessage','Get-SafeguardLoginMessage','Set-SafeguardLoginMessage',
+    'Get-SafeguardOAuth2GrantType','Enable-SafeguardOAuth2GrantType','Disable-SafeguardOAuth2GrantType',
     'Get-SafeguardUserPasswordRule','Set-SafeguardUserPasswordRule','New-SafeguardUserPassword','Test-SafeguardUserPassword',
     # deleted.psm1
     'Get-SafeguardDeletedAsset','Remove-SafeguardDeletedAsset','Restore-SafeguardDeletedAsset',

--- a/src/settings.psm1
+++ b/src/settings.psm1
@@ -1,4 +1,4 @@
-﻿<# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
+<# Copyright (c) 2026 One Identity LLC. All rights reserved. #>
 
 <#
 .SYNOPSIS
@@ -977,4 +977,216 @@ function Test-SafeguardUserPassword
             throw
         }
     }
+}
+
+<#
+.SYNOPSIS
+Get the currently enabled OAuth2 grant types from a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Get the list of OAuth2 grant types that are currently enabled on the Safeguard appliance.
+The Authorization Code with PKCE grant type is always enabled and cannot be disabled.
+The grant types that can be managed are: AuthorizationCode (without PKCE enforcement),
+Implicit, ResourceOwner, and DeviceCode.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A list of strings representing the currently enabled OAuth2 grant types.
+
+.EXAMPLE
+Get-SafeguardOAuth2GrantType -AccessToken $token -Appliance 10.5.32.54 -Insecure
+
+.EXAMPLE
+Get-SafeguardOAuth2GrantType
+#>
+function Get-SafeguardOAuth2GrantType
+{
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Setting = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings/Allowed OAuth2 Grant Types")
+    $local:Value = $local:Setting.Value
+    if ([string]::IsNullOrWhiteSpace($local:Value))
+    {
+        [object[]]@()
+    }
+    else
+    {
+        [object[]]@($local:Value.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+    }
+}
+
+
+<#
+.SYNOPSIS
+Enable an OAuth2 grant type on a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Enable one or more OAuth2 grant types on the Safeguard appliance. The valid grant types
+are: AuthorizationCode, Implicit, ResourceOwner, and DeviceCode. The Authorization Code
+with PKCE grant type is always enabled and cannot be managed via this setting.
+
+One Identity recommends disabling all grant types unless you have a custom integration
+application using them.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER GrantType
+A string containing the OAuth2 grant type to enable. Valid values are:
+AuthorizationCode, Implicit, ResourceOwner, DeviceCode.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A list of strings representing the OAuth2 grant types that are enabled after the operation.
+
+.EXAMPLE
+Enable-SafeguardOAuth2GrantType -AccessToken $token -Appliance 10.5.32.54 -Insecure ResourceOwner
+
+.EXAMPLE
+Enable-SafeguardOAuth2GrantType DeviceCode
+#>
+function Enable-SafeguardOAuth2GrantType
+{
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateSet("AuthorizationCode", "Implicit", "ResourceOwner", "DeviceCode", IgnoreCase=$true)]
+        [string]$GrantType
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Setting = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings/Allowed OAuth2 Grant Types")
+    $local:CurrentValue = $local:Setting.Value
+    if ([string]::IsNullOrWhiteSpace($local:CurrentValue))
+    {
+        $local:GrantTypes = @()
+    }
+    else
+    {
+        $local:GrantTypes = @($local:CurrentValue.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+    }
+
+    if ($local:GrantTypes -notcontains $GrantType)
+    {
+        $local:GrantTypes += $GrantType
+    }
+
+    $local:Setting.Value = ($local:GrantTypes -join ", ")
+    $null = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Settings/Allowed OAuth2 Grant Types" -Body $local:Setting
+    $local:GrantTypes
+}
+
+
+<#
+.SYNOPSIS
+Disable an OAuth2 grant type on a Safeguard appliance via the Web API.
+
+.DESCRIPTION
+Disable one or more OAuth2 grant types on the Safeguard appliance. The valid grant types
+are: AuthorizationCode, Implicit, ResourceOwner, and DeviceCode. The Authorization Code
+with PKCE grant type is always enabled and cannot be managed via this setting.
+
+One Identity recommends disabling all grant types unless you have a custom integration
+application using them.
+
+.PARAMETER Appliance
+IP address or hostname of a Safeguard appliance.
+
+.PARAMETER AccessToken
+A string containing the bearer token to be used with Safeguard Web API.
+
+.PARAMETER Insecure
+Ignore verification of Safeguard appliance SSL certificate.
+
+.PARAMETER GrantType
+A string containing the OAuth2 grant type to disable. Valid values are:
+AuthorizationCode, Implicit, ResourceOwner, DeviceCode.
+
+.INPUTS
+None.
+
+.OUTPUTS
+A list of strings representing the OAuth2 grant types that are enabled after the operation.
+
+.EXAMPLE
+Disable-SafeguardOAuth2GrantType -AccessToken $token -Appliance 10.5.32.54 -Insecure ResourceOwner
+
+.EXAMPLE
+Disable-SafeguardOAuth2GrantType Implicit
+#>
+function Disable-SafeguardOAuth2GrantType
+{
+    [OutputType([object[]])]
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$Appliance,
+        [Parameter(Mandatory=$false)]
+        [object]$AccessToken,
+        [Parameter(Mandatory=$false)]
+        [switch]$Insecure,
+        [Parameter(Mandatory=$true, Position=0)]
+        [ValidateSet("AuthorizationCode", "Implicit", "ResourceOwner", "DeviceCode", IgnoreCase=$true)]
+        [string]$GrantType
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Setting = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core GET "Settings/Allowed OAuth2 Grant Types")
+    $local:CurrentValue = $local:Setting.Value
+    if ([string]::IsNullOrWhiteSpace($local:CurrentValue))
+    {
+        $local:GrantTypes = @()
+    }
+    else
+    {
+        $local:GrantTypes = @($local:CurrentValue.Split(",") | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne "" })
+    }
+
+    $local:GrantTypes = @($local:GrantTypes | Where-Object { $_ -ne $GrantType })
+
+    $local:Setting.Value = ($local:GrantTypes -join ", ")
+    $null = Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Settings/Allowed OAuth2 Grant Types" -Body $local:Setting
+    $local:GrantTypes
 }

--- a/test/Suites/Suite-Settings.ps1
+++ b/test/Suites/Suite-Settings.ps1
@@ -134,6 +134,85 @@
             $readback = Get-SafeguardSyslogServer -Insecure $Context.SuiteData["SyslogId"]
             $readback.Name -eq "${prefix}_SyslogRenamed"
         }
+
+        # =========================================
+        # OAuth2 Grant Type tests
+        # =========================================
+
+        # Save original state for cleanup
+        Test-SgPsAssert "Get-SafeguardOAuth2GrantType returns a list" {
+            $grantTypes = Get-SafeguardOAuth2GrantType -Insecure
+            $Context.SuiteData["OriginalGrantTypes"] = $grantTypes
+
+            Register-SgPsTestCleanup -Description "Restore OAuth2 grant types" -Action {
+                param($Ctx)
+                try {
+                    $original = $Ctx.SuiteData['OriginalGrantTypes']
+                    # Disable all first
+                    @("AuthorizationCode", "Implicit", "ResourceOwner", "DeviceCode") | ForEach-Object {
+                        try { Disable-SafeguardOAuth2GrantType -Insecure $_ } catch {}
+                    }
+                    # Re-enable original set
+                    if ($original -and $original.Count -gt 0) {
+                        $original | ForEach-Object {
+                            try { Enable-SafeguardOAuth2GrantType -Insecure $_ } catch {}
+                        }
+                    }
+                } catch {}
+            }
+
+            $grantTypes -is [array]
+        }
+
+        # --- Enable-SafeguardOAuth2GrantType ---
+        Test-SgPsAssert "Enable-SafeguardOAuth2GrantType enables a grant type" {
+            $result = Enable-SafeguardOAuth2GrantType -Insecure "Implicit"
+            $result -contains "Implicit"
+        }
+
+        Test-SgPsAssert "Enable-SafeguardOAuth2GrantType is idempotent" {
+            $before = Get-SafeguardOAuth2GrantType -Insecure
+            $result = Enable-SafeguardOAuth2GrantType -Insecure "Implicit"
+            $result.Count -eq $before.Count
+        }
+
+        Test-SgPsAssert "Get-SafeguardOAuth2GrantType confirms enable" {
+            $grantTypes = Get-SafeguardOAuth2GrantType -Insecure
+            $grantTypes -contains "Implicit"
+        }
+
+        # --- Disable-SafeguardOAuth2GrantType ---
+        Test-SgPsAssert "Disable-SafeguardOAuth2GrantType disables a grant type" {
+            $result = Disable-SafeguardOAuth2GrantType -Insecure "Implicit"
+            $result -notcontains "Implicit"
+        }
+
+        Test-SgPsAssert "Disable-SafeguardOAuth2GrantType is idempotent" {
+            $before = Get-SafeguardOAuth2GrantType -Insecure
+            $result = Disable-SafeguardOAuth2GrantType -Insecure "Implicit"
+            $result.Count -eq $before.Count
+        }
+
+        Test-SgPsAssert "Get-SafeguardOAuth2GrantType confirms disable" {
+            $grantTypes = Get-SafeguardOAuth2GrantType -Insecure
+            $grantTypes -notcontains "Implicit"
+        }
+
+        # --- Enable multiple grant types ---
+        Test-SgPsAssert "Enable-SafeguardOAuth2GrantType supports multiple types" {
+            Enable-SafeguardOAuth2GrantType -Insecure "AuthorizationCode"
+            $result = Enable-SafeguardOAuth2GrantType -Insecure "DeviceCode"
+            ($result -contains "AuthorizationCode") -and ($result -contains "DeviceCode")
+        }
+
+        # --- Disable all ---
+        Test-SgPsAssert "Disable-SafeguardOAuth2GrantType can clear all" {
+            Disable-SafeguardOAuth2GrantType -Insecure "AuthorizationCode"
+            Disable-SafeguardOAuth2GrantType -Insecure "DeviceCode"
+            Disable-SafeguardOAuth2GrantType -Insecure "Implicit"
+            $result = Disable-SafeguardOAuth2GrantType -Insecure "ResourceOwner"
+            $result.Count -eq 0
+        }
     }
 
     Cleanup = {


### PR DESCRIPTION
Add Get/Enable/Disable-SafeguardOAuth2GrantType cmdlets
 
 Purpose-built cmdlets for managing OAuth2 grant types enabled on the
 appliance (AuthorizationCode, Implicit, ResourceOwner, DeviceCode).
 Uses ValidateSet for the available types. Enable is idempotent.
 
 - Added three cmdlets to settings.psm1 with full help documentation
 - Exported in module manifest
 - Integration tests added to Suite-Settings
