### PR TITLE
Add -Force to bypass Get-Confirmation for automation (#648)

### DIFF
--- a/src/maintenance.psm1
+++ b/src/maintenance.psm1
@@ -901,6 +901,10 @@ Ignore verification of Safeguard appliance SSL certificate.
 The time in UTC to set to the appliance, when omitted the current time of your
 client machine is used.
 
+.PARAMETER Force
+Do not prompt for confirmation before setting the time. Intended for unattended
+or automation scenarios.
+
 .INPUTS
 None.
 
@@ -924,7 +928,9 @@ function Set-SafeguardTime
         [Parameter(Mandatory=$false)]
         [switch]$Insecure,
         [Parameter(Mandatory=$false,Position=0)]
-        [DateTime]$SystemTime
+        [DateTime]$SystemTime,
+        [Parameter(Mandatory=$false)]
+        [switch]$Force
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -940,10 +946,17 @@ function Set-SafeguardTime
     }
 
     Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
-    Write-Host -ForegroundColor Magenta "Setting the UTC time of the Safeguard appliance to: $($local:SystemTimeString)"
-    Write-Host -ForegroundColor Yellow "WARNING: Setting the wrong time can break a Safeguard appliance."
-    $local:Confirmed = (Get-Confirmation "Set Safeguard Time" "Are you sure you want to set the time on this Safeguard appliance?" `
-                                         "Set the time." "Cancels this operation.")
+    if ($Force)
+    {
+        $local:Confirmed = $true
+    }
+    else
+    {
+        Write-Host -ForegroundColor Magenta "Setting the UTC time of the Safeguard appliance to: $($local:SystemTimeString)"
+        Write-Host -ForegroundColor Yellow "WARNING: Setting the wrong time can break a Safeguard appliance."
+        $local:Confirmed = (Get-Confirmation "Set Safeguard Time" "Are you sure you want to set the time on this Safeguard appliance?" `
+                                             "Set the time." "Cancels this operation.")
+    }
 
     if ($local:Confirmed)
     {

--- a/src/sessionjoin.psm1
+++ b/src/sessionjoin.psm1
@@ -799,6 +799,10 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate
 
+.PARAMETER Force
+Do not prompt for confirmation before enabling the Session Access Request Broker.
+Intended for unattended or automation scenarios.
+
 .INPUTS
 None.
 
@@ -820,7 +824,9 @@ function Enable-SafeguardSessionClusterAccessRequestBroker
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$Force
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -834,11 +840,18 @@ function Enable-SafeguardSessionClusterAccessRequestBroker
     else
     {
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
-        $local:Confirmed = (Get-Confirmation "Enable Session Access Request Broker" `
-                                ("You are about to enable SPS to create access requests, monitor workflow, and retrieve credentials on behalf of users to connect sessions.`n" + `
-                                 "Access requests created and used by SPS will still be governed by SPP entitlements.`n" + `
-                                 "Do you want to enable the Session Access Request Broker?") `
-                                "Enable SPS to request access and retrieve credentials on behalf of users." "Cancel this operation.")
+        if ($Force)
+        {
+            $local:Confirmed = $true
+        }
+        else
+        {
+            $local:Confirmed = (Get-Confirmation "Enable Session Access Request Broker" `
+                                    ("You are about to enable SPS to create access requests, monitor workflow, and retrieve credentials on behalf of users to connect sessions.`n" + `
+                                     "Access requests created and used by SPS will still be governed by SPP entitlements.`n" + `
+                                     "Do you want to enable the Session Access Request Broker?") `
+                                    "Enable SPS to request access and retrieve credentials on behalf of users." "Cancel this operation.")
+        }
         if ($local:Confirmed)
         {
             Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Cluster/SessionModules/AccessRequestBroker" -Body @{ Enabled = $true }
@@ -865,6 +878,10 @@ A string containing the bearer token to be used with Safeguard Web API.
 .PARAMETER Insecure
 Ignore verification of Safeguard appliance SSL certificate
 
+.PARAMETER Force
+Do not prompt for confirmation before disabling the Session Access Request Broker.
+Intended for unattended or automation scenarios.
+
 .INPUTS
 None.
 
@@ -886,7 +903,9 @@ function Disable-SafeguardSessionClusterAccessRequestBroker
         [Parameter(Mandatory=$false)]
         [object]$AccessToken,
         [Parameter(Mandatory=$false)]
-        [switch]$Insecure
+        [switch]$Insecure,
+        [Parameter(Mandatory=$false)]
+        [switch]$Force
     )
 
     if (-not $PSBoundParameters.ContainsKey("ErrorAction")) { $ErrorActionPreference = "Stop" }
@@ -900,11 +919,18 @@ function Disable-SafeguardSessionClusterAccessRequestBroker
     else
     {
         Import-Module -Name "$PSScriptRoot\ps-utilities.psm1" -Scope Local
-        $local:Confirmed = (Get-Confirmation "Enable Session Access Request Broker" `
-                                ("You are about to disable SPS from being able to retrieve credentials on behalf of users to connect sessions.`n" + `
-                                 "This will prevent SPS initiated sessions from connecting.`n" + `
-                                 "Do you want to disable the Session Access Request Broker?") `
-                                "Disable to prevent SPS from retrieving credentials on behalf of users." "Cancel this operation.")
+        if ($Force)
+        {
+            $local:Confirmed = $true
+        }
+        else
+        {
+            $local:Confirmed = (Get-Confirmation "Enable Session Access Request Broker" `
+                                    ("You are about to disable SPS from being able to retrieve credentials on behalf of users to connect sessions.`n" + `
+                                     "This will prevent SPS initiated sessions from connecting.`n" + `
+                                     "Do you want to disable the Session Access Request Broker?") `
+                                    "Disable to prevent SPS from retrieving credentials on behalf of users." "Cancel this operation.")
+        }
         if ($local:Confirmed)
         {
             Invoke-SafeguardMethod -AccessToken $AccessToken -Appliance $Appliance -Insecure:$Insecure Core PUT "Cluster/SessionModules/AccessRequestBroker" -Body @{ Enabled = $false }


### PR DESCRIPTION
## Summary

Near-term fix for #648: add an official, supported way to bypass the interactive `Get-Confirmation` prompt so state-changing cmdlets can run unattended in automation.

This mirrors the existing `-Force` precedent already used by `Invoke-SafeguardApplianceShutdown` / `Invoke-SafeguardApplianceReboot` / `Invoke-SafeguardApplianceFactoryReset`. When `-Force` is supplied, the confirmation is treated as accepted; otherwise the prompt (and its warnings) behaves exactly as it does today.

## Cmdlets updated

- `Set-SafeguardTime` (`src/maintenance.psm1`) — the reported cmdlet
- `Enable-SafeguardSessionClusterAccessRequestBroker` (`src/sessionjoin.psm1`)
- `Disable-SafeguardSessionClusterAccessRequestBroker` (`src/sessionjoin.psm1`)

Each gains a `[switch]$Force` parameter and a `.PARAMETER Force` comment-based help entry.

## Not included (by design)

`Invoke-SafeguardStarlingJoinBrowser` and `Invoke-SafeguardSpsStarlingJoinBrowser` were intentionally left out. They open an external browser and then block on `Read-Host` for interactive copy/paste of join credentials, so `-Force` could only skip the confirmation while the cmdlet still cannot run unattended.

## Behavior / compatibility

- No change for interactive users: without `-Force`, the prompt and warnings are identical to today.
- No new exports; only a new optional parameter on existing cmdlets.
- ASCII-only, Windows PowerShell 5.1 compatible.

## Validation

- `./Invoke-PsLint.ps1 -Strict` — no findings.
- Local install cycle; confirmed `-Force` is present on all three cmdlets.

## Follow-up

The long-term `SupportsShouldProcess` / `ShouldContinue` conversion (adding `-WhatIf` / `-Confirm`) is tracked as a separate enhancement issue and is out of scope here.

Fixes #648
