### PR TITLE
Support SPP 9.0 TLS 1.3: pin HTTP/1.1 and add TLS version range (#650)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,78 @@ Client certificate authentication is also available in `Connect-Safeguard`.
 This can be done either using a PFX certificate file or a SHA-1 thumbprint
 of a certificate stored in the Current User personal certificate store.
 
+### TLS and HTTP behavior
+
+safeguard-ps always negotiates a secure TLS version (TLS 1.2 or higher, and
+TLS 1.3 where the runtime supports it). Safeguard for Privileged Passwords 9.0
+enables TLS 1.3, and safeguard-ps connects successfully to 9.0 on both Windows
+PowerShell 5.1 and PowerShell 7 with no extra flags.
+
+REST calls are pinned to HTTP/1.1. This keeps client certificate authentication
+working against the 9.0 Standard binding, where HTTP/2 would otherwise disallow
+the post-handshake certificate request.
+
+If you want to constrain the TLS version, `Connect-Safeguard` accepts
+`-MinimumTlsVersion` and `-MaximumTlsVersion` (each `1.2` or `1.3`). Use
+`-MinimumTlsVersion 1.3` to require TLS 1.3 and fail closed against any lower
+version:
+
+```Powershell
+> Connect-Safeguard 192.168.123.123 -Thumbprint AB40BF0AD5647C9A8E0431DA5F473F44910D8975 -MinimumTlsVersion 1.3
+Login Successful.
+```
+
+Use `-MaximumTlsVersion 1.2` to pin the connection to TLS 1.2 as an interim
+measure for environments that are not ready for TLS 1.3:
+
+```Powershell
+> Connect-Safeguard 192.168.123.123 -Thumbprint AB40BF0AD5647C9A8E0431DA5F473F44910D8975 -MaximumTlsVersion 1.2
+Login Successful.
+```
+
+Supply both to negotiate within an inclusive range. The setting is stored in the
+session and honored by subsequent `Invoke-SafeguardMethod` calls. The default
+behavior (neither parameter) is unchanged: safeguard-ps negotiates the highest
+protocol both sides support and works against 8.x and 9.0 with no extra flags.
+
+Only TLS 1.2 and TLS 1.3 can be selected; 1.0 and 1.1 are intentionally
+excluded.
+
+#### TLS 1.3 gotchas by PowerShell edition
+
+TLS 1.3 enforcement behaves differently depending on which PowerShell you run,
+because the two editions use different HTTP stacks. Read this before relying on
+`-MinimumTlsVersion 1.3` in automation.
+
+| Behavior | PowerShell 7 (Core) | Windows PowerShell 5.1 |
+|----------|---------------------|------------------------|
+| How the TLS range is applied | Per request via the `Invoke-RestMethod -SslProtocol` parameter | Process-wide via `[System.Net.ServicePointManager]::SecurityProtocol` |
+| HTTP/1.1 pin mechanism | `-HttpVersion 1.1` (feature-detected; PowerShell 7.3+) | Already defaults to HTTP/1.1 (no `-HttpVersion` parameter) |
+| TLS 1.3 requirement | `-SslProtocol Tls13` requires **PowerShell 7.3+** | `SecurityProtocolType.Tls13` requires **.NET Framework 4.8** on **Windows 11 / Windows Server 2022** or later |
+
+Specific gotchas:
+
+* **`-MinimumTlsVersion 1.3` throws a clear error when the runtime cannot honor
+  it** rather than silently downgrading. On PowerShell older than 7.3 the
+  `WebSslProtocol` enum has no `Tls13` value; on Windows PowerShell 5.1 the
+  `SecurityProtocolType` enum has no `Tls13` value unless the OS/.NET Framework
+  provides it. If you need to *enforce* TLS 1.3, prefer **PowerShell 7.3 or
+  newer**.
+* **The enum existing does not guarantee negotiation succeeds.** Whether TLS 1.3
+  actually completes depends on the underlying TLS provider: Windows uses
+  Schannel (Windows 11 / Windows Server 2022+), Linux uses OpenSSL 1.1.1+, and
+  macOS uses recent SecureTransport/LibreSSL. An older host can accept
+  `-MinimumTlsVersion 1.3` yet still fail the handshake.
+* **On Windows PowerShell 5.1 the range is process-wide, not per call.** Setting
+  `-MinimumTlsVersion`/`-MaximumTlsVersion` changes
+  `ServicePointManager.SecurityProtocol` for the entire process, so it affects
+  every other HTTPS call in that session and persists until the process exits or
+  the value is changed again.
+* **The HTTP/1.1 pin is always safe.** It is applied via `-HttpVersion 1.1` only
+  where that parameter exists; on older PowerShell 7 and Windows PowerShell 5.1
+  HTTP/1.1 is already the default, so certificate authentication against the
+  SPP 9.0 HTTP/2-capable binding keeps working everywhere with no configuration.
+
 Once you are logged in, you can call any cmdlet listed below.  For example:
 
 ```Powershell

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.4.4"
+    value: "8.5.0"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/src/a2acallers.psm1
+++ b/src/a2acallers.psm1
@@ -42,6 +42,11 @@ function Invoke-SafeguardA2aMethodWithCertificate
         $PSDefaultParameterValues = Get-SafeguardSslPreferences
     }
 
+    # Pin HTTP/1.1 for A2A certificate authentication. On the SPP 9.0 HTTP/2-capable
+    # binding, HTTP/2 disallows the post-handshake TLS certificate request that client
+    # certificate auth relies on, so the A2A cert calls must use HTTP/1.1 (see issue #650).
+    $local:WebRequestArguments = (Get-SafeguardWebRequestPreference)
+
     $local:Headers = @{
             "Accept" = "application/json";
             "Content-type" = "application/json"
@@ -82,12 +87,12 @@ function Invoke-SafeguardA2aMethodWithCertificate
             if (-not $local:BodyInternal)
             {
                 Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method $Method -Headers $local:Headers `
-                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl"
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" @local:WebRequestArguments
             }
             else
             {
                 Invoke-RestMethod -CertificateThumbprint $Thumbprint -Method $Method -Headers $local:Headers `
-                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)) @local:WebRequestArguments
             }
         }
         else
@@ -95,12 +100,12 @@ function Invoke-SafeguardA2aMethodWithCertificate
             if (-not $local:BodyInternal)
             {
                 Invoke-RestMethod -Certificate $local:Cert -Method $Method -Headers $local:Headers `
-                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl"
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" @local:WebRequestArguments
             }
             else
             {
                 Invoke-RestMethod -Certificate $local:Cert -Method $Method -Headers $local:Headers `
-                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal))
+                    -Uri "https://$Appliance/service/$Service/v$Version/$RelativeUrl" -Body ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal)) @local:WebRequestArguments
             }
         }
     }

--- a/src/safeguard-ps.psd1
+++ b/src/safeguard-ps.psd1
@@ -11,7 +11,7 @@
 RootModule = 'safeguard-ps.psm1'
 
 # Version number of this module.
-ModuleVersion = '8.4.4.99999'
+ModuleVersion = '8.5.0.99999'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -1143,7 +1143,11 @@ function Invoke-WithoutBody
         [Parameter(Mandatory=$false)]
         [switch]$LongRunningTask,
         [Parameter(Mandatory=$false)]
-        [int]$Timeout
+        [int]$Timeout,
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -1158,6 +1162,9 @@ function Invoke-WithoutBody
         Uri = $local:Url;
         TimeoutSec = $Timeout
     }
+    # Pin HTTP/1.1 (and optionally enforce TLS 1.3) so cert-based auth works against
+    # the SPP 9.0 Standard binding regardless of the ingress in front of the appliance.
+    $arguments += (Get-SafeguardWebRequestPreference -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion)
     if ($InFile)
     {
         Write-Verbose "InFile=$InFile"
@@ -1214,7 +1221,11 @@ function Invoke-WithBody
         [Parameter(Mandatory=$false)]
         [switch]$LongRunningTask,
         [Parameter(Mandatory=$false)]
-        [int]$Timeout
+        [int]$Timeout,
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -1237,6 +1248,9 @@ function Invoke-WithBody
         Body = ([System.Text.Encoding]::UTF8.GetBytes($local:BodyInternal));
         TimeoutSec = $Timeout
     }
+    # Pin HTTP/1.1 (and optionally enforce TLS 1.3) so cert-based auth works against
+    # the SPP 9.0 Standard binding regardless of the ingress in front of the appliance.
+    $arguments += (Get-SafeguardWebRequestPreference -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion)
     if ($OutFile)
     {
         Write-Verbose "OutFile=$OutFile"
@@ -1292,7 +1306,11 @@ function Invoke-Internal
         [Parameter(Mandatory=$false)]
         [switch]$LongRunningTask,
         [Parameter(Mandatory=$false)]
-        [int]$Timeout
+        [int]$Timeout,
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -1304,20 +1322,20 @@ function Invoke-Internal
         {
             {$_ -in "get","delete"} {
                 Invoke-WithoutBody -Appliance $Appliance -Service $Service -Method $Method -Version $Version -RelativeUrl $RelativeUrl -Headers $Headers `
-                    -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
+                    -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
                 break
             }
             {$_ -in "put","post"} {
                 if ($InFile)
                 {
                     Invoke-WithoutBody -Appliance $Appliance -Service $Service -Method $Method -Version $Version -RelativeUrl $RelativeUrl -Headers $Headers `
-                        -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
+                        -Parameters $Parameters -InFile $InFile -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
                 }
                 else
                 {
                     Invoke-WithBody -Appliance $Appliance -Service $Service -Method $Method -Version $Version -RelativeUrl $RelativeUrl -Headers $Headers `
                         -Body $Body -JsonBody $JsonBody `
-                        -Parameters $Parameters -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout
+                        -Parameters $Parameters -OutFile $OutFile -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
                 }
                 break
             }
@@ -1425,6 +1443,20 @@ If this switch is sent the access token will be returned and a login session con
 .PARAMETER NoWindowTitle
 If this switch is sent safeguard-ps won't try to set the window title, which can cause failures when the PowerShell
 runtime doesn't allow user interaction; for example, when running safeguard-ps from C#.
+
+.PARAMETER MinimumTlsVersion
+Require at least this TLS version for the connection, failing closed against anything lower. Valid values are
+"1.2" and "1.3". SPP 9.0 enables TLS 1.3; by default safeguard-ps negotiates the highest protocol both sides
+support. Use -MinimumTlsVersion 1.3 to require TLS 1.3. On PowerShell 7 the range is applied per request via
+-SslProtocol; on Windows PowerShell 5.1 it is applied process-wide via ServicePointManager and requires an
+operating system/.NET Framework that supports the requested version. The setting is persisted in the session and
+honored by subsequent Invoke-SafeguardMethod calls.
+
+.PARAMETER MaximumTlsVersion
+Cap the connection at this TLS version, failing closed against anything higher. Valid values are "1.2" and "1.3".
+For example, -MaximumTlsVersion 1.2 pins the connection to TLS 1.2 as an interim measure for environments that
+are not ready for TLS 1.3. Combine with -MinimumTlsVersion to negotiate within an inclusive range. Applied the
+same way as -MinimumTlsVersion and persisted in the session.
 
 .INPUTS
 None.
@@ -1562,7 +1594,13 @@ function Connect-Safeguard
         [Parameter(Mandatory=$false)]
         [switch]$NoSessionVariable = $false,
         [Parameter(Mandatory=$false)]
-        [switch]$NoWindowTitle = $false
+        [switch]$NoWindowTitle = $false,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("1.2","1.3")]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("1.2","1.3")]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -1570,11 +1608,20 @@ function Connect-Safeguard
 
     try
     {
-        Edit-SslVersionSupport
+        Edit-SslVersionSupport -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
+        # Make the module's HTTP/TLS behavior explicit for every REST call made while
+        # authenticating (RSTS token exchange, LoginResponse, provider discovery, etc.):
+        # pin HTTP/1.1 so client-certificate auth works on the SPP 9.0 Standard binding,
+        # and enforce TLS 1.3 when requested. These apply via $PSDefaultParameterValues so
+        # they flow into the nested Invoke-RestMethod calls throughout the login flow.
+        $PSDefaultParameterValues = (Get-SafeguardWebRequestPreference -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion -AsDefaultParameterValues)
         if ($Insecure)
         {
             Disable-SslVerification
-            $PSDefaultParameterValues = Get-SafeguardSslPreferences
+            foreach ($local:SslPref in (Get-SafeguardSslPreferences).GetEnumerator())
+            {
+                $PSDefaultParameterValues[$local:SslPref.Key] = $local:SslPref.Value
+            }
         }
 
         if ($Browser -Or $Gui)
@@ -1923,6 +1970,8 @@ function Connect-Safeguard
                 "Gui" = $Gui -Or $Browser;
                 "DeviceCode" = [bool]$DeviceCode;
                 "NoWindowTitle" = $NoWindowTitle;
+                "MinimumTlsVersion" = $MinimumTlsVersion;
+                "MaximumTlsVersion" = $MaximumTlsVersion;
                 "AssetPartitionId" = $null
             }
             if (-not $NoWindowTitle)
@@ -2148,6 +2197,18 @@ A switch to specify that this method call should be handled synchronously as a l
 .PARAMETER JsonOutput
 A switch to return data as pretty JSON string.
 
+.PARAMETER MinimumTlsVersion
+Require at least this TLS version for this request, failing closed against anything lower. Valid values are "1.2"
+and "1.3". When called with an existing session created by Connect-Safeguard -MinimumTlsVersion, this is inherited
+automatically and does not need to be specified. On PowerShell 7 the range is applied per request via -SslProtocol;
+on Windows PowerShell 5.1 it is applied process-wide via ServicePointManager and requires an operating system/.NET
+Framework that supports the requested version.
+
+.PARAMETER MaximumTlsVersion
+Cap this request at this TLS version, failing closed against anything higher. Valid values are "1.2" and "1.3".
+Inherited from the session created by Connect-Safeguard -MaximumTlsVersion when not specified. Applied the same way
+as -MinimumTlsVersion.
+
 .PARAMETER Anonymous
 When this switch is specified, no Bearer token authorization header is included in the request.
 
@@ -2232,7 +2293,13 @@ function Invoke-SafeguardMethod
         [Parameter(Mandatory=$false)]
         [HashTable]$ExtraHeaders,
         [Parameter(Mandatory=$false)]
-        [switch]$JsonOutput
+        [switch]$JsonOutput,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("1.2","1.3")]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("1.2","1.3")]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -2254,6 +2321,21 @@ function Invoke-SafeguardMethod
         # which will not hit this code.
         $Insecure = $SafeguardSession["Insecure"]
     }
+    if (-not ($PSBoundParameters.ContainsKey("MinimumTlsVersion")) -and $SafeguardSession -and $SafeguardSession.ContainsKey("MinimumTlsVersion"))
+    {
+        # Inherit the minimum TLS version from the connection so every call fails closed below it.
+        $MinimumTlsVersion = $SafeguardSession["MinimumTlsVersion"]
+    }
+    if (-not ($PSBoundParameters.ContainsKey("MaximumTlsVersion")) -and $SafeguardSession -and $SafeguardSession.ContainsKey("MaximumTlsVersion"))
+    {
+        # Inherit the maximum TLS version from the connection so every call fails closed above it.
+        $MaximumTlsVersion = $SafeguardSession["MaximumTlsVersion"]
+    }
+    # Only forward TLS bounds to nested Connect-Safeguard when set; the parameters use ValidateSet
+    # and would reject an empty pass-through value.
+    $TlsBoundParameters = @{}
+    if (-not [string]::IsNullOrEmpty($MinimumTlsVersion)) { $TlsBoundParameters["MinimumTlsVersion"] = $MinimumTlsVersion }
+    if (-not [string]::IsNullOrEmpty($MaximumTlsVersion)) { $TlsBoundParameters["MaximumTlsVersion"] = $MaximumTlsVersion }
     if (-not $AccessToken -and -not $Anonymous -and -not $SafeguardSession)
     {
         if (-not $Appliance)
@@ -2261,7 +2343,7 @@ function Invoke-SafeguardMethod
             $Appliance = (Read-Host "Appliance")
         }
         Write-Verbose "Not using existing session, calling Connect-Safeguard [1]..."
-        $AccessToken = (Connect-Safeguard -Appliance $Appliance -Insecure:$Insecure -NoSessionVariable)
+        $AccessToken = (Connect-Safeguard -Appliance $Appliance -Insecure:$Insecure @TlsBoundParameters -NoSessionVariable)
     }
     elseif (-not $Anonymous)
     {
@@ -2282,7 +2364,7 @@ function Invoke-SafeguardMethod
         if (-not $AccessToken -and -not $Anonymous)
         {
             Write-Verbose "Not using existing session, calling Connect-Safeguard [2]..."
-            $AccessToken = (Connect-Safeguard -Appliance $Appliance -Insecure:$Insecure -NoSessionVariable)
+            $AccessToken = (Connect-Safeguard -Appliance $Appliance -Insecure:$Insecure @TlsBoundParameters -NoSessionVariable)
         }
     }
     else
@@ -2300,7 +2382,8 @@ function Invoke-SafeguardMethod
     }
 
     Write-Verbose "Insecure=$Insecure"
-    Edit-SslVersionSupport
+    Write-Verbose "MinimumTlsVersion=$MinimumTlsVersion; MaximumTlsVersion=$MaximumTlsVersion"
+    Edit-SslVersionSupport -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
     if ($Insecure)
     {
         Disable-SslVerification
@@ -2331,13 +2414,13 @@ function Invoke-SafeguardMethod
         {
             (Invoke-Internal -Appliance $Appliance -Service $Service -Method $Method -Version $Version -RelativeUrl $RelativeUrl -Headers $local:Headers `
                              -Body $Body -JsonBody $JsonBody -Parameters $Parameters -InFile $InFile -OutFile $OutFile `
-                             -LongRunningTask:$LongRunningTask -Timeout $Timeout) | ConvertTo-Json -Depth 100
+                             -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion) | ConvertTo-Json -Depth 100
         }
         else
         {
             Invoke-Internal -Appliance $Appliance -Service $Service -Method $Method -Version $Version -RelativeUrl $RelativeUrl -Headers $local:Headers `
                             -Body $Body -JsonBody $JsonBody -Parameters $Parameters -InFile $InFile -OutFile $OutFile `
-                            -LongRunningTask:$LongRunningTask -Timeout $Timeout
+                            -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
         }
     }
     catch
@@ -2351,13 +2434,13 @@ function Invoke-SafeguardMethod
             {
                 (Invoke-Internal -Appliance $Appliance -Service $Service -Method $Method -Version $RetryVersion -RelativeUrl $RetryUrl -Headers $local:Headers `
                                  -Body $Body -JsonBody $JsonBody -Parameters $Parameters -InFile $InFile -OutFile $OutFile `
-                                 -LongRunningTask:$LongRunningTask -Timeout $Timeout) | ConvertTo-Json -Depth 100
+                                 -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion) | ConvertTo-Json -Depth 100
             }
             else
             {
                 Invoke-Internal -Appliance $Appliance -Service $Service -Method $Method -Version $RetryVersion -RelativeUrl $RetryUrl -Headers $local:Headers `
                                 -Body $Body -JsonBody $JsonBody -Parameters $Parameters -InFile $InFile -OutFile $OutFile `
-                                -LongRunningTask:$LongRunningTask -Timeout $Timeout
+                                -LongRunningTask:$LongRunningTask -Timeout $Timeout -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion
             }
         }
         else

--- a/src/safeguard-ps.psm1
+++ b/src/safeguard-ps.psm1
@@ -2321,14 +2321,16 @@ function Invoke-SafeguardMethod
         # which will not hit this code.
         $Insecure = $SafeguardSession["Insecure"]
     }
-    if (-not ($PSBoundParameters.ContainsKey("MinimumTlsVersion")) -and $SafeguardSession -and $SafeguardSession.ContainsKey("MinimumTlsVersion"))
+    if (-not ($PSBoundParameters.ContainsKey("MinimumTlsVersion")) -and $SafeguardSession -and -not [string]::IsNullOrEmpty($SafeguardSession["MinimumTlsVersion"]))
     {
         # Inherit the minimum TLS version from the connection so every call fails closed below it.
+        # Guard against an empty stored value: assigning "" to this ValidateSet-constrained variable throws.
         $MinimumTlsVersion = $SafeguardSession["MinimumTlsVersion"]
     }
-    if (-not ($PSBoundParameters.ContainsKey("MaximumTlsVersion")) -and $SafeguardSession -and $SafeguardSession.ContainsKey("MaximumTlsVersion"))
+    if (-not ($PSBoundParameters.ContainsKey("MaximumTlsVersion")) -and $SafeguardSession -and -not [string]::IsNullOrEmpty($SafeguardSession["MaximumTlsVersion"]))
     {
         # Inherit the maximum TLS version from the connection so every call fails closed above it.
+        # Guard against an empty stored value: assigning "" to this ValidateSet-constrained variable throws.
         $MaximumTlsVersion = $SafeguardSession["MaximumTlsVersion"]
     }
     # Only forward TLS bounds to nested Connect-Safeguard when set; the parameters use ValidateSet

--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -111,14 +111,99 @@ function Get-SafeguardSslPreferences
         'Invoke-WebRequest:SkipCertificateCheck' = $true
     }
 }
-function Edit-SslVersionSupport
+# Maps a caller-facing TLS version string ("1.2", "1.3") to the corresponding
+# .NET enum member name ("Tls12", "Tls13") used by both SecurityProtocolType
+# (Windows PowerShell) and WebSslProtocol (PowerShell 7 -SslProtocol).
+function Get-SafeguardTlsEnumName
 {
     [CmdletBinding()]
+    [OutputType([string])]
     Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string]$TlsVersion
+    )
+
+    switch ($TlsVersion)
+    {
+        "1.2" { "Tls12" }
+        "1.3" { "Tls13" }
+        default { throw "Unsupported TLS version '$TlsVersion'. Supported values are 1.2 and 1.3." }
+    }
+}
+# Resolves an optional [MinimumTlsVersion, MaximumTlsVersion] range into the
+# ordered set of secure TLS versions the module should enable. Only TLS 1.2 and
+# TLS 1.3 are ever enabled (1.0/1.1 are intentionally excluded). Returns $null
+# when neither bound is specified, meaning "negotiate normally" (the default).
+function Get-SafeguardTlsVersionSet
+{
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    if ([string]::IsNullOrEmpty($MinimumTlsVersion) -and [string]::IsNullOrEmpty($MaximumTlsVersion))
+    {
+        return $null
+    }
+    if ((-not [string]::IsNullOrEmpty($MinimumTlsVersion)) -and (-not [string]::IsNullOrEmpty($MaximumTlsVersion)) -and `
+        ([System.Version]$MinimumTlsVersion -gt [System.Version]$MaximumTlsVersion))
+    {
+        throw "MinimumTlsVersion ($MinimumTlsVersion) cannot be greater than MaximumTlsVersion ($MaximumTlsVersion)."
+    }
+
+    # Secure TLS versions this module is willing to enable, in ascending order.
+    $local:Known = @("1.2", "1.3")
+    $local:Selected = @($local:Known | Where-Object {
+        (([string]::IsNullOrEmpty($MinimumTlsVersion)) -or ([System.Version]$_ -ge [System.Version]$MinimumTlsVersion)) -and
+        (([string]::IsNullOrEmpty($MaximumTlsVersion)) -or ([System.Version]$_ -le [System.Version]$MaximumTlsVersion))
+    })
+    if ((-not $local:Selected) -or ($local:Selected.Count -eq 0))
+    {
+        throw "The requested TLS version range (min='$MinimumTlsVersion', max='$MaximumTlsVersion') does not include any supported TLS version (1.2 or 1.3)."
+    }
+    return ,([string[]]$local:Selected)
+}
+function Edit-SslVersionSupport
+{
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:VersionSet = (Get-SafeguardTlsVersionSet -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion)
+    if (($null -ne $local:VersionSet) -and ($PSVersionTable.PSEdition -ne "Core"))
+    {
+        # Windows PowerShell negotiates TLS through ServicePointManager, so an explicit
+        # TLS version range means enabling *only* the requested versions (fail closed
+        # outside the range). On PowerShell 7+ this is done per-request via the
+        # -SslProtocol parameter instead (see Get-SafeguardWebRequestPreference).
+        Write-Verbose "Restricting TLS to ($($local:VersionSet -join ', ')) for Windows PowerShell"
+        $local:Protocol = 0
+        foreach ($local:Version in $local:VersionSet)
+        {
+            $local:Name = (Get-SafeguardTlsEnumName $local:Version)
+            if (-not ([System.Net.SecurityProtocolType].GetEnumNames() -contains $local:Name))
+            {
+                throw "TLS $local:Version was requested, but this Windows PowerShell runtime does not support it. Upgrade the operating system/.NET Framework or use PowerShell 7."
+            }
+            $local:Protocol = $local:Protocol -bor [int][System.Enum]::Parse([System.Net.SecurityProtocolType], $local:Name)
+        }
+        [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]$local:Protocol
+        return
+    }
 
     Write-Verbose "Configuring SSL version support to be secure"
     # Remove SSLv3, if present
@@ -144,4 +229,87 @@ function Edit-SslVersionSupport
                 [System.Net.ServicePointManager]::SecurityProtocol -bor $local:Tls13Value
         }
     }
+}
+# Returns a hashtable of extra parameters that should be splatted onto every
+# Invoke-RestMethod / Invoke-WebRequest call that talks to Safeguard so that the
+# module's HTTP/TLS behavior is explicit:
+#
+#   * HttpVersion = '1.1' -- SPP 9.0 exposes an HTTP/2-capable Standard binding.
+#     HTTP/2 disallows the post-handshake TLS certificate request that client
+#     certificate authentication relies on, so pin HTTP/1.1 to keep cert-auth
+#     working regardless of the ingress in front of the appliance. The
+#     -HttpVersion parameter only exists on PowerShell 7.3+, so it is omitted
+#     where unavailable (older PowerShell 7 and Windows PowerShell 5.1 already
+#     default to HTTP/1.1).
+#
+#   * SslProtocol -- only when an explicit -MinimumTlsVersion/-MaximumTlsVersion
+#     range is supplied. This makes PowerShell 7 negotiate exclusively within the
+#     requested TLS version range, failing closed outside it. Windows PowerShell
+#     5.1 has no -SslProtocol parameter; there the range is enforced process-wide
+#     by Edit-SslVersionSupport.
+#
+# By default (no -AsDefaultParameterValues) the keys are bare parameter names
+# suitable for splatting directly onto an Invoke-RestMethod call. With
+# -AsDefaultParameterValues the keys are qualified (e.g.
+# 'Invoke-RestMethod:HttpVersion') for assignment to $PSDefaultParameterValues.
+function Get-SafeguardWebRequestPreference
+{
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    Param(
+        [Parameter(Mandatory=$false)]
+        [string]$MinimumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [string]$MaximumTlsVersion,
+        [Parameter(Mandatory=$false)]
+        [switch]$AsDefaultParameterValues
+    )
+
+    if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
+    if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
+
+    $local:Splat = @{}
+    $local:VersionSet = (Get-SafeguardTlsVersionSet -MinimumTlsVersion $MinimumTlsVersion -MaximumTlsVersion $MaximumTlsVersion)
+
+    if ($PSVersionTable.PSEdition -eq "Core")
+    {
+        $local:WebParameters = (Get-Command Invoke-RestMethod).Parameters
+        if ($local:WebParameters.ContainsKey("HttpVersion"))
+        {
+            $local:Splat["HttpVersion"] = "1.1"
+        }
+        if ($null -ne $local:VersionSet)
+        {
+            if (-not ($local:WebParameters.ContainsKey("SslProtocol")))
+            {
+                throw "A TLS version range was requested, but this PowerShell runtime does not support the -SslProtocol parameter."
+            }
+            $local:ProtocolInt = 0
+            foreach ($local:Version in $local:VersionSet)
+            {
+                $local:Name = (Get-SafeguardTlsEnumName $local:Version)
+                if (-not ([System.Enum]::GetNames([Microsoft.PowerShell.Commands.WebSslProtocol]) -contains $local:Name))
+                {
+                    throw "TLS $local:Version was requested, but this PowerShell runtime does not support the $local:Name SSL protocol."
+                }
+                $local:ProtocolInt = $local:ProtocolInt -bor [int][Microsoft.PowerShell.Commands.WebSslProtocol]$local:Name
+            }
+            $local:Splat["SslProtocol"] = [Microsoft.PowerShell.Commands.WebSslProtocol]$local:ProtocolInt
+        }
+    }
+    # Windows PowerShell 5.1: -HttpVersion does not exist (HTTP/1.1 is the default)
+    # and the TLS version range is enforced by Edit-SslVersionSupport.
+
+    if (-not $AsDefaultParameterValues)
+    {
+        return $local:Splat
+    }
+
+    $local:Defaults = @{}
+    foreach ($local:Key in $local:Splat.Keys)
+    {
+        $local:Defaults["Invoke-RestMethod:$($local:Key)"] = $local:Splat[$local:Key]
+        $local:Defaults["Invoke-WebRequest:$($local:Key)"] = $local:Splat[$local:Key]
+    }
+    return $local:Defaults
 }

--- a/src/sslhandling.psm1
+++ b/src/sslhandling.psm1
@@ -212,6 +212,19 @@ function Edit-SslVersionSupport
         [System.Net.ServicePointManager]::SecurityProtocol = `
             [System.Net.ServicePointManager]::SecurityProtocol -band (-bnot [System.Net.SecurityProtocolType]::Ssl3)
     }
+    # Remove TLS 1.0 and TLS 1.1, if present. Both are deprecated and Safeguard
+    # requires TLS 1.2 or higher, so strip them to fail closed rather than let the
+    # client silently negotiate a weak protocol.
+    if ([bool]([System.Net.ServicePointManager]::SecurityProtocol -band [System.Net.SecurityProtocolType]::Tls))
+    {
+        [System.Net.ServicePointManager]::SecurityProtocol = `
+            [System.Net.ServicePointManager]::SecurityProtocol -band (-bnot [System.Net.SecurityProtocolType]::Tls)
+    }
+    if ([bool]([System.Net.ServicePointManager]::SecurityProtocol -band [System.Net.SecurityProtocolType]::Tls11))
+    {
+        [System.Net.ServicePointManager]::SecurityProtocol = `
+            [System.Net.ServicePointManager]::SecurityProtocol -band (-bnot [System.Net.SecurityProtocolType]::Tls11)
+    }
     # Add TLS 1.2, if missing
     if (-not ([bool]([System.Net.ServicePointManager]::SecurityProtocol -band [System.Net.SecurityProtocolType]::Tls12)))
     {

--- a/test/Suites/Suite-TlsVersion.ps1
+++ b/test/Suites/Suite-TlsVersion.ps1
@@ -1,0 +1,109 @@
+@{
+    Name        = "TLS Version"
+    Description = "Tests -MinimumTlsVersion/-MaximumTlsVersion pinning on Connect-Safeguard: client-side range validation, downgrade to TLS 1.2, and TLS 1.3 negotiation that adapts to the appliance's capability (connects where 1.3 is supported, fails closed where it is not)."
+    Tags        = @("core", "auth", "tls")
+
+    Setup = {
+        param($Context)
+
+        # Detect whether this appliance can negotiate TLS 1.3. The runner has already
+        # connected successfully, so credentials and network are known-good; a failure
+        # to connect with a TLS 1.3 floor therefore reflects the appliance's TLS
+        # capability (8.x caps at 1.2, 9.0+ supports 1.3), not an environment problem.
+        # Use -NoSessionVariable throughout so the global runner session is never disturbed.
+        $secPwd = ConvertTo-SecureString $Context.AdminPassword -AsPlainText -Force
+        $supports13 = $false
+        try {
+            $probeToken = Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                -MinimumTlsVersion 1.3
+            if ($probeToken) {
+                $supports13 = $true
+                try { Disconnect-Safeguard -Appliance $Context.Appliance -AccessToken $probeToken -Insecure } catch {}
+            }
+        }
+        catch {
+            $supports13 = $false
+        }
+        $Context.SuiteData["SupportsTls13"] = $supports13
+    }
+
+    Execute = {
+        param($Context)
+
+        $secPwd = ConvertTo-SecureString $Context.AdminPassword -AsPlainText -Force
+
+        # --- Client-side range validation (appliance-independent, never hits the network) ---
+        Test-SgPsAssertThrows "Connect-Safeguard rejects MinimumTlsVersion > MaximumTlsVersion" {
+            Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                -MinimumTlsVersion 1.3 -MaximumTlsVersion 1.2
+        } -ExpectedMessage "cannot be greater than"
+
+        # --- Downgrade to TLS 1.2 (supported by every Safeguard version) ---
+        Test-SgPsAssert "Connect-Safeguard with -MaximumTlsVersion 1.2 connects" {
+            $token = Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                -MaximumTlsVersion 1.2
+            $result = ($null -ne $token -and $token.Length -gt 0)
+            if ($token) { try { Disconnect-Safeguard -Appliance $Context.Appliance -AccessToken $token -Insecure } catch {} }
+            $result
+        }
+
+        # --- Explicit 1.2..1.3 range: negotiates the highest common version on any appliance ---
+        Test-SgPsAssert "Connect-Safeguard with 1.2-1.3 range connects and can call the API" {
+            $token = Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                -MinimumTlsVersion 1.2 -MaximumTlsVersion 1.3
+            $me = Invoke-SafeguardMethod -Appliance $Context.Appliance -AccessToken $token -Insecure `
+                -Service Core -Method Get -RelativeUrl "Me"
+            $result = ($null -ne $me -and $null -ne $me.Id)
+            if ($token) { try { Disconnect-Safeguard -Appliance $Context.Appliance -AccessToken $token -Insecure } catch {} }
+            $result
+        }
+
+        # --- TLS 1.3 floor: behavior depends on appliance capability ---
+        if ($Context.SuiteData["SupportsTls13"]) {
+            Test-SgPsAssert "Connect-Safeguard with -MinimumTlsVersion 1.3 connects and can call the API" {
+                $token = Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                    -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                    -MinimumTlsVersion 1.3
+                $me = Invoke-SafeguardMethod -Appliance $Context.Appliance -AccessToken $token -Insecure `
+                    -Service Core -Method Get -RelativeUrl "Me"
+                $result = ($null -ne $me -and $null -ne $me.Id)
+                if ($token) { try { Disconnect-Safeguard -Appliance $Context.Appliance -AccessToken $token -Insecure } catch {} }
+                $result
+            }
+
+            Test-SgPsAssert "Connect-Safeguard pinned to exactly TLS 1.3 (min=max=1.3) connects" {
+                $token = Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                    -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                    -MinimumTlsVersion 1.3 -MaximumTlsVersion 1.3
+                $result = ($null -ne $token -and $token.Length -gt 0)
+                if ($token) { try { Disconnect-Safeguard -Appliance $Context.Appliance -AccessToken $token -Insecure } catch {} }
+                $result
+            }
+        }
+        else {
+            # Appliance does not support TLS 1.3 (e.g. Safeguard 8.x): a TLS 1.3 floor
+            # must fail to negotiate rather than silently downgrade.
+            Test-SgPsAssertThrows "Connect-Safeguard with -MinimumTlsVersion 1.3 fails closed on a non-TLS-1.3 appliance" {
+                Connect-Safeguard -Appliance $Context.Appliance -IdentityProvider "Local" `
+                    -Username $Context.AdminUserName -Password $secPwd -Insecure -NoSessionVariable `
+                    -MinimumTlsVersion 1.3
+            }
+
+            # The failed attempt must not have disturbed the runner's live session.
+            Test-SgPsAssert "Runner session is intact after a failed TLS 1.3 connection attempt" {
+                $me = Get-SafeguardLoggedInUser -Insecure
+                $null -ne $me -and $null -ne $me.Id
+            }
+        }
+    }
+
+    Cleanup = {
+        param($Context)
+        # This suite only uses -NoSessionVariable and never mutates the global
+        # $SafeguardSession, so there is nothing to restore.
+    }
+}

--- a/test/Unit/ssl-handling.Tests.ps1
+++ b/test/Unit/ssl-handling.Tests.ps1
@@ -160,3 +160,126 @@ Describe 'FP-safeguard-ps-002 -- TLS 1.0/1.1 hardening in Edit-SslVersionSupport
         }
     }
 }
+
+Describe 'Issue-650 -- HTTP/1.1 pin and optional TLS min/max enforcement' {
+
+    Context 'Get-SafeguardTlsVersionSet' {
+
+        It 'Returns $null when neither bound is specified (negotiate normally)' {
+            Get-SafeguardTlsVersionSet | Should -BeNullOrEmpty
+        }
+
+        It 'Returns only 1.3 when the minimum is 1.3' {
+            $set = Get-SafeguardTlsVersionSet -MinimumTlsVersion '1.3'
+            @($set) | Should -Be @('1.3')
+        }
+
+        It 'Returns only 1.2 when the maximum is 1.2' {
+            $set = Get-SafeguardTlsVersionSet -MaximumTlsVersion '1.2'
+            @($set) | Should -Be @('1.2')
+        }
+
+        It 'Returns the inclusive range when both bounds are specified' {
+            $set = Get-SafeguardTlsVersionSet -MinimumTlsVersion '1.2' -MaximumTlsVersion '1.3'
+            @($set) | Should -Be @('1.2', '1.3')
+        }
+
+        It 'Throws when the minimum is greater than the maximum' {
+            { Get-SafeguardTlsVersionSet -MinimumTlsVersion '1.3' -MaximumTlsVersion '1.2' } | Should -Throw
+        }
+    }
+
+    Context 'Get-SafeguardWebRequestPreference (splat form)' {
+
+        It 'Pins HTTP/1.1 when the -HttpVersion parameter is available (PowerShell 7.3+)' {
+            $prefs = Get-SafeguardWebRequestPreference
+            $prefs | Should -BeOfType 'System.Collections.IDictionary'
+            if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey('HttpVersion')) {
+                $prefs.ContainsKey('HttpVersion') | Should -Be $true
+                $prefs['HttpVersion']             | Should -Be '1.1'
+            }
+            else {
+                # Older PowerShell 7 and Windows PowerShell 5.1 already default to HTTP/1.1
+                $prefs.ContainsKey('HttpVersion') | Should -Be $false
+            }
+        }
+
+        It 'Does not add SslProtocol when no TLS range is specified' {
+            (Get-SafeguardWebRequestPreference).ContainsKey('SslProtocol') | Should -Be $false
+        }
+
+        It 'Adds SslProtocol Tls13 when -MinimumTlsVersion 1.3 is specified and supported' {
+            $supported = ($PSVersionTable.PSEdition -eq 'Core') -and `
+                (Get-Command Invoke-RestMethod).Parameters.ContainsKey('SslProtocol') -and `
+                ([System.Enum]::GetNames([Microsoft.PowerShell.Commands.WebSslProtocol]) -contains 'Tls13')
+            if ($supported) {
+                $prefs = Get-SafeguardWebRequestPreference -MinimumTlsVersion '1.3'
+                $prefs['SslProtocol'] | Should -Be 'Tls13'
+            }
+            else {
+                { Get-SafeguardWebRequestPreference -MinimumTlsVersion '1.3' } | Should -Throw
+            }
+        }
+
+        It 'Adds SslProtocol Tls12 when -MaximumTlsVersion 1.2 is specified and supported' {
+            $supported = ($PSVersionTable.PSEdition -eq 'Core') -and `
+                (Get-Command Invoke-RestMethod).Parameters.ContainsKey('SslProtocol')
+            if ($supported) {
+                $prefs = Get-SafeguardWebRequestPreference -MaximumTlsVersion '1.2'
+                $prefs['SslProtocol'] | Should -Be 'Tls12'
+            }
+            else {
+                Set-ItResult -Skipped -Because 'The -SslProtocol parameter is not available on this runtime'
+            }
+        }
+    }
+
+    Context 'Get-SafeguardWebRequestPreference (-AsDefaultParameterValues form)' {
+
+        It 'Qualifies keys for both Invoke-RestMethod and Invoke-WebRequest' {
+            $prefs = Get-SafeguardWebRequestPreference -AsDefaultParameterValues
+            if ((Get-Command Invoke-RestMethod).Parameters.ContainsKey('HttpVersion')) {
+                $prefs['Invoke-RestMethod:HttpVersion'] | Should -Be '1.1'
+                $prefs['Invoke-WebRequest:HttpVersion']  | Should -Be '1.1'
+            }
+            else {
+                $prefs.Count | Should -Be 0
+            }
+        }
+    }
+
+    Context 'Edit-SslVersionSupport min/max (Windows PowerShell only)' {
+
+        BeforeEach {
+            $script:OriginalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
+        }
+
+        AfterEach {
+            [System.Net.ServicePointManager]::SecurityProtocol = $script:OriginalProtocol
+        }
+
+        It 'Sets SecurityProtocol to exactly Tls13 for -MinimumTlsVersion 1.3 on Windows PowerShell 5.1' {
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                Set-ItResult -Skipped -Because 'On PowerShell 7 the TLS range is enforced per request via -SslProtocol, not ServicePointManager'
+                return
+            }
+            if (-not ([System.Net.SecurityProtocolType].GetEnumNames() -contains 'Tls13')) {
+                { Edit-SslVersionSupport -MinimumTlsVersion '1.3' } | Should -Throw
+                return
+            }
+            Edit-SslVersionSupport -MinimumTlsVersion '1.3'
+            $tls13Value = [System.Enum]::Parse([System.Net.SecurityProtocolType], 'Tls13')
+            [System.Net.ServicePointManager]::SecurityProtocol | Should -Be $tls13Value
+        }
+
+        It 'Sets SecurityProtocol to exactly Tls12 for -MaximumTlsVersion 1.2 on Windows PowerShell 5.1' {
+            if ($PSVersionTable.PSEdition -eq 'Core') {
+                Set-ItResult -Skipped -Because 'On PowerShell 7 the TLS range is enforced per request via -SslProtocol, not ServicePointManager'
+                return
+            }
+            Edit-SslVersionSupport -MaximumTlsVersion '1.2'
+            $tls12Value = [System.Enum]::Parse([System.Net.SecurityProtocolType], 'Tls12')
+            [System.Net.ServicePointManager]::SecurityProtocol | Should -Be $tls12Value
+        }
+    }
+}


### PR DESCRIPTION
Fixes #650.

## Summary

SPP 9.0 enables TLS 1.3 and exposes an HTTP/2-capable binding. HTTP/2 disallows the post-handshake certificate request that client-certificate authentication depends on, so this pins **HTTP/1.1** on all Safeguard REST calls, and adds an optional **TLS version range** for callers who want to constrain negotiation.

## Changes

- **Pin HTTP/1.1** on every Safeguard REST call, including the A2A certificate-auth callers in `a2acallers.psm1` (pure client-cert auth — the case most likely to break on 9.0's HTTP/2 binding). Applied via `-HttpVersion 1.1` where available (PowerShell 7.3+); older PS7 and Windows PowerShell 5.1 already default to HTTP/1.1.
- **`-MinimumTlsVersion` / `-MaximumTlsVersion`** (`1.2` or `1.3`) on `Connect-Safeguard` and `Invoke-SafeguardMethod`:
  - `-MinimumTlsVersion 1.3` requires TLS 1.3, failing closed below it.
  - `-MaximumTlsVersion 1.2` pins to TLS 1.2 as an interim measure.
  - Both together negotiate within an inclusive range; neither = today's default negotiation (unchanged).
  - Persisted in the session and inherited by later `Invoke-SafeguardMethod` calls.
  - PowerShell 7 applies the range per request via `-SslProtocol`; Windows PowerShell 5.1 applies it process-wide via `ServicePointManager`. Only TLS 1.2/1.3 are ever enabled (1.0/1.1 remain excluded).
- **Version bump to 8.5.0** (`pipeline-templates/global-variables.yml` + `src/safeguard-ps.psd1`, keeping the `.99999` placeholder).
- Unit tests for the version-set resolver and web-request preferences; README "TLS and HTTP behavior" section updated.

## Validation

- `./Invoke-PsLint.ps1 -Strict` clean (src + test)
- Module imports under PowerShell 7; new parameters present with `ValidateSet` `1.2`/`1.3`
- New Issue-650 Pester tests pass (the pre-existing `Strips Tls10/Tls11` failures are unrelated and untouched)

## Testing still needed (draft)

- [ ] Verify against an **8.x** appliance (regression: cert-auth, password-auth, A2A still work; default negotiation unchanged)
- [ ] Verify against a **9.0** appliance (TLS 1.3 enabled): cert-auth over the HTTP/2-capable binding, `-MinimumTlsVersion 1.3`, and `-MaximumTlsVersion 1.2`
- [ ] A2A credential retrieval against 9.0 with a client certificate