### PR TITLE
Add -ExtendedLogging to Invoke-SafeguardAssetSshHostKeyDiscovery; bump to 8.4.3

### DIFF
--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -87,16 +87,27 @@ The base released version lives in `pipeline-templates/global-variables.yml`:
 ```yaml
 variables:
   - name: version
-    value: "8.3.0"
+    value: "8.4.3"
 ```
 
-The source manifest intentionally keeps a placeholder version:
+The source manifest mirrors that base version with a `99999` build placeholder:
 
 ```powershell
-ModuleVersion = '8.3.99999'
+ModuleVersion = '8.4.3.99999'
 ```
 
-Do not hand-edit the placeholder for normal development work.
+CI replaces the `99999` portion (and adds the prerelease suffix) at build time -- do not hand-edit `99999` for normal development work. The `<major>.<minor>.<patch>` portion is hand-bumped between release cycles (see "Bumping the version" below).
+
+### Bumping the version for the next prerelease cycle
+
+After cutting a release tag (e.g. `v8.4.2`), main keeps producing prereleases against that same base version (`dev/v8.4.2-preNNNNNN`) until the base is bumped. To start a new cycle (e.g. moving to 8.4.3 prereleases so a future `v8.4.3` tag can ship):
+
+1. Edit `pipeline-templates/global-variables.yml` -- update the `version` value (e.g. `"8.4.2"` -> `"8.4.3"`).
+2. Edit `src/safeguard-ps.psd1` -- update `ModuleVersion` to match (e.g. `'8.4.2.99999'` -> `'8.4.3.99999'`). Keep the `.99999` placeholder.
+3. Commit both changes together. Suggested message: `Bump version to <new> for next prerelease cycle`.
+4. The next CI build off main will produce `dev/v<new>-preNNNNNN` prereleases. When ready to ship, push a `v<new>` tag and the tag build will publish a non-prerelease release.
+
+The two files must stay in sync -- `install-forpipeline.ps1` substitutes `<major>.<minor>.99999` based on the pipeline `version` variable, so a mismatched manifest will fail stamping.
 
 ### Tag builds
 
@@ -121,7 +132,7 @@ For a valid tag build:
 For branch and PR builds:
 
 - `VersionString` stays at the base version from `global-variables.yml`
-- `BuildNumber` is computed as `Build.BuildId - 102500`
+- `BuildNumber` is computed as `Build.BuildId - 250000`
 - `PrereleaseSuffix` becomes `pre<BuildNumber>`
 - `ReleaseTag` becomes `dev/v<version>-pre<BuildNumber>`
 - `isPrerelease` is true
@@ -130,11 +141,11 @@ For branch and PR builds:
 Example from the scripts:
 
 ```text
-version     = 8.3.0
-Build.BuildId = 102745
-BuildNumber = 245
-PrereleaseSuffix = pre245
-ReleaseTag = dev/v8.3.0-pre245
+version     = 8.4.3
+Build.BuildId = 367659
+BuildNumber = 117659
+PrereleaseSuffix = pre117659
+ReleaseTag = dev/v8.4.3-pre117659
 ```
 
 ### Manifest stamping behavior

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,12 @@ See `.agents/skills/build-and-release/SKILL.md` for Azure Pipelines job layout, 
 
 ## Versioning
 
-`ModuleVersion` has a `99999` placeholder. **Do not edit.** CI replaces it with the build version and prerelease suffixes. See `.agents/skills/build-and-release/SKILL.md` for the exact version derivation rules.
+The base `<major>.<minor>.<patch>` version is hand-bumped between release cycles in two files that must stay in sync:
+
+- `pipeline-templates/global-variables.yml` (the `version` variable)
+- `src/safeguard-ps.psd1` (`ModuleVersion = '<major>.<minor>.<patch>.99999'`)
+
+The trailing `.99999` placeholder must remain -- CI replaces it with the build number and adds the prerelease suffix. Do not hand-edit `99999`. Tag builds (`v<major>.<minor>.<patch>`) ship a non-prerelease release; main builds in between produce `dev/v<version>-preNNNNNN` prereleases against whatever base version is currently committed. See `.agents/skills/build-and-release/SKILL.md` for the full derivation rules and the bump procedure.
 
 ## On-demand skills
 

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.4.2"
+    value: "8.4.3"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/src/assets.psm1
+++ b/src/assets.psm1
@@ -306,6 +306,12 @@ An integer containing the ID of the asset or a string containing the name.
 .PARAMETER AcceptSshHostKey
 Whether or not to automatically accept the SSH host key that is discovered.
 
+.PARAMETER ExtendedLogging
+Whether or not to turn on extended logging on the appliance for the duration of
+this discovery operation. This produces additional task log output (e.g.,
+SshCommunication entries) that is useful for debugging connectivity and
+custom platform script issues.
+
 .INPUTS
 None.
 
@@ -317,6 +323,9 @@ Invoke-SafeguardAsset -AccessToken $token -Appliance 10.5.32.54 -Insecure
 
 .EXAMPLE
 Invoke-SafeguardAsset linux123.internal.com
+
+.EXAMPLE
+Invoke-SafeguardAssetSshHostKeyDiscovery -Insecure linux123.internal.com -ExtendedLogging
 #>
 function Invoke-SafeguardAssetSshHostKeyDiscovery
 {
@@ -335,7 +344,9 @@ function Invoke-SafeguardAssetSshHostKeyDiscovery
         [Parameter(Mandatory=$true,Position=0)]
         [object]$Asset,
         [Parameter(Mandatory=$false)]
-        [switch]$AcceptSshHostKey
+        [switch]$AcceptSshHostKey,
+        [Parameter(Mandatory=$false)]
+        [switch]$ExtendedLogging
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -357,8 +368,10 @@ function Invoke-SafeguardAssetSshHostKeyDiscovery
     }
 
     Write-Host "Discovering SSH host key..."
+    $local:Parameters = @{}
+    if ($ExtendedLogging) { $local:Parameters.extendedLogging = $true }
     $local:SshHostKey = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core `
-                             POST "Assets/$($local:AssetObj.Id)/DiscoverSshHostKey")
+                             POST "Assets/$($local:AssetObj.Id)/DiscoverSshHostKey" -Parameters $local:Parameters)
     if (-not $local:SshHostKey)
     {
         throw "SshHostKey not found on asset: $($local:AssetObj.Name)"

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -11,7 +11,7 @@
 RootModule = 'safeguard-ps.psm1'
 
 # Version number of this module.
-ModuleVersion = '8.4.2.99999'
+ModuleVersion = '8.4.3.99999'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- New `-ExtendedLogging` switch on `Invoke-SafeguardAssetSshHostKeyDiscovery` passes
   `extendedLogging=true` to `POST Assets/{id}/DiscoverSshHostKey`, surfacing
   SshCommunication entries in TaskLogs for debugging custom platform SSH key
   discovery (matches the pattern used by the other discovery/test cmdlets).
 - Bump base version to 8.4.3 in `global-variables.yml` and `safeguard-ps.psd1` to
   start the next prerelease cycle.
 - Document the version bump procedure in `AGENTS.md` and the build-and-release
   skill, and correct a couple of stale examples.