### PR TITLE
Make appliance maintenance cmdlets work on both SPP 8.x and 9.0

### DIFF
--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -999,8 +999,10 @@ function Get-SafeguardApplianceUptime
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    $local:Os = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET OperatingSystem)
-    $local:Ts =  [timespan]::FromSeconds($local:Os.UptimeInSeconds)
+    # The Appliance/OperatingSystem resource was removed in Safeguard 9.0. Read uptime from the
+    # appliance health status instead, which exposes the same value on both 8.x and 9.0.
+    $local:Health = (Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "ApplianceStatus/Health")
+    $local:Ts = [timespan]::FromMilliseconds($local:Health.UpTime.TotalMilliseconds)
     New-Object -TypeName PSObject -Property @{
         TotalSeconds = $local:Ts.TotalSeconds;
         Days = $local:Ts.Days;
@@ -3281,6 +3283,21 @@ function Set-SafeguardBmcAdminPassword
     Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT BmcConfiguration -Body $local:Body
 }
 
+# The TLS 1.2 Only (SecureSsl) appliance setting was removed in Safeguard 9.0, which negotiates
+# TLS 1.3 and no longer supports restricting the appliance to TLS 1.2 only. The Web API returns
+# HTTP 405 with error code 60612 for this resource on 9.0 and later.
+function Test-SafeguardSecureSslRemoved
+{
+    [CmdletBinding()]
+    [OutputType([bool])]
+    Param(
+        [Parameter(Mandatory=$true,Position=0)]
+        $ErrorRecord
+    )
+
+    ($ErrorRecord.Exception.HttpStatusCode -eq 405) -and ($ErrorRecord.Exception.ErrorCode -eq 60612)
+}
+
 <#
 .SYNOPSIS
 Get current status of TLS 1.2 Only setting in Safeguard via the Web API.
@@ -3289,6 +3306,9 @@ Get current status of TLS 1.2 Only setting in Safeguard via the Web API.
 TLS 1.2 Only means Safeguard will only negotiate TLS 1.2+ connections when
 clients access the Web API and Web UI.  This cmdlet reports the current
 status of that setting: true or false.
+
+This setting was removed in Safeguard 9.0, which negotiates TLS 1.3. On 9.0
+and later this cmdlet writes a warning and returns nothing.
 
 .PARAMETER Appliance
 IP address or hostname of a Safeguard appliance.
@@ -3326,7 +3346,20 @@ function Get-SafeguardTls12OnlyStatus
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "ApplianceStatus/SecureSsl"
+    try
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance GET "ApplianceStatus/SecureSsl"
+    }
+    catch
+    {
+        if (Test-SafeguardSecureSslRemoved $_)
+        {
+            Write-Warning ("The TLS 1.2 Only setting was removed in Safeguard 9.0. Safeguard now negotiates " +
+                           "TLS 1.3 and no longer supports restricting the appliance to TLS 1.2 only.")
+            return
+        }
+        throw
+    }
 }
 
 <#
@@ -3375,7 +3408,19 @@ function Enable-SafeguardTls12Only
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "ApplianceStatus/SecureSsl" -Body $true
+    try
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "ApplianceStatus/SecureSsl" -Body $true
+    }
+    catch
+    {
+        if (Test-SafeguardSecureSslRemoved $_)
+        {
+            throw ("The TLS 1.2 Only setting was removed in Safeguard 9.0. Safeguard now negotiates " +
+                   "TLS 1.3 and no longer supports restricting the appliance to TLS 1.2 only.")
+        }
+        throw
+    }
     Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
 
     Write-Host -ForegroundColor Yellow "In order for this setting to take effect you need to reboot the Safeguard appliance."
@@ -3433,7 +3478,19 @@ function Disable-SafeguardTls12Only
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
     if (-not $PSBoundParameters.ContainsKey("Verbose")) { $VerbosePreference = $PSCmdlet.GetVariableValue("VerbosePreference") }
 
-    Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "ApplianceStatus/SecureSsl" -Body $false
+    try
+    {
+        Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Appliance PUT "ApplianceStatus/SecureSsl" -Body $false
+    }
+    catch
+    {
+        if (Test-SafeguardSecureSslRemoved $_)
+        {
+            throw ("The TLS 1.2 Only setting was removed in Safeguard 9.0. Safeguard now negotiates " +
+                   "TLS 1.3 and no longer supports restricting the appliance to TLS 1.2 only.")
+        }
+        throw
+    }
     Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
 
     Write-Host -ForegroundColor Yellow "In order for this setting to take effect you need to reboot the Safeguard appliance."

--- a/test/Suites/Suite-ApplianceStatus.ps1
+++ b/test/Suites/Suite-ApplianceStatus.ps1
@@ -77,9 +77,12 @@
         }
 
         # --- Get-SafeguardTls12OnlyStatus ---
-        Test-SgPsAssert "Get-SafeguardTls12OnlyStatus returns TLS status" {
-            $tls = Get-SafeguardTls12OnlyStatus -Insecure
-            $null -ne $tls
+        Test-SgPsAssert "Get-SafeguardTls12OnlyStatus returns status (8.x) or is removed (9.0+)" {
+            # The TLS 1.2 Only setting was removed in Safeguard 9.0, which negotiates TLS 1.3.
+            # On 8.x the cmdlet returns a boolean; on 9.0+ it warns and returns nothing.
+            $major = (Get-SafeguardVersion -Appliance $Context.Appliance -Insecure).Major
+            $tls = Get-SafeguardTls12OnlyStatus -Insecure -WarningAction SilentlyContinue
+            if ($major -ge 9) { $null -eq $tls } else { $tls -is [bool] }
         }
 
         # --- Get-SafeguardApplianceDnsSuffix ---

--- a/test/Suites/Suite-AuditLog.ps1
+++ b/test/Suites/Suite-AuditLog.ps1
@@ -155,9 +155,18 @@
             if ($hasData)
             {
                 $entry = if ($result -is [Array]) { $result[0] } else { $result }
-                $logId = [string]$entry.LogId
-                $detail = Get-SafeguardAuditLog -Insecure Patches -Id $logId
-                $null -ne $detail -and $detail.LogId -eq $logId
+                # Patches audit entries are keyed by LogId on 8.x and by Id on 9.0.
+                $logId = if ($entry.LogId) { [string]$entry.LogId } else { [string]$entry.Id }
+                if ([string]::IsNullOrEmpty($logId))
+                {
+                    Write-Host "  (skipped -- patch audit entry has no id field)"
+                    $true
+                }
+                else
+                {
+                    $detail = Get-SafeguardAuditLog -Insecure Patches -Id $logId
+                    $null -ne $detail -and (([string]$detail.LogId -eq $logId) -or ([string]$detail.Id -eq $logId))
+                }
             }
             else
             {

--- a/test/Suites/Suite-AuditLogMaintenance.ps1
+++ b/test/Suites/Suite-AuditLogMaintenance.ps1
@@ -80,8 +80,9 @@
             $threw = $false
             try { Invoke-SafeguardAuditLogMaintenance -Insecure }
             catch {
-                # 60818 means a maintenance operation is already in progress -- acceptable
-                if ($_ -match "60818") { $threw = $false }
+                # 60818 = maintenance already in progress; 60819 = schedule not configured to
+                # archive or purge. Both are benign responses to a run-now request.
+                if ($_ -match "60818" -or $_ -match "60819") { $threw = $false }
                 else { $threw = $true }
             }
             -not $threw
@@ -93,8 +94,8 @@
                 $success = ($null -eq $result -or $result -eq "")
             }
             catch {
-                # Already in progress is acceptable
-                $success = ($_ -match "60818")
+                # Already in progress (60818) or nothing to archive/purge (60819) are acceptable.
+                $success = ($_ -match "60818" -or $_ -match "60819")
             }
             $success
         }

--- a/test/Suites/Suite-ManagementShell.ps1
+++ b/test/Suites/Suite-ManagementShell.ps1
@@ -33,9 +33,25 @@
 
         # --- Get-SafeguardBanner ---
         Test-SgPsAssert "Get-SafeguardBanner returns output" {
-            # Get-SafeguardBanner clears screen and writes to host, so just verify it doesn't throw
-            $null = Get-SafeguardBanner
-            $true
+            # Get-SafeguardBanner clears the screen and writes to the host. In a non-interactive
+            # host (no console) it cannot set the cursor position; treat that as a skip.
+            try
+            {
+                $null = Get-SafeguardBanner
+                $true
+            }
+            catch
+            {
+                if ($_ -match "CursorPosition" -or $_ -match "handle is invalid")
+                {
+                    Write-Host "  (skipped -- no interactive console host available)"
+                    $true
+                }
+                else
+                {
+                    throw
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Safeguard 9.0 removed two appliance resources that these cmdlets depended on, so they failed against 9.0 while continuing to work on 8.x. This makes them work on **both** SPP 8.x and 9.0.

## Cmdlet fixes (`src/maintenance.psm1`)

- **`Get-SafeguardApplianceUptime`** — `Appliance/OperatingSystem` was removed in 9.0 (404). Now reads uptime from `ApplianceStatus/Health`, which exposes the same value on both 8.x and 9.0 (the same endpoint `Get-SafeguardHealth` uses).
- **`Get-SafeguardTls12OnlyStatus`** — `ApplianceStatus/SecureSsl` was retired in 9.0 (405 / error 60612 "no longer supported"), because 9.0 negotiates TLS 1.3 and no longer supports restricting the appliance to TLS 1.2 only. Now writes a warning and returns nothing on 9.0+.
- **`Enable-`/`Disable-SafeguardTls12Only`** — on 9.0+ throw a clear message **before** any reboot prompt instead of surfacing a raw 405.
- Added a shared private helper `Test-SafeguardSecureSslRemoved` (not exported) to detect the removed resource.

## Test hardening (`test/Suites/*`) — clean runs on both builds

- **Suite-AuditLog** — Patches lookup accepts the 9.0 `Id` key (8.x used `LogId`), null-guards to a skip.
- **Suite-AuditLogMaintenance** — run-now tolerates the not-configured error code (60819) as well as already-in-progress (60818).
- **Suite-ApplianceStatus** — TLS-1.2-Only assertion is now version-aware (expects `$null` on 9.0+, boolean on 8.x).
- **Suite-ManagementShell** — banner test tolerates a headless console.

## Validation

Full regression, zero failures on both appliances:

| Appliance | Result |
| --- | --- |
| SPP 9.0 (real TLS 1.3) | **761 pass / 0 fail / 11 skip** |
| SPP 8.x (TLS 1.2 max) | **763 pass / 0 fail / 9 skip** |

`Invoke-PsLint.ps1 -Strict` (src + test): no findings. Both fixed cmdlets verified live on both appliances.
