### PR TITLE
Add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to safeguard-ps
+
+Thanks for your interest in improving safeguard-ps, the PowerShell module
+for the One Identity Safeguard Web API.
+
+## Reporting issues
+
+- **Bugs and feature requests:** open a GitHub Issue.
+- **Security vulnerabilities:** do **not** open a public issue — follow
+  [SECURITY.md](SECURITY.md).
+
+## Prerequisites
+
+- Windows PowerShell 5.1 (the module source stays 5.1-compatible) and
+  [PowerShell 7](https://aka.ms/powershell) (required to run the tests and
+  the linter).
+- PSScriptAnalyzer (auto-installed by the lint script if missing).
+- A live Safeguard for Privileged Passwords appliance for the test suites.
+
+## Building
+
+The module is pure PowerShell — there is no compile step. Reinstall it
+locally after each change:
+
+    ./cleanup-local.ps1
+    ./install-local.ps1
+
+Then verify:
+
+    Import-Module safeguard-ps
+
+## Testing
+
+The suites run against a live appliance and require PowerShell 7:
+
+    ./test/Invoke-SafeguardPsTests.ps1 -ListSuites
+    ./test/Invoke-SafeguardPsTests.ps1 -Appliance <address> -AdminPassword <password>
+
+## Coding conventions
+
+All code must pass the linter in strict mode before merging:
+
+    ./Invoke-PsLint.ps1 -Strict
+
+Module source must stay Windows PowerShell 5.1-compatible (ASCII only). See
+[AGENTS.md](AGENTS.md) for the full conventions.
+
+## Submitting changes
+
+1. Fork the repository and create a feature branch.
+2. Keep commits focused with clear messages.
+3. Ensure `./Invoke-PsLint.ps1 -Strict` passes.
+4. Open a pull request describing the behavior you changed and the tests
+   that prove it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of One Identity's Safeguard open source projects
+seriously. **Please do not report security vulnerabilities through public
+GitHub issues, pull requests, or discussions.** Use one of the private
+channels below.
+
+### Preferred: GitHub Private Vulnerability Reporting
+
+1. Open the **Security** tab of this repository.
+2. Click **Report a vulnerability**.
+3. Include the affected version(s), a description, reproduction steps,
+   and impact.
+
+This opens a private advisory visible only to you and the maintainers.
+If we confirm and fix the issue, we will credit you in the published
+GitHub Security Advisory unless you ask us not to.
+
+### Alternative: One Identity responsible disclosure
+
+You may also report through One Identity's official process at
+https://support.oneidentity.com/essentials/reporting-security-vulnerability
+(choose **Report Vulnerability**). Use this if you prefer to work through
+One Identity Support or are reporting across multiple products.
+
+## Our commitment
+
+We will acknowledge and respond to your report within **48 hours** and
+keep you informed as we investigate and work toward a fix. Please give us
+a reasonable opportunity to address the issue before any public
+disclosure.
+
+## Scope
+
+This policy covers the code in this repository. Vulnerabilities in the
+Safeguard for Privileged Passwords or Safeguard for Privileged Sessions
+appliances should be reported through One Identity's process at
+https://support.oneidentity.com/essentials/reporting-security-vulnerability.


### PR DESCRIPTION
Adds the two standard community-health files to bring this repository to parity with the other Safeguard open source projects.

- **SECURITY.md** - directs reporters to GitHub Private Vulnerability Reporting (preferred) and One Identity's official responsible-disclosure process, with a 48-hour acknowledgement commitment.
- **CONTRIBUTING.md** - documents prerequisites, building, testing (hermetic unit vs. live-appliance), coding conventions, and the fork/PR workflow, tailored to this repo's toolchain.

Private Vulnerability Reporting is already enabled in the Security tab, and the dependencies / security / ci labels exist.